### PR TITLE
Fix namecheap MX record support.

### DIFF
--- a/lexicon/tests/providers/test_namecheap.py
+++ b/lexicon/tests/providers/test_namecheap.py
@@ -62,7 +62,7 @@ class NamecheapProviderTests(TestCase, IntegrationTests):
             LEXICON_NAMECHEAP_DOMAIN
         """
         env_domain = os.environ.get('LEXICON_NAMECHEAP_DOMAIN', None)
-        return env_domain or 'example-aptise.com'
+        return env_domain or 'unittest2.dev'
 
     def _filter_query_parameters(self):
         return ['ApiKey', 'UserName', 'ApiUser']
@@ -98,4 +98,4 @@ class NamecheapManagedProviderTests(NamecheapProviderTests):
             LEXICON_NAMECHEAP_DOMAINMANAGED
         """
         env_domain = os.environ.get('LEXICON_NAMECHEAP_DOMAINMANAGED', None)
-        return env_domain or 'example-aptise-2.com'
+        return env_domain or 'unittest-seconddomain.dev'

--- a/tests/fixtures/cassettes/namecheap/IntegrationTests/test_provider_authenticate.yaml
+++ b/tests/fixtures/cassettes/namecheap/IntegrationTests/test_provider_authenticate.yaml
@@ -2,41 +2,59 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise.com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=unittest2.dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
-        \ Status=\"Ok\" ID=\"277432\" DomainName=\"example-aptise.com\" OwnerName=\"\
-        jvsandbox\" IsOwner=\"true\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
-        \n        <CreatedDate>03/25/2018</CreatedDate>\r\n        <ExpiredDate>03/25/2019</ExpiredDate>\r\
-        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
-        \ />\r\n      <Whoisguard Enabled=\"NotAlloted\">\r\n        <ID>0</ID>\r\n\
-        \      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
-        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
-        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
-        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
-        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"18\" EmailType=\"\
-        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
-        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
-        \n      <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.849</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult
+        Status=\"Ok\" ID=\"589667\" DomainName=\"unittest2.dev\" OwnerName=\"phassberg\"
+        IsOwner=\"true\" IsPremium=\"false\">\r\n      <DomainDetails>\r\n        <CreatedDate>05/20/2020</CreatedDate>\r\n
+        \       <ExpiredDate>05/20/2021</ExpiredDate>\r\n        <NumYears>0</NumYears>\r\n
+        \     </DomainDetails>\r\n      <LockDetails />\r\n      <Whoisguard Enabled=\"True\">\r\n
+        \       <ID>481121</ID>\r\n        <ExpiredDate>05/20/2021</ExpiredDate>\r\n
+        \       <EmailDetails WhoisGuardEmail=\"824017ccbed343119b3459c7d3304ba5.protect@whoisguard.com\"
+        ForwardedTo=\"dr.doddo@gmail.com\" LastAutoEmailChangeDate=\"05/20/2020\"
+        AutoEmailChangeFrequencyDays=\"3\" />\r\n      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n
+        \       <UseAutoRenew>false</UseAutoRenew>\r\n        <SubscriptionId>-1</SubscriptionId>\r\n
+        \       <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n
+        \       <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n
+        \     <DnsDetails ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"31\"
+        EmailType=\"FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\n
+        \       <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\n
+        \     <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.241</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['1493']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:40:58 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 18:59:13 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '1740'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/namecheap/IntegrationTests/test_provider_authenticate_with_unmanaged_domain_should_fail.yaml
+++ b/tests/fixtures/cassettes/namecheap/IntegrationTests/test_provider_authenticate_with_unmanaged_domain_should_fail.yaml
@@ -2,38 +2,53 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=thisisadomainidonotown.com
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"ERROR\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors>\r\n    <Error Number=\"2030166\">Domain is invalid</Error>\r\
-        \n  </Errors>\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
-        \ ID=\"0\" IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
-        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
-        \ />\r\n      <Whoisguard>\r\n        <ID>0</ID>\r\n      </Whoisguard>\r\n\
-        \      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
-        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
-        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
-        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
-        \ IsUsingOurDNS=\"false\" HostCount=\"0\" DynamicDNSStatus=\"false\" IsFailover=\"\
-        false\" />\r\n      <Modificationrights />\r\n    </DomainGetInfoResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.191</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"ERROR\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors>\r\n    <Error
+        Number=\"2030166\">Domain is invalid</Error>\r\n  </Errors>\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult
+        ID=\"0\" IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\n
+        \       <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails
+        />\r\n      <Whoisguard>\r\n        <ID>0</ID>\r\n      </Whoisguard>\r\n
+        \     <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\n
+        \       <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\n
+        \       <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n        <IsActive>false</IsActive>\r\n
+        \     </PremiumDnsSubscription>\r\n      <DnsDetails IsUsingOurDNS=\"false\"
+        HostCount=\"0\" DynamicDNSStatus=\"false\" IsFailover=\"false\" />\r\n      <Modificationrights
+        />\r\n    </DomainGetInfoResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.246</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['1189']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:40:58 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 18:59:13 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '1192'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/namecheap/IntegrationTests/test_provider_when_calling_create_record_for_A_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/namecheap/IntegrationTests/test_provider_when_calling_create_record_for_A_with_valid_name_and_content.yaml
@@ -2,148 +2,227 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise.com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=unittest2.dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
-        \ Status=\"Ok\" ID=\"277432\" DomainName=\"example-aptise.com\" OwnerName=\"\
-        jvsandbox\" IsOwner=\"true\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
-        \n        <CreatedDate>03/25/2018</CreatedDate>\r\n        <ExpiredDate>03/25/2019</ExpiredDate>\r\
-        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
-        \ />\r\n      <Whoisguard Enabled=\"NotAlloted\">\r\n        <ID>0</ID>\r\n\
-        \      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
-        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
-        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
-        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
-        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"18\" EmailType=\"\
-        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
-        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
-        \n      <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.244</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult
+        Status=\"Ok\" ID=\"589667\" DomainName=\"unittest2.dev\" OwnerName=\"phassberg\"
+        IsOwner=\"true\" IsPremium=\"false\">\r\n      <DomainDetails>\r\n        <CreatedDate>05/20/2020</CreatedDate>\r\n
+        \       <ExpiredDate>05/20/2021</ExpiredDate>\r\n        <NumYears>0</NumYears>\r\n
+        \     </DomainDetails>\r\n      <LockDetails />\r\n      <Whoisguard Enabled=\"True\">\r\n
+        \       <ID>481121</ID>\r\n        <ExpiredDate>05/20/2021</ExpiredDate>\r\n
+        \       <EmailDetails WhoisGuardEmail=\"824017ccbed343119b3459c7d3304ba5.protect@whoisguard.com\"
+        ForwardedTo=\"dr.doddo@gmail.com\" LastAutoEmailChangeDate=\"05/20/2020\"
+        AutoEmailChangeFrequencyDays=\"3\" />\r\n      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n
+        \       <UseAutoRenew>false</UseAutoRenew>\r\n        <SubscriptionId>-1</SubscriptionId>\r\n
+        \       <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n
+        \       <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n
+        \     <DnsDetails ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"31\"
+        EmailType=\"FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\n
+        \       <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\n
+        \     <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.036</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['1493']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:40:59 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 18:59:15 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '1740'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest2&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524157\" Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524158\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524214\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
-        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
-        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.818</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest2.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n      <host
+        HostId=\"746360\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746361\" Name=\"docs\" Type=\"CNAME\" Address=\"docs.example.com.\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746355\" Name=\"www\" Type=\"CNAME\"
+        Address=\"parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\"
+        FriendlyName=\"CNAME Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n
+        \     <host HostId=\"746365\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746366\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746372\" Name=\"_acme-challenge.deleterecordinset\"
+        Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746373\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746374\" Name=\"_acme-challenge.deleterecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746375\" Name=\"_acme-challenge.deleterecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746362\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746363\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746376\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746377\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746367\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746364\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746368\" Name=\"delete.testfilt\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746369\" Name=\"delete.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746370\" Name=\"delete.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746371\" Name=\"delete.testid\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746383\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746384\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746381\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746385\" Name=\"orig.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746387\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746378\" Name=\"random.fqdntest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746379\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746380\" Name=\"random.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746382\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746386\" Name=\"updated.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746388\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746354\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest2.dev/\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL
+        Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.154</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['3987']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:00 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 18:59:15 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '6601'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'IsActive10=true&IsDDNSEnabled18=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=URL&RecordType19=A&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524214&HostId9=524166&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524156&HostId5=524157&HostId6=524158&HostId7=524168&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&FriendlyName3=CName+Record&FriendlyName18=URL+Record&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524163&HostId13=524164&HostId10=524170&HostId11=524172&HostId16=524171&HostId17=524173&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=updated&Address9=challengetoken&IsActive9=true&IsActive8=true&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=60&HostName12=random.fqdntest&HostName13=random.fulltest&HostName10=orig.testfqdn&HostName11=orig.testfull&HostName16=updated.testfqdn&HostName17=updated.testfull&HostName14=random.test&Address1=127.0.0.1&HostName18=yyy&HostName19=localhost&MXPref5=10&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=60&TTL6=1800&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&Address12=challengetoken&Address18=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&Address19=127.0.0.1&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.fqdn&HostName5=_acme-challenge.full&HostName6=_acme-challenge.test&HostName7=orig.nameonly.test&HostName8=orig.nameonly.test&HostName9=orig.test&Address10=challengetoken&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken&TTL16=1800&FriendlyName16=&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=updated.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise&MXPref4=10&TTL18=1800&AssociatedAppTitle18=&HostId14=524165&HostId15=524167&HostId18=524160'
+    body: HostId1=746360&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746361&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746355&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746365&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746366&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746372&Address6=challengetoken1&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.deleterecordinset&RecordType6=TXT&HostId7=746373&Address7=challengetoken2&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.deleterecordinset&RecordType7=TXT&HostId8=746374&Address8=challengetoken1&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.deleterecordset&RecordType8=TXT&HostId9=746375&Address9=challengetoken2&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.deleterecordset&RecordType9=TXT&HostId10=746362&Address10=challengetoken&MXPref10=10&TTL10=3600&AssociatedAppTitle10=&FriendlyName10=&IsActive10=true&IsDDNSEnabled10=false&HostName10=_acme-challenge.fqdn&RecordType10=TXT&HostId11=746363&Address11=challengetoken&MXPref11=10&TTL11=3600&AssociatedAppTitle11=&FriendlyName11=&IsActive11=true&IsDDNSEnabled11=false&HostName11=_acme-challenge.full&RecordType11=TXT&HostId12=746376&Address12=challengetoken1&MXPref12=10&TTL12=3600&AssociatedAppTitle12=&FriendlyName12=&IsActive12=true&IsDDNSEnabled12=false&HostName12=_acme-challenge.listrecordset&RecordType12=TXT&HostId13=746377&Address13=challengetoken2&MXPref13=10&TTL13=3600&AssociatedAppTitle13=&FriendlyName13=&IsActive13=true&IsDDNSEnabled13=false&HostName13=_acme-challenge.listrecordset&RecordType13=TXT&HostId14=746367&Address14=challengetoken&MXPref14=10&TTL14=3600&AssociatedAppTitle14=&FriendlyName14=&IsActive14=true&IsDDNSEnabled14=false&HostName14=_acme-challenge.noop&RecordType14=TXT&HostId15=746364&Address15=challengetoken&MXPref15=10&TTL15=3600&AssociatedAppTitle15=&FriendlyName15=&IsActive15=true&IsDDNSEnabled15=false&HostName15=_acme-challenge.test&RecordType15=TXT&HostId16=746368&Address16=challengetoken&MXPref16=10&TTL16=3600&AssociatedAppTitle16=&FriendlyName16=&IsActive16=true&IsDDNSEnabled16=false&HostName16=delete.testfilt&RecordType16=TXT&HostId17=746369&Address17=challengetoken&MXPref17=10&TTL17=3600&AssociatedAppTitle17=&FriendlyName17=&IsActive17=true&IsDDNSEnabled17=false&HostName17=delete.testfqdn&RecordType17=TXT&HostId18=746370&Address18=challengetoken&MXPref18=10&TTL18=3600&AssociatedAppTitle18=&FriendlyName18=&IsActive18=true&IsDDNSEnabled18=false&HostName18=delete.testfull&RecordType18=TXT&HostId19=746371&Address19=challengetoken&MXPref19=10&TTL19=3600&AssociatedAppTitle19=&FriendlyName19=&IsActive19=true&IsDDNSEnabled19=false&HostName19=delete.testid&RecordType19=TXT&HostId20=746383&Address20=challengetoken&MXPref20=10&TTL20=3600&AssociatedAppTitle20=&FriendlyName20=&IsActive20=true&IsDDNSEnabled20=false&HostName20=orig.nameonly.test&RecordType20=TXT&HostId21=746384&Address21=updated&MXPref21=10&TTL21=3600&AssociatedAppTitle21=&FriendlyName21=&IsActive21=true&IsDDNSEnabled21=false&HostName21=orig.nameonly.test&RecordType21=TXT&HostId22=746381&Address22=challengetoken&MXPref22=10&TTL22=3600&AssociatedAppTitle22=&FriendlyName22=&IsActive22=true&IsDDNSEnabled22=false&HostName22=orig.test&RecordType22=TXT&HostId23=746385&Address23=challengetoken&MXPref23=10&TTL23=3600&AssociatedAppTitle23=&FriendlyName23=&IsActive23=true&IsDDNSEnabled23=false&HostName23=orig.testfqdn&RecordType23=TXT&HostId24=746387&Address24=challengetoken&MXPref24=10&TTL24=3600&AssociatedAppTitle24=&FriendlyName24=&IsActive24=true&IsDDNSEnabled24=false&HostName24=orig.testfull&RecordType24=TXT&HostId25=746378&Address25=challengetoken&MXPref25=10&TTL25=3600&AssociatedAppTitle25=&FriendlyName25=&IsActive25=true&IsDDNSEnabled25=false&HostName25=random.fqdntest&RecordType25=TXT&HostId26=746379&Address26=challengetoken&MXPref26=10&TTL26=3600&AssociatedAppTitle26=&FriendlyName26=&IsActive26=true&IsDDNSEnabled26=false&HostName26=random.fulltest&RecordType26=TXT&HostId27=746380&Address27=challengetoken&MXPref27=10&TTL27=3600&AssociatedAppTitle27=&FriendlyName27=&IsActive27=true&IsDDNSEnabled27=false&HostName27=random.test&RecordType27=TXT&HostId28=746382&Address28=challengetoken&MXPref28=10&TTL28=3600&AssociatedAppTitle28=&FriendlyName28=&IsActive28=true&IsDDNSEnabled28=false&HostName28=updated.test&RecordType28=TXT&HostId29=746386&Address29=challengetoken&MXPref29=10&TTL29=3600&AssociatedAppTitle29=&FriendlyName29=&IsActive29=true&IsDDNSEnabled29=false&HostName29=updated.testfqdn&RecordType29=TXT&HostId30=746388&Address30=challengetoken&MXPref30=10&TTL30=3600&AssociatedAppTitle30=&FriendlyName30=&IsActive30=true&IsDDNSEnabled30=false&HostName30=updated.testfull&RecordType30=TXT&HostId31=746354&Address31=http%3A%2F%2Fwww.unittest2.dev%2F&MXPref31=10&TTL31=1800&AssociatedAppTitle31=URL+Forwarding&FriendlyName31=URL+Record&IsActive31=true&IsDDNSEnabled31=false&HostName31=%40&RecordType31=URL&Address32=127.0.0.1&TTL32=3600&HostName32=localhost&RecordType32=A&SLD=unittest2&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['3326']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '5866'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.744</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest2.dev\" IsSuccess=\"true\">\r\n      <Warnings />\r\n    </DomainDNSSetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.979</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['559']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:02 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 18:59:17 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '557'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/namecheap/IntegrationTests/test_provider_when_calling_create_record_for_CNAME_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/namecheap/IntegrationTests/test_provider_when_calling_create_record_for_CNAME_with_valid_name_and_content.yaml
@@ -2,148 +2,227 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise.com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=unittest2.dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
-        \ Status=\"Ok\" ID=\"277432\" DomainName=\"example-aptise.com\" OwnerName=\"\
-        jvsandbox\" IsOwner=\"true\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
-        \n        <CreatedDate>03/25/2018</CreatedDate>\r\n        <ExpiredDate>03/25/2019</ExpiredDate>\r\
-        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
-        \ />\r\n      <Whoisguard Enabled=\"NotAlloted\">\r\n        <ID>0</ID>\r\n\
-        \      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
-        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
-        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
-        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
-        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"18\" EmailType=\"\
-        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
-        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
-        \n      <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.033</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult
+        Status=\"Ok\" ID=\"589667\" DomainName=\"unittest2.dev\" OwnerName=\"phassberg\"
+        IsOwner=\"true\" IsPremium=\"false\">\r\n      <DomainDetails>\r\n        <CreatedDate>05/20/2020</CreatedDate>\r\n
+        \       <ExpiredDate>05/20/2021</ExpiredDate>\r\n        <NumYears>0</NumYears>\r\n
+        \     </DomainDetails>\r\n      <LockDetails />\r\n      <Whoisguard Enabled=\"True\">\r\n
+        \       <ID>481121</ID>\r\n        <ExpiredDate>05/20/2021</ExpiredDate>\r\n
+        \       <EmailDetails WhoisGuardEmail=\"824017ccbed343119b3459c7d3304ba5.protect@whoisguard.com\"
+        ForwardedTo=\"dr.doddo@gmail.com\" LastAutoEmailChangeDate=\"05/20/2020\"
+        AutoEmailChangeFrequencyDays=\"3\" />\r\n      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n
+        \       <UseAutoRenew>false</UseAutoRenew>\r\n        <SubscriptionId>-1</SubscriptionId>\r\n
+        \       <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n
+        \       <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n
+        \     <DnsDetails ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"31\"
+        EmailType=\"FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\n
+        \       <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\n
+        \     <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.034</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['1493']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:02 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 18:59:18 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '1740'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest2&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524157\" Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524158\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524214\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
-        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
-        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.822</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest2.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n      <host
+        HostId=\"746360\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746361\" Name=\"docs\" Type=\"CNAME\" Address=\"docs.example.com.\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746355\" Name=\"www\" Type=\"CNAME\"
+        Address=\"parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\"
+        FriendlyName=\"CNAME Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n
+        \     <host HostId=\"746365\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746366\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746372\" Name=\"_acme-challenge.deleterecordinset\"
+        Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746373\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746374\" Name=\"_acme-challenge.deleterecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746375\" Name=\"_acme-challenge.deleterecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746362\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746363\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746376\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746377\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746367\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746364\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746368\" Name=\"delete.testfilt\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746369\" Name=\"delete.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746370\" Name=\"delete.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746371\" Name=\"delete.testid\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746383\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746384\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746381\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746385\" Name=\"orig.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746387\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746378\" Name=\"random.fqdntest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746379\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746380\" Name=\"random.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746382\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746386\" Name=\"updated.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746388\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746354\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest2.dev/\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL
+        Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.484</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['3987']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:03 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 18:59:19 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '6601'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'IsActive10=true&IsDDNSEnabled18=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=URL&RecordType19=CNAME&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524214&HostId9=524166&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524156&HostId5=524157&HostId6=524158&HostId7=524168&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&FriendlyName3=CName+Record&FriendlyName18=URL+Record&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524163&HostId13=524164&HostId10=524170&HostId11=524172&HostId16=524171&HostId17=524173&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=updated&Address9=challengetoken&IsActive9=true&IsActive8=true&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=60&HostName12=random.fqdntest&HostName13=random.fulltest&HostName10=orig.testfqdn&HostName11=orig.testfull&HostName16=updated.testfqdn&HostName17=updated.testfull&HostName14=random.test&Address1=127.0.0.1&HostName18=yyy&HostName19=docs&MXPref5=10&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=60&TTL6=1800&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&Address12=challengetoken&Address18=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&Address19=docs.example.com&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.fqdn&HostName5=_acme-challenge.full&HostName6=_acme-challenge.test&HostName7=orig.nameonly.test&HostName8=orig.nameonly.test&HostName9=orig.test&Address10=challengetoken&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken&TTL16=1800&FriendlyName16=&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=updated.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise&MXPref4=10&TTL18=1800&AssociatedAppTitle18=&HostId14=524165&HostId15=524167&HostId18=524160'
+    body: HostId1=746360&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746361&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746355&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746365&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746366&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746372&Address6=challengetoken1&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.deleterecordinset&RecordType6=TXT&HostId7=746373&Address7=challengetoken2&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.deleterecordinset&RecordType7=TXT&HostId8=746374&Address8=challengetoken1&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.deleterecordset&RecordType8=TXT&HostId9=746375&Address9=challengetoken2&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.deleterecordset&RecordType9=TXT&HostId10=746362&Address10=challengetoken&MXPref10=10&TTL10=3600&AssociatedAppTitle10=&FriendlyName10=&IsActive10=true&IsDDNSEnabled10=false&HostName10=_acme-challenge.fqdn&RecordType10=TXT&HostId11=746363&Address11=challengetoken&MXPref11=10&TTL11=3600&AssociatedAppTitle11=&FriendlyName11=&IsActive11=true&IsDDNSEnabled11=false&HostName11=_acme-challenge.full&RecordType11=TXT&HostId12=746376&Address12=challengetoken1&MXPref12=10&TTL12=3600&AssociatedAppTitle12=&FriendlyName12=&IsActive12=true&IsDDNSEnabled12=false&HostName12=_acme-challenge.listrecordset&RecordType12=TXT&HostId13=746377&Address13=challengetoken2&MXPref13=10&TTL13=3600&AssociatedAppTitle13=&FriendlyName13=&IsActive13=true&IsDDNSEnabled13=false&HostName13=_acme-challenge.listrecordset&RecordType13=TXT&HostId14=746367&Address14=challengetoken&MXPref14=10&TTL14=3600&AssociatedAppTitle14=&FriendlyName14=&IsActive14=true&IsDDNSEnabled14=false&HostName14=_acme-challenge.noop&RecordType14=TXT&HostId15=746364&Address15=challengetoken&MXPref15=10&TTL15=3600&AssociatedAppTitle15=&FriendlyName15=&IsActive15=true&IsDDNSEnabled15=false&HostName15=_acme-challenge.test&RecordType15=TXT&HostId16=746368&Address16=challengetoken&MXPref16=10&TTL16=3600&AssociatedAppTitle16=&FriendlyName16=&IsActive16=true&IsDDNSEnabled16=false&HostName16=delete.testfilt&RecordType16=TXT&HostId17=746369&Address17=challengetoken&MXPref17=10&TTL17=3600&AssociatedAppTitle17=&FriendlyName17=&IsActive17=true&IsDDNSEnabled17=false&HostName17=delete.testfqdn&RecordType17=TXT&HostId18=746370&Address18=challengetoken&MXPref18=10&TTL18=3600&AssociatedAppTitle18=&FriendlyName18=&IsActive18=true&IsDDNSEnabled18=false&HostName18=delete.testfull&RecordType18=TXT&HostId19=746371&Address19=challengetoken&MXPref19=10&TTL19=3600&AssociatedAppTitle19=&FriendlyName19=&IsActive19=true&IsDDNSEnabled19=false&HostName19=delete.testid&RecordType19=TXT&HostId20=746383&Address20=challengetoken&MXPref20=10&TTL20=3600&AssociatedAppTitle20=&FriendlyName20=&IsActive20=true&IsDDNSEnabled20=false&HostName20=orig.nameonly.test&RecordType20=TXT&HostId21=746384&Address21=updated&MXPref21=10&TTL21=3600&AssociatedAppTitle21=&FriendlyName21=&IsActive21=true&IsDDNSEnabled21=false&HostName21=orig.nameonly.test&RecordType21=TXT&HostId22=746381&Address22=challengetoken&MXPref22=10&TTL22=3600&AssociatedAppTitle22=&FriendlyName22=&IsActive22=true&IsDDNSEnabled22=false&HostName22=orig.test&RecordType22=TXT&HostId23=746385&Address23=challengetoken&MXPref23=10&TTL23=3600&AssociatedAppTitle23=&FriendlyName23=&IsActive23=true&IsDDNSEnabled23=false&HostName23=orig.testfqdn&RecordType23=TXT&HostId24=746387&Address24=challengetoken&MXPref24=10&TTL24=3600&AssociatedAppTitle24=&FriendlyName24=&IsActive24=true&IsDDNSEnabled24=false&HostName24=orig.testfull&RecordType24=TXT&HostId25=746378&Address25=challengetoken&MXPref25=10&TTL25=3600&AssociatedAppTitle25=&FriendlyName25=&IsActive25=true&IsDDNSEnabled25=false&HostName25=random.fqdntest&RecordType25=TXT&HostId26=746379&Address26=challengetoken&MXPref26=10&TTL26=3600&AssociatedAppTitle26=&FriendlyName26=&IsActive26=true&IsDDNSEnabled26=false&HostName26=random.fulltest&RecordType26=TXT&HostId27=746380&Address27=challengetoken&MXPref27=10&TTL27=3600&AssociatedAppTitle27=&FriendlyName27=&IsActive27=true&IsDDNSEnabled27=false&HostName27=random.test&RecordType27=TXT&HostId28=746382&Address28=challengetoken&MXPref28=10&TTL28=3600&AssociatedAppTitle28=&FriendlyName28=&IsActive28=true&IsDDNSEnabled28=false&HostName28=updated.test&RecordType28=TXT&HostId29=746386&Address29=challengetoken&MXPref29=10&TTL29=3600&AssociatedAppTitle29=&FriendlyName29=&IsActive29=true&IsDDNSEnabled29=false&HostName29=updated.testfqdn&RecordType29=TXT&HostId30=746388&Address30=challengetoken&MXPref30=10&TTL30=3600&AssociatedAppTitle30=&FriendlyName30=&IsActive30=true&IsDDNSEnabled30=false&HostName30=updated.testfull&RecordType30=TXT&HostId31=746354&Address31=http%3A%2F%2Fwww.unittest2.dev%2F&MXPref31=10&TTL31=1800&AssociatedAppTitle31=URL+Forwarding&FriendlyName31=URL+Record&IsActive31=true&IsDDNSEnabled31=false&HostName31=%40&RecordType31=URL&Address32=docs.example.com&TTL32=3600&HostName32=docs&RecordType32=CNAME&SLD=unittest2&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['3332']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '5872'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.963</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest2.dev\" IsSuccess=\"true\">\r\n      <Warnings />\r\n    </DomainDNSSetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.858</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['559']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:05 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 18:59:21 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '557'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/namecheap/IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_fqdn_name_and_content.yaml
+++ b/tests/fixtures/cassettes/namecheap/IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_fqdn_name_and_content.yaml
@@ -2,148 +2,227 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise.com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=unittest2.dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
-        \ Status=\"Ok\" ID=\"277432\" DomainName=\"example-aptise.com\" OwnerName=\"\
-        jvsandbox\" IsOwner=\"true\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
-        \n        <CreatedDate>03/25/2018</CreatedDate>\r\n        <ExpiredDate>03/25/2019</ExpiredDate>\r\
-        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
-        \ />\r\n      <Whoisguard Enabled=\"NotAlloted\">\r\n        <ID>0</ID>\r\n\
-        \      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
-        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
-        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
-        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
-        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"18\" EmailType=\"\
-        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
-        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
-        \n      <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.057</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult
+        Status=\"Ok\" ID=\"589667\" DomainName=\"unittest2.dev\" OwnerName=\"phassberg\"
+        IsOwner=\"true\" IsPremium=\"false\">\r\n      <DomainDetails>\r\n        <CreatedDate>05/20/2020</CreatedDate>\r\n
+        \       <ExpiredDate>05/20/2021</ExpiredDate>\r\n        <NumYears>0</NumYears>\r\n
+        \     </DomainDetails>\r\n      <LockDetails />\r\n      <Whoisguard Enabled=\"True\">\r\n
+        \       <ID>481121</ID>\r\n        <ExpiredDate>05/20/2021</ExpiredDate>\r\n
+        \       <EmailDetails WhoisGuardEmail=\"824017ccbed343119b3459c7d3304ba5.protect@whoisguard.com\"
+        ForwardedTo=\"dr.doddo@gmail.com\" LastAutoEmailChangeDate=\"05/20/2020\"
+        AutoEmailChangeFrequencyDays=\"3\" />\r\n      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n
+        \       <UseAutoRenew>false</UseAutoRenew>\r\n        <SubscriptionId>-1</SubscriptionId>\r\n
+        \       <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n
+        \       <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n
+        \     <DnsDetails ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"31\"
+        EmailType=\"FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\n
+        \       <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\n
+        \     <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.019</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['1493']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:05 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 18:59:22 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '1740'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest2&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524157\" Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524158\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524214\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
-        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
-        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.766</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest2.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n      <host
+        HostId=\"746360\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746361\" Name=\"docs\" Type=\"CNAME\" Address=\"docs.example.com.\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746355\" Name=\"www\" Type=\"CNAME\"
+        Address=\"parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\"
+        FriendlyName=\"CNAME Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n
+        \     <host HostId=\"746365\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746366\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746372\" Name=\"_acme-challenge.deleterecordinset\"
+        Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746373\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746374\" Name=\"_acme-challenge.deleterecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746375\" Name=\"_acme-challenge.deleterecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746362\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746363\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746376\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746377\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746367\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746364\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746368\" Name=\"delete.testfilt\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746369\" Name=\"delete.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746370\" Name=\"delete.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746371\" Name=\"delete.testid\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746383\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746384\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746381\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746385\" Name=\"orig.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746387\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746378\" Name=\"random.fqdntest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746379\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746380\" Name=\"random.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746382\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746386\" Name=\"updated.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746388\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746354\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest2.dev/\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL
+        Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.439</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['3987']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:07 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 18:59:23 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '6601'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'IsActive10=true&IsDDNSEnabled18=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=URL&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524214&HostId9=524166&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524156&HostId5=524157&HostId6=524158&HostId7=524168&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&FriendlyName3=CName+Record&FriendlyName18=URL+Record&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524163&HostId13=524164&HostId10=524170&HostId11=524172&HostId16=524171&HostId17=524173&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=updated&Address9=challengetoken&IsActive9=true&IsActive8=true&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=60&HostName12=random.fqdntest&HostName13=random.fulltest&HostName10=orig.testfqdn&HostName11=orig.testfull&HostName16=updated.testfqdn&HostName17=updated.testfull&HostName14=random.test&Address1=127.0.0.1&HostName18=yyy&HostName19=_acme-challenge.fqdn&MXPref5=10&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=60&TTL6=1800&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&Address12=challengetoken&Address18=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.fqdn&HostName5=_acme-challenge.full&HostName6=_acme-challenge.test&HostName7=orig.nameonly.test&HostName8=orig.nameonly.test&HostName9=orig.test&Address10=challengetoken&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken&TTL16=1800&FriendlyName16=&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=updated.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise&MXPref4=10&TTL18=1800&AssociatedAppTitle18=&HostId14=524165&HostId15=524167&HostId18=524160'
+    body: HostId1=746360&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746361&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746355&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746365&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746366&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746372&Address6=challengetoken1&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.deleterecordinset&RecordType6=TXT&HostId7=746373&Address7=challengetoken2&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.deleterecordinset&RecordType7=TXT&HostId8=746374&Address8=challengetoken1&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.deleterecordset&RecordType8=TXT&HostId9=746375&Address9=challengetoken2&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.deleterecordset&RecordType9=TXT&HostId10=746362&Address10=challengetoken&MXPref10=10&TTL10=3600&AssociatedAppTitle10=&FriendlyName10=&IsActive10=true&IsDDNSEnabled10=false&HostName10=_acme-challenge.fqdn&RecordType10=TXT&HostId11=746363&Address11=challengetoken&MXPref11=10&TTL11=3600&AssociatedAppTitle11=&FriendlyName11=&IsActive11=true&IsDDNSEnabled11=false&HostName11=_acme-challenge.full&RecordType11=TXT&HostId12=746376&Address12=challengetoken1&MXPref12=10&TTL12=3600&AssociatedAppTitle12=&FriendlyName12=&IsActive12=true&IsDDNSEnabled12=false&HostName12=_acme-challenge.listrecordset&RecordType12=TXT&HostId13=746377&Address13=challengetoken2&MXPref13=10&TTL13=3600&AssociatedAppTitle13=&FriendlyName13=&IsActive13=true&IsDDNSEnabled13=false&HostName13=_acme-challenge.listrecordset&RecordType13=TXT&HostId14=746367&Address14=challengetoken&MXPref14=10&TTL14=3600&AssociatedAppTitle14=&FriendlyName14=&IsActive14=true&IsDDNSEnabled14=false&HostName14=_acme-challenge.noop&RecordType14=TXT&HostId15=746364&Address15=challengetoken&MXPref15=10&TTL15=3600&AssociatedAppTitle15=&FriendlyName15=&IsActive15=true&IsDDNSEnabled15=false&HostName15=_acme-challenge.test&RecordType15=TXT&HostId16=746368&Address16=challengetoken&MXPref16=10&TTL16=3600&AssociatedAppTitle16=&FriendlyName16=&IsActive16=true&IsDDNSEnabled16=false&HostName16=delete.testfilt&RecordType16=TXT&HostId17=746369&Address17=challengetoken&MXPref17=10&TTL17=3600&AssociatedAppTitle17=&FriendlyName17=&IsActive17=true&IsDDNSEnabled17=false&HostName17=delete.testfqdn&RecordType17=TXT&HostId18=746370&Address18=challengetoken&MXPref18=10&TTL18=3600&AssociatedAppTitle18=&FriendlyName18=&IsActive18=true&IsDDNSEnabled18=false&HostName18=delete.testfull&RecordType18=TXT&HostId19=746371&Address19=challengetoken&MXPref19=10&TTL19=3600&AssociatedAppTitle19=&FriendlyName19=&IsActive19=true&IsDDNSEnabled19=false&HostName19=delete.testid&RecordType19=TXT&HostId20=746383&Address20=challengetoken&MXPref20=10&TTL20=3600&AssociatedAppTitle20=&FriendlyName20=&IsActive20=true&IsDDNSEnabled20=false&HostName20=orig.nameonly.test&RecordType20=TXT&HostId21=746384&Address21=updated&MXPref21=10&TTL21=3600&AssociatedAppTitle21=&FriendlyName21=&IsActive21=true&IsDDNSEnabled21=false&HostName21=orig.nameonly.test&RecordType21=TXT&HostId22=746381&Address22=challengetoken&MXPref22=10&TTL22=3600&AssociatedAppTitle22=&FriendlyName22=&IsActive22=true&IsDDNSEnabled22=false&HostName22=orig.test&RecordType22=TXT&HostId23=746385&Address23=challengetoken&MXPref23=10&TTL23=3600&AssociatedAppTitle23=&FriendlyName23=&IsActive23=true&IsDDNSEnabled23=false&HostName23=orig.testfqdn&RecordType23=TXT&HostId24=746387&Address24=challengetoken&MXPref24=10&TTL24=3600&AssociatedAppTitle24=&FriendlyName24=&IsActive24=true&IsDDNSEnabled24=false&HostName24=orig.testfull&RecordType24=TXT&HostId25=746378&Address25=challengetoken&MXPref25=10&TTL25=3600&AssociatedAppTitle25=&FriendlyName25=&IsActive25=true&IsDDNSEnabled25=false&HostName25=random.fqdntest&RecordType25=TXT&HostId26=746379&Address26=challengetoken&MXPref26=10&TTL26=3600&AssociatedAppTitle26=&FriendlyName26=&IsActive26=true&IsDDNSEnabled26=false&HostName26=random.fulltest&RecordType26=TXT&HostId27=746380&Address27=challengetoken&MXPref27=10&TTL27=3600&AssociatedAppTitle27=&FriendlyName27=&IsActive27=true&IsDDNSEnabled27=false&HostName27=random.test&RecordType27=TXT&HostId28=746382&Address28=challengetoken&MXPref28=10&TTL28=3600&AssociatedAppTitle28=&FriendlyName28=&IsActive28=true&IsDDNSEnabled28=false&HostName28=updated.test&RecordType28=TXT&HostId29=746386&Address29=challengetoken&MXPref29=10&TTL29=3600&AssociatedAppTitle29=&FriendlyName29=&IsActive29=true&IsDDNSEnabled29=false&HostName29=updated.testfqdn&RecordType29=TXT&HostId30=746388&Address30=challengetoken&MXPref30=10&TTL30=3600&AssociatedAppTitle30=&FriendlyName30=&IsActive30=true&IsDDNSEnabled30=false&HostName30=updated.testfull&RecordType30=TXT&HostId31=746354&Address31=http%3A%2F%2Fwww.unittest2.dev%2F&MXPref31=10&TTL31=1800&AssociatedAppTitle31=URL+Forwarding&FriendlyName31=URL+Record&IsActive31=true&IsDDNSEnabled31=false&HostName31=%40&RecordType31=URL&Address32=challengetoken&TTL32=3600&HostName32=_acme-challenge.fqdn&RecordType32=TXT&SLD=unittest2&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['3344']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '5884'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.716</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest2.dev\" IsSuccess=\"true\">\r\n      <Warnings />\r\n    </DomainDNSSetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.956</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['559']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:08 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 18:59:25 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '557'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/namecheap/IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_full_name_and_content.yaml
+++ b/tests/fixtures/cassettes/namecheap/IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_full_name_and_content.yaml
@@ -2,148 +2,227 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise.com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=unittest2.dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
-        \ Status=\"Ok\" ID=\"277432\" DomainName=\"example-aptise.com\" OwnerName=\"\
-        jvsandbox\" IsOwner=\"true\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
-        \n        <CreatedDate>03/25/2018</CreatedDate>\r\n        <ExpiredDate>03/25/2019</ExpiredDate>\r\
-        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
-        \ />\r\n      <Whoisguard Enabled=\"NotAlloted\">\r\n        <ID>0</ID>\r\n\
-        \      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
-        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
-        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
-        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
-        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"18\" EmailType=\"\
-        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
-        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
-        \n      <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.03</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult
+        Status=\"Ok\" ID=\"589667\" DomainName=\"unittest2.dev\" OwnerName=\"phassberg\"
+        IsOwner=\"true\" IsPremium=\"false\">\r\n      <DomainDetails>\r\n        <CreatedDate>05/20/2020</CreatedDate>\r\n
+        \       <ExpiredDate>05/20/2021</ExpiredDate>\r\n        <NumYears>0</NumYears>\r\n
+        \     </DomainDetails>\r\n      <LockDetails />\r\n      <Whoisguard Enabled=\"True\">\r\n
+        \       <ID>481121</ID>\r\n        <ExpiredDate>05/20/2021</ExpiredDate>\r\n
+        \       <EmailDetails WhoisGuardEmail=\"824017ccbed343119b3459c7d3304ba5.protect@whoisguard.com\"
+        ForwardedTo=\"dr.doddo@gmail.com\" LastAutoEmailChangeDate=\"05/20/2020\"
+        AutoEmailChangeFrequencyDays=\"3\" />\r\n      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n
+        \       <UseAutoRenew>false</UseAutoRenew>\r\n        <SubscriptionId>-1</SubscriptionId>\r\n
+        \       <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n
+        \       <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n
+        \     <DnsDetails ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"31\"
+        EmailType=\"FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\n
+        \       <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\n
+        \     <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.287</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['1492']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:08 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 18:59:26 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '1740'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest2&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524157\" Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524158\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524214\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
-        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
-        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>1.036</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest2.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n      <host
+        HostId=\"746360\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746361\" Name=\"docs\" Type=\"CNAME\" Address=\"docs.example.com.\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746355\" Name=\"www\" Type=\"CNAME\"
+        Address=\"parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\"
+        FriendlyName=\"CNAME Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n
+        \     <host HostId=\"746365\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746366\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746372\" Name=\"_acme-challenge.deleterecordinset\"
+        Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746373\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746374\" Name=\"_acme-challenge.deleterecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746375\" Name=\"_acme-challenge.deleterecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746362\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746363\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746376\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746377\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746367\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746364\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746368\" Name=\"delete.testfilt\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746369\" Name=\"delete.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746370\" Name=\"delete.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746371\" Name=\"delete.testid\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746383\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746384\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746381\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746385\" Name=\"orig.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746387\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746378\" Name=\"random.fqdntest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746379\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746380\" Name=\"random.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746382\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746386\" Name=\"updated.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746388\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746354\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest2.dev/\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL
+        Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.157</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['3987']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:10 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 18:59:27 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '6601'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'IsActive10=true&IsDDNSEnabled18=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=URL&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524214&HostId9=524166&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524156&HostId5=524157&HostId6=524158&HostId7=524168&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&FriendlyName3=CName+Record&FriendlyName18=URL+Record&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524163&HostId13=524164&HostId10=524170&HostId11=524172&HostId16=524171&HostId17=524173&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=updated&Address9=challengetoken&IsActive9=true&IsActive8=true&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=60&HostName12=random.fqdntest&HostName13=random.fulltest&HostName10=orig.testfqdn&HostName11=orig.testfull&HostName16=updated.testfqdn&HostName17=updated.testfull&HostName14=random.test&Address1=127.0.0.1&HostName18=yyy&HostName19=_acme-challenge.full&MXPref5=10&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=60&TTL6=1800&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&Address12=challengetoken&Address18=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.fqdn&HostName5=_acme-challenge.full&HostName6=_acme-challenge.test&HostName7=orig.nameonly.test&HostName8=orig.nameonly.test&HostName9=orig.test&Address10=challengetoken&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken&TTL16=1800&FriendlyName16=&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=updated.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise&MXPref4=10&TTL18=1800&AssociatedAppTitle18=&HostId14=524165&HostId15=524167&HostId18=524160'
+    body: HostId1=746360&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746361&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746355&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746365&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746366&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746372&Address6=challengetoken1&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.deleterecordinset&RecordType6=TXT&HostId7=746373&Address7=challengetoken2&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.deleterecordinset&RecordType7=TXT&HostId8=746374&Address8=challengetoken1&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.deleterecordset&RecordType8=TXT&HostId9=746375&Address9=challengetoken2&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.deleterecordset&RecordType9=TXT&HostId10=746362&Address10=challengetoken&MXPref10=10&TTL10=3600&AssociatedAppTitle10=&FriendlyName10=&IsActive10=true&IsDDNSEnabled10=false&HostName10=_acme-challenge.fqdn&RecordType10=TXT&HostId11=746363&Address11=challengetoken&MXPref11=10&TTL11=3600&AssociatedAppTitle11=&FriendlyName11=&IsActive11=true&IsDDNSEnabled11=false&HostName11=_acme-challenge.full&RecordType11=TXT&HostId12=746376&Address12=challengetoken1&MXPref12=10&TTL12=3600&AssociatedAppTitle12=&FriendlyName12=&IsActive12=true&IsDDNSEnabled12=false&HostName12=_acme-challenge.listrecordset&RecordType12=TXT&HostId13=746377&Address13=challengetoken2&MXPref13=10&TTL13=3600&AssociatedAppTitle13=&FriendlyName13=&IsActive13=true&IsDDNSEnabled13=false&HostName13=_acme-challenge.listrecordset&RecordType13=TXT&HostId14=746367&Address14=challengetoken&MXPref14=10&TTL14=3600&AssociatedAppTitle14=&FriendlyName14=&IsActive14=true&IsDDNSEnabled14=false&HostName14=_acme-challenge.noop&RecordType14=TXT&HostId15=746364&Address15=challengetoken&MXPref15=10&TTL15=3600&AssociatedAppTitle15=&FriendlyName15=&IsActive15=true&IsDDNSEnabled15=false&HostName15=_acme-challenge.test&RecordType15=TXT&HostId16=746368&Address16=challengetoken&MXPref16=10&TTL16=3600&AssociatedAppTitle16=&FriendlyName16=&IsActive16=true&IsDDNSEnabled16=false&HostName16=delete.testfilt&RecordType16=TXT&HostId17=746369&Address17=challengetoken&MXPref17=10&TTL17=3600&AssociatedAppTitle17=&FriendlyName17=&IsActive17=true&IsDDNSEnabled17=false&HostName17=delete.testfqdn&RecordType17=TXT&HostId18=746370&Address18=challengetoken&MXPref18=10&TTL18=3600&AssociatedAppTitle18=&FriendlyName18=&IsActive18=true&IsDDNSEnabled18=false&HostName18=delete.testfull&RecordType18=TXT&HostId19=746371&Address19=challengetoken&MXPref19=10&TTL19=3600&AssociatedAppTitle19=&FriendlyName19=&IsActive19=true&IsDDNSEnabled19=false&HostName19=delete.testid&RecordType19=TXT&HostId20=746383&Address20=challengetoken&MXPref20=10&TTL20=3600&AssociatedAppTitle20=&FriendlyName20=&IsActive20=true&IsDDNSEnabled20=false&HostName20=orig.nameonly.test&RecordType20=TXT&HostId21=746384&Address21=updated&MXPref21=10&TTL21=3600&AssociatedAppTitle21=&FriendlyName21=&IsActive21=true&IsDDNSEnabled21=false&HostName21=orig.nameonly.test&RecordType21=TXT&HostId22=746381&Address22=challengetoken&MXPref22=10&TTL22=3600&AssociatedAppTitle22=&FriendlyName22=&IsActive22=true&IsDDNSEnabled22=false&HostName22=orig.test&RecordType22=TXT&HostId23=746385&Address23=challengetoken&MXPref23=10&TTL23=3600&AssociatedAppTitle23=&FriendlyName23=&IsActive23=true&IsDDNSEnabled23=false&HostName23=orig.testfqdn&RecordType23=TXT&HostId24=746387&Address24=challengetoken&MXPref24=10&TTL24=3600&AssociatedAppTitle24=&FriendlyName24=&IsActive24=true&IsDDNSEnabled24=false&HostName24=orig.testfull&RecordType24=TXT&HostId25=746378&Address25=challengetoken&MXPref25=10&TTL25=3600&AssociatedAppTitle25=&FriendlyName25=&IsActive25=true&IsDDNSEnabled25=false&HostName25=random.fqdntest&RecordType25=TXT&HostId26=746379&Address26=challengetoken&MXPref26=10&TTL26=3600&AssociatedAppTitle26=&FriendlyName26=&IsActive26=true&IsDDNSEnabled26=false&HostName26=random.fulltest&RecordType26=TXT&HostId27=746380&Address27=challengetoken&MXPref27=10&TTL27=3600&AssociatedAppTitle27=&FriendlyName27=&IsActive27=true&IsDDNSEnabled27=false&HostName27=random.test&RecordType27=TXT&HostId28=746382&Address28=challengetoken&MXPref28=10&TTL28=3600&AssociatedAppTitle28=&FriendlyName28=&IsActive28=true&IsDDNSEnabled28=false&HostName28=updated.test&RecordType28=TXT&HostId29=746386&Address29=challengetoken&MXPref29=10&TTL29=3600&AssociatedAppTitle29=&FriendlyName29=&IsActive29=true&IsDDNSEnabled29=false&HostName29=updated.testfqdn&RecordType29=TXT&HostId30=746388&Address30=challengetoken&MXPref30=10&TTL30=3600&AssociatedAppTitle30=&FriendlyName30=&IsActive30=true&IsDDNSEnabled30=false&HostName30=updated.testfull&RecordType30=TXT&HostId31=746354&Address31=http%3A%2F%2Fwww.unittest2.dev%2F&MXPref31=10&TTL31=1800&AssociatedAppTitle31=URL+Forwarding&FriendlyName31=URL+Record&IsActive31=true&IsDDNSEnabled31=false&HostName31=%40&RecordType31=URL&Address32=challengetoken&TTL32=3600&HostName32=_acme-challenge.full&RecordType32=TXT&SLD=unittest2&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['3344']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '5884'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>1.215</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest2.dev\" IsSuccess=\"true\">\r\n      <Warnings />\r\n    </DomainDNSSetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.58</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['559']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:11 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 18:59:29 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '556'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/namecheap/IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/namecheap/IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_valid_name_and_content.yaml
@@ -2,148 +2,227 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise.com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=unittest2.dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
-        \ Status=\"Ok\" ID=\"277432\" DomainName=\"example-aptise.com\" OwnerName=\"\
-        jvsandbox\" IsOwner=\"true\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
-        \n        <CreatedDate>03/25/2018</CreatedDate>\r\n        <ExpiredDate>03/25/2019</ExpiredDate>\r\
-        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
-        \ />\r\n      <Whoisguard Enabled=\"NotAlloted\">\r\n        <ID>0</ID>\r\n\
-        \      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
-        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
-        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
-        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
-        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"18\" EmailType=\"\
-        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
-        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
-        \n      <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.208</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult
+        Status=\"Ok\" ID=\"589667\" DomainName=\"unittest2.dev\" OwnerName=\"phassberg\"
+        IsOwner=\"true\" IsPremium=\"false\">\r\n      <DomainDetails>\r\n        <CreatedDate>05/20/2020</CreatedDate>\r\n
+        \       <ExpiredDate>05/20/2021</ExpiredDate>\r\n        <NumYears>0</NumYears>\r\n
+        \     </DomainDetails>\r\n      <LockDetails />\r\n      <Whoisguard Enabled=\"True\">\r\n
+        \       <ID>481121</ID>\r\n        <ExpiredDate>05/20/2021</ExpiredDate>\r\n
+        \       <EmailDetails WhoisGuardEmail=\"824017ccbed343119b3459c7d3304ba5.protect@whoisguard.com\"
+        ForwardedTo=\"dr.doddo@gmail.com\" LastAutoEmailChangeDate=\"05/20/2020\"
+        AutoEmailChangeFrequencyDays=\"3\" />\r\n      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n
+        \       <UseAutoRenew>false</UseAutoRenew>\r\n        <SubscriptionId>-1</SubscriptionId>\r\n
+        \       <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n
+        \       <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n
+        \     <DnsDetails ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"31\"
+        EmailType=\"FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\n
+        \       <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\n
+        \     <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.04</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['1493']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:11 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 18:59:28 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '1739'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest2&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524157\" Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524158\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524214\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
-        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
-        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.769</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest2.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n      <host
+        HostId=\"746360\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746361\" Name=\"docs\" Type=\"CNAME\" Address=\"docs.example.com.\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746355\" Name=\"www\" Type=\"CNAME\"
+        Address=\"parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\"
+        FriendlyName=\"CNAME Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n
+        \     <host HostId=\"746365\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746366\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746372\" Name=\"_acme-challenge.deleterecordinset\"
+        Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746373\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746374\" Name=\"_acme-challenge.deleterecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746375\" Name=\"_acme-challenge.deleterecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746362\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746363\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746376\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746377\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746367\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746364\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746368\" Name=\"delete.testfilt\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746369\" Name=\"delete.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746370\" Name=\"delete.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746371\" Name=\"delete.testid\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746383\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746384\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746381\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746385\" Name=\"orig.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746387\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746378\" Name=\"random.fqdntest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746379\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746380\" Name=\"random.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746382\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746386\" Name=\"updated.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746388\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746354\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest2.dev/\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL
+        Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.407</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['3987']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:13 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 18:59:31 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '6601'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'IsActive10=true&IsDDNSEnabled18=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=URL&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524214&HostId9=524166&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524156&HostId5=524157&HostId6=524158&HostId7=524168&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&FriendlyName3=CName+Record&FriendlyName18=URL+Record&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524163&HostId13=524164&HostId10=524170&HostId11=524172&HostId16=524171&HostId17=524173&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=updated&Address9=challengetoken&IsActive9=true&IsActive8=true&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=60&HostName12=random.fqdntest&HostName13=random.fulltest&HostName10=orig.testfqdn&HostName11=orig.testfull&HostName16=updated.testfqdn&HostName17=updated.testfull&HostName14=random.test&Address1=127.0.0.1&HostName18=yyy&HostName19=_acme-challenge.test&MXPref5=10&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=60&TTL6=1800&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&Address12=challengetoken&Address18=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.fqdn&HostName5=_acme-challenge.full&HostName6=_acme-challenge.test&HostName7=orig.nameonly.test&HostName8=orig.nameonly.test&HostName9=orig.test&Address10=challengetoken&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken&TTL16=1800&FriendlyName16=&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=updated.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise&MXPref4=10&TTL18=1800&AssociatedAppTitle18=&HostId14=524165&HostId15=524167&HostId18=524160'
+    body: HostId1=746360&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746361&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746355&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746365&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746366&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746372&Address6=challengetoken1&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.deleterecordinset&RecordType6=TXT&HostId7=746373&Address7=challengetoken2&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.deleterecordinset&RecordType7=TXT&HostId8=746374&Address8=challengetoken1&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.deleterecordset&RecordType8=TXT&HostId9=746375&Address9=challengetoken2&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.deleterecordset&RecordType9=TXT&HostId10=746362&Address10=challengetoken&MXPref10=10&TTL10=3600&AssociatedAppTitle10=&FriendlyName10=&IsActive10=true&IsDDNSEnabled10=false&HostName10=_acme-challenge.fqdn&RecordType10=TXT&HostId11=746363&Address11=challengetoken&MXPref11=10&TTL11=3600&AssociatedAppTitle11=&FriendlyName11=&IsActive11=true&IsDDNSEnabled11=false&HostName11=_acme-challenge.full&RecordType11=TXT&HostId12=746376&Address12=challengetoken1&MXPref12=10&TTL12=3600&AssociatedAppTitle12=&FriendlyName12=&IsActive12=true&IsDDNSEnabled12=false&HostName12=_acme-challenge.listrecordset&RecordType12=TXT&HostId13=746377&Address13=challengetoken2&MXPref13=10&TTL13=3600&AssociatedAppTitle13=&FriendlyName13=&IsActive13=true&IsDDNSEnabled13=false&HostName13=_acme-challenge.listrecordset&RecordType13=TXT&HostId14=746367&Address14=challengetoken&MXPref14=10&TTL14=3600&AssociatedAppTitle14=&FriendlyName14=&IsActive14=true&IsDDNSEnabled14=false&HostName14=_acme-challenge.noop&RecordType14=TXT&HostId15=746364&Address15=challengetoken&MXPref15=10&TTL15=3600&AssociatedAppTitle15=&FriendlyName15=&IsActive15=true&IsDDNSEnabled15=false&HostName15=_acme-challenge.test&RecordType15=TXT&HostId16=746368&Address16=challengetoken&MXPref16=10&TTL16=3600&AssociatedAppTitle16=&FriendlyName16=&IsActive16=true&IsDDNSEnabled16=false&HostName16=delete.testfilt&RecordType16=TXT&HostId17=746369&Address17=challengetoken&MXPref17=10&TTL17=3600&AssociatedAppTitle17=&FriendlyName17=&IsActive17=true&IsDDNSEnabled17=false&HostName17=delete.testfqdn&RecordType17=TXT&HostId18=746370&Address18=challengetoken&MXPref18=10&TTL18=3600&AssociatedAppTitle18=&FriendlyName18=&IsActive18=true&IsDDNSEnabled18=false&HostName18=delete.testfull&RecordType18=TXT&HostId19=746371&Address19=challengetoken&MXPref19=10&TTL19=3600&AssociatedAppTitle19=&FriendlyName19=&IsActive19=true&IsDDNSEnabled19=false&HostName19=delete.testid&RecordType19=TXT&HostId20=746383&Address20=challengetoken&MXPref20=10&TTL20=3600&AssociatedAppTitle20=&FriendlyName20=&IsActive20=true&IsDDNSEnabled20=false&HostName20=orig.nameonly.test&RecordType20=TXT&HostId21=746384&Address21=updated&MXPref21=10&TTL21=3600&AssociatedAppTitle21=&FriendlyName21=&IsActive21=true&IsDDNSEnabled21=false&HostName21=orig.nameonly.test&RecordType21=TXT&HostId22=746381&Address22=challengetoken&MXPref22=10&TTL22=3600&AssociatedAppTitle22=&FriendlyName22=&IsActive22=true&IsDDNSEnabled22=false&HostName22=orig.test&RecordType22=TXT&HostId23=746385&Address23=challengetoken&MXPref23=10&TTL23=3600&AssociatedAppTitle23=&FriendlyName23=&IsActive23=true&IsDDNSEnabled23=false&HostName23=orig.testfqdn&RecordType23=TXT&HostId24=746387&Address24=challengetoken&MXPref24=10&TTL24=3600&AssociatedAppTitle24=&FriendlyName24=&IsActive24=true&IsDDNSEnabled24=false&HostName24=orig.testfull&RecordType24=TXT&HostId25=746378&Address25=challengetoken&MXPref25=10&TTL25=3600&AssociatedAppTitle25=&FriendlyName25=&IsActive25=true&IsDDNSEnabled25=false&HostName25=random.fqdntest&RecordType25=TXT&HostId26=746379&Address26=challengetoken&MXPref26=10&TTL26=3600&AssociatedAppTitle26=&FriendlyName26=&IsActive26=true&IsDDNSEnabled26=false&HostName26=random.fulltest&RecordType26=TXT&HostId27=746380&Address27=challengetoken&MXPref27=10&TTL27=3600&AssociatedAppTitle27=&FriendlyName27=&IsActive27=true&IsDDNSEnabled27=false&HostName27=random.test&RecordType27=TXT&HostId28=746382&Address28=challengetoken&MXPref28=10&TTL28=3600&AssociatedAppTitle28=&FriendlyName28=&IsActive28=true&IsDDNSEnabled28=false&HostName28=updated.test&RecordType28=TXT&HostId29=746386&Address29=challengetoken&MXPref29=10&TTL29=3600&AssociatedAppTitle29=&FriendlyName29=&IsActive29=true&IsDDNSEnabled29=false&HostName29=updated.testfqdn&RecordType29=TXT&HostId30=746388&Address30=challengetoken&MXPref30=10&TTL30=3600&AssociatedAppTitle30=&FriendlyName30=&IsActive30=true&IsDDNSEnabled30=false&HostName30=updated.testfull&RecordType30=TXT&HostId31=746354&Address31=http%3A%2F%2Fwww.unittest2.dev%2F&MXPref31=10&TTL31=1800&AssociatedAppTitle31=URL+Forwarding&FriendlyName31=URL+Record&IsActive31=true&IsDDNSEnabled31=false&HostName31=%40&RecordType31=URL&Address32=challengetoken&TTL32=3600&HostName32=_acme-challenge.test&RecordType32=TXT&SLD=unittest2&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['3344']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '5884'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.717</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest2.dev\" IsSuccess=\"true\">\r\n      <Warnings />\r\n    </DomainDNSSetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>1.228</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['559']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:14 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 18:59:33 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '557'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/namecheap/IntegrationTests/test_provider_when_calling_create_record_multiple_times_should_create_record_set.yaml
+++ b/tests/fixtures/cassettes/namecheap/IntegrationTests/test_provider_when_calling_create_record_multiple_times_should_create_record_set.yaml
@@ -2,258 +2,395 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise.com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=unittest2.dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
-        \ Status=\"Ok\" ID=\"277432\" DomainName=\"example-aptise.com\" OwnerName=\"\
-        jvsandbox\" IsOwner=\"true\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
-        \n        <CreatedDate>03/25/2018</CreatedDate>\r\n        <ExpiredDate>03/25/2019</ExpiredDate>\r\
-        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
-        \ />\r\n      <Whoisguard Enabled=\"NotAlloted\">\r\n        <ID>0</ID>\r\n\
-        \      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
-        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
-        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
-        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
-        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"18\" EmailType=\"\
-        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
-        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
-        \n      <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.033</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult
+        Status=\"Ok\" ID=\"589667\" DomainName=\"unittest2.dev\" OwnerName=\"phassberg\"
+        IsOwner=\"true\" IsPremium=\"false\">\r\n      <DomainDetails>\r\n        <CreatedDate>05/20/2020</CreatedDate>\r\n
+        \       <ExpiredDate>05/20/2021</ExpiredDate>\r\n        <NumYears>0</NumYears>\r\n
+        \     </DomainDetails>\r\n      <LockDetails />\r\n      <Whoisguard Enabled=\"True\">\r\n
+        \       <ID>481121</ID>\r\n        <ExpiredDate>05/20/2021</ExpiredDate>\r\n
+        \       <EmailDetails WhoisGuardEmail=\"824017ccbed343119b3459c7d3304ba5.protect@whoisguard.com\"
+        ForwardedTo=\"dr.doddo@gmail.com\" LastAutoEmailChangeDate=\"05/20/2020\"
+        AutoEmailChangeFrequencyDays=\"3\" />\r\n      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n
+        \       <UseAutoRenew>false</UseAutoRenew>\r\n        <SubscriptionId>-1</SubscriptionId>\r\n
+        \       <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n
+        \       <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n
+        \     <DnsDetails ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"31\"
+        EmailType=\"FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\n
+        \       <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\n
+        \     <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.039</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['1493']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:14 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 18:59:34 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '1740'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest2&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524157\" Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524158\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524214\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
-        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
-        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.838</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest2.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n      <host
+        HostId=\"746360\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746361\" Name=\"docs\" Type=\"CNAME\" Address=\"docs.example.com.\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746355\" Name=\"www\" Type=\"CNAME\"
+        Address=\"parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\"
+        FriendlyName=\"CNAME Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n
+        \     <host HostId=\"746365\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746366\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746372\" Name=\"_acme-challenge.deleterecordinset\"
+        Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746373\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746374\" Name=\"_acme-challenge.deleterecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746375\" Name=\"_acme-challenge.deleterecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746362\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746363\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746376\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746377\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746367\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746364\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746368\" Name=\"delete.testfilt\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746369\" Name=\"delete.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746370\" Name=\"delete.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746371\" Name=\"delete.testid\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746383\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746384\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746381\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746385\" Name=\"orig.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746387\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746378\" Name=\"random.fqdntest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746379\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746380\" Name=\"random.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746382\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746386\" Name=\"updated.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746388\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746354\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest2.dev/\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL
+        Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.445</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['3987']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:16 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 18:59:35 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '6601'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'IsActive10=true&IsDDNSEnabled18=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=URL&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524214&HostId9=524166&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524156&HostId5=524157&HostId6=524158&HostId7=524168&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&FriendlyName3=CName+Record&FriendlyName18=URL+Record&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524163&HostId13=524164&HostId10=524170&HostId11=524172&HostId16=524171&HostId17=524173&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=updated&Address9=challengetoken&IsActive9=true&IsActive8=true&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=60&HostName12=random.fqdntest&HostName13=random.fulltest&HostName10=orig.testfqdn&HostName11=orig.testfull&HostName16=updated.testfqdn&HostName17=updated.testfull&HostName14=random.test&Address1=127.0.0.1&HostName18=yyy&HostName19=_acme-challenge.createrecordset&MXPref5=10&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=60&TTL6=1800&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&Address12=challengetoken&Address18=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&Address19=challengetoken1&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.fqdn&HostName5=_acme-challenge.full&HostName6=_acme-challenge.test&HostName7=orig.nameonly.test&HostName8=orig.nameonly.test&HostName9=orig.test&Address10=challengetoken&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken&TTL16=1800&FriendlyName16=&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=updated.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise&MXPref4=10&TTL18=1800&AssociatedAppTitle18=&HostId14=524165&HostId15=524167&HostId18=524160'
+    body: HostId1=746360&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746361&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746355&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746365&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746366&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746372&Address6=challengetoken1&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.deleterecordinset&RecordType6=TXT&HostId7=746373&Address7=challengetoken2&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.deleterecordinset&RecordType7=TXT&HostId8=746374&Address8=challengetoken1&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.deleterecordset&RecordType8=TXT&HostId9=746375&Address9=challengetoken2&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.deleterecordset&RecordType9=TXT&HostId10=746362&Address10=challengetoken&MXPref10=10&TTL10=3600&AssociatedAppTitle10=&FriendlyName10=&IsActive10=true&IsDDNSEnabled10=false&HostName10=_acme-challenge.fqdn&RecordType10=TXT&HostId11=746363&Address11=challengetoken&MXPref11=10&TTL11=3600&AssociatedAppTitle11=&FriendlyName11=&IsActive11=true&IsDDNSEnabled11=false&HostName11=_acme-challenge.full&RecordType11=TXT&HostId12=746376&Address12=challengetoken1&MXPref12=10&TTL12=3600&AssociatedAppTitle12=&FriendlyName12=&IsActive12=true&IsDDNSEnabled12=false&HostName12=_acme-challenge.listrecordset&RecordType12=TXT&HostId13=746377&Address13=challengetoken2&MXPref13=10&TTL13=3600&AssociatedAppTitle13=&FriendlyName13=&IsActive13=true&IsDDNSEnabled13=false&HostName13=_acme-challenge.listrecordset&RecordType13=TXT&HostId14=746367&Address14=challengetoken&MXPref14=10&TTL14=3600&AssociatedAppTitle14=&FriendlyName14=&IsActive14=true&IsDDNSEnabled14=false&HostName14=_acme-challenge.noop&RecordType14=TXT&HostId15=746364&Address15=challengetoken&MXPref15=10&TTL15=3600&AssociatedAppTitle15=&FriendlyName15=&IsActive15=true&IsDDNSEnabled15=false&HostName15=_acme-challenge.test&RecordType15=TXT&HostId16=746368&Address16=challengetoken&MXPref16=10&TTL16=3600&AssociatedAppTitle16=&FriendlyName16=&IsActive16=true&IsDDNSEnabled16=false&HostName16=delete.testfilt&RecordType16=TXT&HostId17=746369&Address17=challengetoken&MXPref17=10&TTL17=3600&AssociatedAppTitle17=&FriendlyName17=&IsActive17=true&IsDDNSEnabled17=false&HostName17=delete.testfqdn&RecordType17=TXT&HostId18=746370&Address18=challengetoken&MXPref18=10&TTL18=3600&AssociatedAppTitle18=&FriendlyName18=&IsActive18=true&IsDDNSEnabled18=false&HostName18=delete.testfull&RecordType18=TXT&HostId19=746371&Address19=challengetoken&MXPref19=10&TTL19=3600&AssociatedAppTitle19=&FriendlyName19=&IsActive19=true&IsDDNSEnabled19=false&HostName19=delete.testid&RecordType19=TXT&HostId20=746383&Address20=challengetoken&MXPref20=10&TTL20=3600&AssociatedAppTitle20=&FriendlyName20=&IsActive20=true&IsDDNSEnabled20=false&HostName20=orig.nameonly.test&RecordType20=TXT&HostId21=746384&Address21=updated&MXPref21=10&TTL21=3600&AssociatedAppTitle21=&FriendlyName21=&IsActive21=true&IsDDNSEnabled21=false&HostName21=orig.nameonly.test&RecordType21=TXT&HostId22=746381&Address22=challengetoken&MXPref22=10&TTL22=3600&AssociatedAppTitle22=&FriendlyName22=&IsActive22=true&IsDDNSEnabled22=false&HostName22=orig.test&RecordType22=TXT&HostId23=746385&Address23=challengetoken&MXPref23=10&TTL23=3600&AssociatedAppTitle23=&FriendlyName23=&IsActive23=true&IsDDNSEnabled23=false&HostName23=orig.testfqdn&RecordType23=TXT&HostId24=746387&Address24=challengetoken&MXPref24=10&TTL24=3600&AssociatedAppTitle24=&FriendlyName24=&IsActive24=true&IsDDNSEnabled24=false&HostName24=orig.testfull&RecordType24=TXT&HostId25=746378&Address25=challengetoken&MXPref25=10&TTL25=3600&AssociatedAppTitle25=&FriendlyName25=&IsActive25=true&IsDDNSEnabled25=false&HostName25=random.fqdntest&RecordType25=TXT&HostId26=746379&Address26=challengetoken&MXPref26=10&TTL26=3600&AssociatedAppTitle26=&FriendlyName26=&IsActive26=true&IsDDNSEnabled26=false&HostName26=random.fulltest&RecordType26=TXT&HostId27=746380&Address27=challengetoken&MXPref27=10&TTL27=3600&AssociatedAppTitle27=&FriendlyName27=&IsActive27=true&IsDDNSEnabled27=false&HostName27=random.test&RecordType27=TXT&HostId28=746382&Address28=challengetoken&MXPref28=10&TTL28=3600&AssociatedAppTitle28=&FriendlyName28=&IsActive28=true&IsDDNSEnabled28=false&HostName28=updated.test&RecordType28=TXT&HostId29=746386&Address29=challengetoken&MXPref29=10&TTL29=3600&AssociatedAppTitle29=&FriendlyName29=&IsActive29=true&IsDDNSEnabled29=false&HostName29=updated.testfqdn&RecordType29=TXT&HostId30=746388&Address30=challengetoken&MXPref30=10&TTL30=3600&AssociatedAppTitle30=&FriendlyName30=&IsActive30=true&IsDDNSEnabled30=false&HostName30=updated.testfull&RecordType30=TXT&HostId31=746354&Address31=http%3A%2F%2Fwww.unittest2.dev%2F&MXPref31=10&TTL31=1800&AssociatedAppTitle31=URL+Forwarding&FriendlyName31=URL+Record&IsActive31=true&IsDDNSEnabled31=false&HostName31=%40&RecordType31=URL&Address32=challengetoken1&TTL32=3600&HostName32=_acme-challenge.createrecordset&RecordType32=TXT&SLD=unittest2&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['3356']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '5896'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.932</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest2.dev\" IsSuccess=\"true\">\r\n      <Warnings />\r\n    </DomainDNSSetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.767</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['559']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:18 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 18:59:36 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '557'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest2&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
-        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524158\" Name=\"_acme-challenge.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524168\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524214\"\
-        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"updated\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\" Name=\"orig.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524170\" Name=\"orig.testfqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524172\"\
-        \ Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\" Name=\"random.fqdntest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524164\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524165\"\
-        \ Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"updated.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524173\"\
-        \ Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\" Name=\"yyy\"\
-        \ Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\
-        \n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.729</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest2.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n      <host
+        HostId=\"746360\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746361\" Name=\"docs\" Type=\"CNAME\" Address=\"docs.example.com.\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746355\" Name=\"www\" Type=\"CNAME\"
+        Address=\"parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\"
+        FriendlyName=\"CNAME Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n
+        \     <host HostId=\"746365\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746366\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746372\" Name=\"_acme-challenge.deleterecordinset\"
+        Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746373\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746374\" Name=\"_acme-challenge.deleterecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746375\" Name=\"_acme-challenge.deleterecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746362\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746363\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746376\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746377\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746367\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746364\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746368\" Name=\"delete.testfilt\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746369\" Name=\"delete.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746370\" Name=\"delete.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746371\" Name=\"delete.testid\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746383\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746384\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746381\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746385\" Name=\"orig.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746387\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746378\" Name=\"random.fqdntest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746379\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746380\" Name=\"random.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746382\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746386\" Name=\"updated.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746388\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746354\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest2.dev/\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL
+        Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.343</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4194']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:19 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 18:59:37 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '6601'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'HostId19=524160&RecordType20=TXT&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=URL&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524168&HostId9=524214&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524831&HostId5=524156&HostId6=524157&HostId7=524158&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&FriendlyName3=CName+Record&FriendlyName19=URL+Record&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524172&HostId13=524163&HostId10=524166&HostId11=524170&HostId16=524167&HostId17=524171&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=challengetoken&Address9=updated&IsActive9=true&IsActive8=true&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&HostName12=orig.testfull&HostName13=random.fqdntest&HostName10=orig.test&HostName11=orig.testfqdn&HostName16=updated.test&HostName17=updated.testfqdn&HostName14=random.fulltest&Address1=127.0.0.1&HostName18=updated.testfull&HostName19=yyy&MXPref5=10&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=60&TTL6=60&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&Address12=challengetoken&Address18=challengetoken&Address19=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.fqdn&HostName6=_acme-challenge.full&HostName7=_acme-challenge.test&HostName8=orig.nameonly.test&HostName9=orig.nameonly.test&Address10=challengetoken&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName20=_acme-challenge.createrecordset&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken&TTL16=1800&FriendlyName16=&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=random.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise&MXPref4=10&TTL18=1800&Address20=challengetoken2&AssociatedAppTitle18=&TTL19=1800&HostId14=524164&AssociatedAppTitle19=&HostId15=524165&HostId18=524173'
+    body: HostId1=746360&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746361&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746355&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746365&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746366&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746372&Address6=challengetoken1&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.deleterecordinset&RecordType6=TXT&HostId7=746373&Address7=challengetoken2&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.deleterecordinset&RecordType7=TXT&HostId8=746374&Address8=challengetoken1&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.deleterecordset&RecordType8=TXT&HostId9=746375&Address9=challengetoken2&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.deleterecordset&RecordType9=TXT&HostId10=746362&Address10=challengetoken&MXPref10=10&TTL10=3600&AssociatedAppTitle10=&FriendlyName10=&IsActive10=true&IsDDNSEnabled10=false&HostName10=_acme-challenge.fqdn&RecordType10=TXT&HostId11=746363&Address11=challengetoken&MXPref11=10&TTL11=3600&AssociatedAppTitle11=&FriendlyName11=&IsActive11=true&IsDDNSEnabled11=false&HostName11=_acme-challenge.full&RecordType11=TXT&HostId12=746376&Address12=challengetoken1&MXPref12=10&TTL12=3600&AssociatedAppTitle12=&FriendlyName12=&IsActive12=true&IsDDNSEnabled12=false&HostName12=_acme-challenge.listrecordset&RecordType12=TXT&HostId13=746377&Address13=challengetoken2&MXPref13=10&TTL13=3600&AssociatedAppTitle13=&FriendlyName13=&IsActive13=true&IsDDNSEnabled13=false&HostName13=_acme-challenge.listrecordset&RecordType13=TXT&HostId14=746367&Address14=challengetoken&MXPref14=10&TTL14=3600&AssociatedAppTitle14=&FriendlyName14=&IsActive14=true&IsDDNSEnabled14=false&HostName14=_acme-challenge.noop&RecordType14=TXT&HostId15=746364&Address15=challengetoken&MXPref15=10&TTL15=3600&AssociatedAppTitle15=&FriendlyName15=&IsActive15=true&IsDDNSEnabled15=false&HostName15=_acme-challenge.test&RecordType15=TXT&HostId16=746368&Address16=challengetoken&MXPref16=10&TTL16=3600&AssociatedAppTitle16=&FriendlyName16=&IsActive16=true&IsDDNSEnabled16=false&HostName16=delete.testfilt&RecordType16=TXT&HostId17=746369&Address17=challengetoken&MXPref17=10&TTL17=3600&AssociatedAppTitle17=&FriendlyName17=&IsActive17=true&IsDDNSEnabled17=false&HostName17=delete.testfqdn&RecordType17=TXT&HostId18=746370&Address18=challengetoken&MXPref18=10&TTL18=3600&AssociatedAppTitle18=&FriendlyName18=&IsActive18=true&IsDDNSEnabled18=false&HostName18=delete.testfull&RecordType18=TXT&HostId19=746371&Address19=challengetoken&MXPref19=10&TTL19=3600&AssociatedAppTitle19=&FriendlyName19=&IsActive19=true&IsDDNSEnabled19=false&HostName19=delete.testid&RecordType19=TXT&HostId20=746383&Address20=challengetoken&MXPref20=10&TTL20=3600&AssociatedAppTitle20=&FriendlyName20=&IsActive20=true&IsDDNSEnabled20=false&HostName20=orig.nameonly.test&RecordType20=TXT&HostId21=746384&Address21=updated&MXPref21=10&TTL21=3600&AssociatedAppTitle21=&FriendlyName21=&IsActive21=true&IsDDNSEnabled21=false&HostName21=orig.nameonly.test&RecordType21=TXT&HostId22=746381&Address22=challengetoken&MXPref22=10&TTL22=3600&AssociatedAppTitle22=&FriendlyName22=&IsActive22=true&IsDDNSEnabled22=false&HostName22=orig.test&RecordType22=TXT&HostId23=746385&Address23=challengetoken&MXPref23=10&TTL23=3600&AssociatedAppTitle23=&FriendlyName23=&IsActive23=true&IsDDNSEnabled23=false&HostName23=orig.testfqdn&RecordType23=TXT&HostId24=746387&Address24=challengetoken&MXPref24=10&TTL24=3600&AssociatedAppTitle24=&FriendlyName24=&IsActive24=true&IsDDNSEnabled24=false&HostName24=orig.testfull&RecordType24=TXT&HostId25=746378&Address25=challengetoken&MXPref25=10&TTL25=3600&AssociatedAppTitle25=&FriendlyName25=&IsActive25=true&IsDDNSEnabled25=false&HostName25=random.fqdntest&RecordType25=TXT&HostId26=746379&Address26=challengetoken&MXPref26=10&TTL26=3600&AssociatedAppTitle26=&FriendlyName26=&IsActive26=true&IsDDNSEnabled26=false&HostName26=random.fulltest&RecordType26=TXT&HostId27=746380&Address27=challengetoken&MXPref27=10&TTL27=3600&AssociatedAppTitle27=&FriendlyName27=&IsActive27=true&IsDDNSEnabled27=false&HostName27=random.test&RecordType27=TXT&HostId28=746382&Address28=challengetoken&MXPref28=10&TTL28=3600&AssociatedAppTitle28=&FriendlyName28=&IsActive28=true&IsDDNSEnabled28=false&HostName28=updated.test&RecordType28=TXT&HostId29=746386&Address29=challengetoken&MXPref29=10&TTL29=3600&AssociatedAppTitle29=&FriendlyName29=&IsActive29=true&IsDDNSEnabled29=false&HostName29=updated.testfqdn&RecordType29=TXT&HostId30=746388&Address30=challengetoken&MXPref30=10&TTL30=3600&AssociatedAppTitle30=&FriendlyName30=&IsActive30=true&IsDDNSEnabled30=false&HostName30=updated.testfull&RecordType30=TXT&HostId31=746354&Address31=http%3A%2F%2Fwww.unittest2.dev%2F&MXPref31=10&TTL31=1800&AssociatedAppTitle31=URL+Forwarding&FriendlyName31=URL+Record&IsActive31=true&IsDDNSEnabled31=false&HostName31=%40&RecordType31=URL&Address32=challengetoken2&TTL32=3600&HostName32=_acme-challenge.createrecordset&RecordType32=TXT&SLD=unittest2&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['3557']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '5896'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>1.063</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest2.dev\" IsSuccess=\"true\">\r\n      <Warnings />\r\n    </DomainDNSSetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>1.216</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['559']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:20 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 18:59:40 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '557'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/namecheap/IntegrationTests/test_provider_when_calling_create_record_with_duplicate_records_should_be_noop.yaml
+++ b/tests/fixtures/cassettes/namecheap/IntegrationTests/test_provider_when_calling_create_record_with_duplicate_records_should_be_noop.yaml
@@ -2,354 +2,517 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise.com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=unittest2.dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
-        \ Status=\"Ok\" ID=\"277432\" DomainName=\"example-aptise.com\" OwnerName=\"\
-        jvsandbox\" IsOwner=\"true\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
-        \n        <CreatedDate>03/25/2018</CreatedDate>\r\n        <ExpiredDate>03/25/2019</ExpiredDate>\r\
-        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
-        \ />\r\n      <Whoisguard Enabled=\"NotAlloted\">\r\n        <ID>0</ID>\r\n\
-        \      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
-        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
-        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
-        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
-        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"20\" EmailType=\"\
-        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
-        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
-        \n      <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.037</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult
+        Status=\"Ok\" ID=\"589667\" DomainName=\"unittest2.dev\" OwnerName=\"phassberg\"
+        IsOwner=\"true\" IsPremium=\"false\">\r\n      <DomainDetails>\r\n        <CreatedDate>05/20/2020</CreatedDate>\r\n
+        \       <ExpiredDate>05/20/2021</ExpiredDate>\r\n        <NumYears>0</NumYears>\r\n
+        \     </DomainDetails>\r\n      <LockDetails />\r\n      <Whoisguard Enabled=\"True\">\r\n
+        \       <ID>481121</ID>\r\n        <ExpiredDate>05/20/2021</ExpiredDate>\r\n
+        \       <EmailDetails WhoisGuardEmail=\"824017ccbed343119b3459c7d3304ba5.protect@whoisguard.com\"
+        ForwardedTo=\"dr.doddo@gmail.com\" LastAutoEmailChangeDate=\"05/20/2020\"
+        AutoEmailChangeFrequencyDays=\"3\" />\r\n      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n
+        \       <UseAutoRenew>false</UseAutoRenew>\r\n        <SubscriptionId>-1</SubscriptionId>\r\n
+        \       <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n
+        \       <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n
+        \     <DnsDetails ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"31\"
+        EmailType=\"FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\n
+        \       <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\n
+        \     <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.021</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['1493']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:20 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 18:59:41 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '1740'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest2&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
-        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524158\" Name=\"_acme-challenge.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524168\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524214\"\
-        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"updated\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\" Name=\"orig.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524170\" Name=\"orig.testfqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524172\"\
-        \ Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\" Name=\"random.fqdntest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524164\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524165\"\
-        \ Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"updated.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524173\"\
-        \ Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\" Name=\"yyy\"\
-        \ Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\
-        \n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.709</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest2.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n      <host
+        HostId=\"746360\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746361\" Name=\"docs\" Type=\"CNAME\" Address=\"docs.example.com.\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746355\" Name=\"www\" Type=\"CNAME\"
+        Address=\"parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\"
+        FriendlyName=\"CNAME Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n
+        \     <host HostId=\"746365\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746366\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746372\" Name=\"_acme-challenge.deleterecordinset\"
+        Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746373\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746374\" Name=\"_acme-challenge.deleterecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746375\" Name=\"_acme-challenge.deleterecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746362\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746363\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746376\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746377\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746367\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746364\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746368\" Name=\"delete.testfilt\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746369\" Name=\"delete.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746370\" Name=\"delete.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746371\" Name=\"delete.testid\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746383\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746384\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746381\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746385\" Name=\"orig.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746387\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746378\" Name=\"random.fqdntest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746379\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746380\" Name=\"random.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746382\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746386\" Name=\"updated.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746388\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746354\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest2.dev/\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL
+        Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.671</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4401']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:22 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 18:59:42 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '6601'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'RecordType21=TXT&HostId19=524173&RecordType20=URL&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524158&HostId9=524168&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524831&HostId5=524832&HostId6=524156&HostId7=524157&HostId20=524160&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&MXPref20=10&FriendlyName3=CName+Record&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524170&HostId13=524172&HostId10=524214&HostId11=524166&HostId16=524165&HostId17=524167&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=URL+Record&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&HostName12=orig.testfqdn&HostName13=orig.testfull&HostName10=orig.nameonly.test&HostName11=orig.test&HostName16=random.test&HostName17=updated.test&HostName14=random.fqdntest&Address1=127.0.0.1&HostName18=updated.testfqdn&HostName19=updated.testfull&MXPref5=10&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=60&TTL7=60&TTL14=1800&Address13=challengetoken&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&AssociatedAppTitle20=&Address12=challengetoken&Address18=challengetoken&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.fqdn&HostName7=_acme-challenge.full&HostName8=_acme-challenge.test&HostName9=orig.nameonly.test&Address10=updated&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName21=_acme-challenge.noop&HostName20=yyy&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=random.fulltest&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise&MXPref4=10&TTL18=1800&Address21=challengetoken&Address20=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&AssociatedAppTitle18=&TTL19=1800&HostId14=524163&AssociatedAppTitle19=&HostId15=524164&HostId18=524171'
+    body: HostId1=746360&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746361&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746355&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746365&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746366&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746372&Address6=challengetoken1&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.deleterecordinset&RecordType6=TXT&HostId7=746373&Address7=challengetoken2&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.deleterecordinset&RecordType7=TXT&HostId8=746374&Address8=challengetoken1&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.deleterecordset&RecordType8=TXT&HostId9=746375&Address9=challengetoken2&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.deleterecordset&RecordType9=TXT&HostId10=746362&Address10=challengetoken&MXPref10=10&TTL10=3600&AssociatedAppTitle10=&FriendlyName10=&IsActive10=true&IsDDNSEnabled10=false&HostName10=_acme-challenge.fqdn&RecordType10=TXT&HostId11=746363&Address11=challengetoken&MXPref11=10&TTL11=3600&AssociatedAppTitle11=&FriendlyName11=&IsActive11=true&IsDDNSEnabled11=false&HostName11=_acme-challenge.full&RecordType11=TXT&HostId12=746376&Address12=challengetoken1&MXPref12=10&TTL12=3600&AssociatedAppTitle12=&FriendlyName12=&IsActive12=true&IsDDNSEnabled12=false&HostName12=_acme-challenge.listrecordset&RecordType12=TXT&HostId13=746377&Address13=challengetoken2&MXPref13=10&TTL13=3600&AssociatedAppTitle13=&FriendlyName13=&IsActive13=true&IsDDNSEnabled13=false&HostName13=_acme-challenge.listrecordset&RecordType13=TXT&HostId14=746367&Address14=challengetoken&MXPref14=10&TTL14=3600&AssociatedAppTitle14=&FriendlyName14=&IsActive14=true&IsDDNSEnabled14=false&HostName14=_acme-challenge.noop&RecordType14=TXT&HostId15=746364&Address15=challengetoken&MXPref15=10&TTL15=3600&AssociatedAppTitle15=&FriendlyName15=&IsActive15=true&IsDDNSEnabled15=false&HostName15=_acme-challenge.test&RecordType15=TXT&HostId16=746368&Address16=challengetoken&MXPref16=10&TTL16=3600&AssociatedAppTitle16=&FriendlyName16=&IsActive16=true&IsDDNSEnabled16=false&HostName16=delete.testfilt&RecordType16=TXT&HostId17=746369&Address17=challengetoken&MXPref17=10&TTL17=3600&AssociatedAppTitle17=&FriendlyName17=&IsActive17=true&IsDDNSEnabled17=false&HostName17=delete.testfqdn&RecordType17=TXT&HostId18=746370&Address18=challengetoken&MXPref18=10&TTL18=3600&AssociatedAppTitle18=&FriendlyName18=&IsActive18=true&IsDDNSEnabled18=false&HostName18=delete.testfull&RecordType18=TXT&HostId19=746371&Address19=challengetoken&MXPref19=10&TTL19=3600&AssociatedAppTitle19=&FriendlyName19=&IsActive19=true&IsDDNSEnabled19=false&HostName19=delete.testid&RecordType19=TXT&HostId20=746383&Address20=challengetoken&MXPref20=10&TTL20=3600&AssociatedAppTitle20=&FriendlyName20=&IsActive20=true&IsDDNSEnabled20=false&HostName20=orig.nameonly.test&RecordType20=TXT&HostId21=746384&Address21=updated&MXPref21=10&TTL21=3600&AssociatedAppTitle21=&FriendlyName21=&IsActive21=true&IsDDNSEnabled21=false&HostName21=orig.nameonly.test&RecordType21=TXT&HostId22=746381&Address22=challengetoken&MXPref22=10&TTL22=3600&AssociatedAppTitle22=&FriendlyName22=&IsActive22=true&IsDDNSEnabled22=false&HostName22=orig.test&RecordType22=TXT&HostId23=746385&Address23=challengetoken&MXPref23=10&TTL23=3600&AssociatedAppTitle23=&FriendlyName23=&IsActive23=true&IsDDNSEnabled23=false&HostName23=orig.testfqdn&RecordType23=TXT&HostId24=746387&Address24=challengetoken&MXPref24=10&TTL24=3600&AssociatedAppTitle24=&FriendlyName24=&IsActive24=true&IsDDNSEnabled24=false&HostName24=orig.testfull&RecordType24=TXT&HostId25=746378&Address25=challengetoken&MXPref25=10&TTL25=3600&AssociatedAppTitle25=&FriendlyName25=&IsActive25=true&IsDDNSEnabled25=false&HostName25=random.fqdntest&RecordType25=TXT&HostId26=746379&Address26=challengetoken&MXPref26=10&TTL26=3600&AssociatedAppTitle26=&FriendlyName26=&IsActive26=true&IsDDNSEnabled26=false&HostName26=random.fulltest&RecordType26=TXT&HostId27=746380&Address27=challengetoken&MXPref27=10&TTL27=3600&AssociatedAppTitle27=&FriendlyName27=&IsActive27=true&IsDDNSEnabled27=false&HostName27=random.test&RecordType27=TXT&HostId28=746382&Address28=challengetoken&MXPref28=10&TTL28=3600&AssociatedAppTitle28=&FriendlyName28=&IsActive28=true&IsDDNSEnabled28=false&HostName28=updated.test&RecordType28=TXT&HostId29=746386&Address29=challengetoken&MXPref29=10&TTL29=3600&AssociatedAppTitle29=&FriendlyName29=&IsActive29=true&IsDDNSEnabled29=false&HostName29=updated.testfqdn&RecordType29=TXT&HostId30=746388&Address30=challengetoken&MXPref30=10&TTL30=3600&AssociatedAppTitle30=&FriendlyName30=&IsActive30=true&IsDDNSEnabled30=false&HostName30=updated.testfull&RecordType30=TXT&HostId31=746354&Address31=http%3A%2F%2Fwww.unittest2.dev%2F&MXPref31=10&TTL31=1800&AssociatedAppTitle31=URL+Forwarding&FriendlyName31=URL+Record&IsActive31=true&IsDDNSEnabled31=false&HostName31=%40&RecordType31=URL&Address32=challengetoken&TTL32=3600&HostName32=_acme-challenge.noop&RecordType32=TXT&SLD=unittest2&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['3746']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '5884'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>1.185</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest2.dev\" IsSuccess=\"true\">\r\n      <Warnings />\r\n    </DomainDNSSetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.453</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['559']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:24 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 18:59:43 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '557'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest2&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
-        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524833\" Name=\"_acme-challenge.noop\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524158\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\"\
-        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524214\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524166\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"\
-        orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524163\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\"\
-        \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524165\" Name=\"random.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524167\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524171\" Name=\"\
-        updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524160\" Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
-        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.654</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest2.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n      <host
+        HostId=\"746360\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746361\" Name=\"docs\" Type=\"CNAME\" Address=\"docs.example.com.\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746355\" Name=\"www\" Type=\"CNAME\"
+        Address=\"parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\"
+        FriendlyName=\"CNAME Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n
+        \     <host HostId=\"746365\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746366\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746372\" Name=\"_acme-challenge.deleterecordinset\"
+        Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746373\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746374\" Name=\"_acme-challenge.deleterecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746375\" Name=\"_acme-challenge.deleterecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746362\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746363\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746376\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746377\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746367\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746364\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746368\" Name=\"delete.testfilt\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746369\" Name=\"delete.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746370\" Name=\"delete.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746371\" Name=\"delete.testid\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746383\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746384\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746381\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746385\" Name=\"orig.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746387\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746378\" Name=\"random.fqdntest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746379\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746380\" Name=\"random.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746382\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746386\" Name=\"updated.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746388\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746354\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest2.dev/\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL
+        Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.347</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4596']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:25 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 18:59:46 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '6601'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'RecordType21=URL&HostId19=524171&RecordType20=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524833&HostId9=524158&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524831&HostId5=524832&HostId6=524156&HostId7=524157&HostId21=524160&HostId20=524173&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=CName+Record&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524166&HostId13=524170&HostId10=524168&HostId11=524214&HostId16=524164&HostId17=524165&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&HostName12=orig.test&HostName13=orig.testfqdn&HostName10=orig.nameonly.test&HostName11=orig.nameonly.test&HostName16=random.fulltest&HostName17=random.test&HostName14=orig.testfull&Address1=127.0.0.1&HostName18=updated.test&HostName19=updated.testfqdn&MXPref5=10&FriendlyName21=URL+Record&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=60&TTL7=60&TTL14=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&Address18=challengetoken&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.fqdn&HostName7=_acme-challenge.full&HostName8=_acme-challenge.noop&HostName9=_acme-challenge.test&Address10=challengetoken&Address11=updated&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName22=_acme-challenge.noop&HostName21=yyy&HostName20=updated.testfull&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=random.fqdntest&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise&MXPref4=10&TTL18=1800&Address21=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524172&AssociatedAppTitle19=&HostId15=524163&HostId18=524167'
+    body: HostId1=746360&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746361&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746355&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746365&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746366&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746372&Address6=challengetoken1&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.deleterecordinset&RecordType6=TXT&HostId7=746373&Address7=challengetoken2&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.deleterecordinset&RecordType7=TXT&HostId8=746374&Address8=challengetoken1&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.deleterecordset&RecordType8=TXT&HostId9=746375&Address9=challengetoken2&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.deleterecordset&RecordType9=TXT&HostId10=746362&Address10=challengetoken&MXPref10=10&TTL10=3600&AssociatedAppTitle10=&FriendlyName10=&IsActive10=true&IsDDNSEnabled10=false&HostName10=_acme-challenge.fqdn&RecordType10=TXT&HostId11=746363&Address11=challengetoken&MXPref11=10&TTL11=3600&AssociatedAppTitle11=&FriendlyName11=&IsActive11=true&IsDDNSEnabled11=false&HostName11=_acme-challenge.full&RecordType11=TXT&HostId12=746376&Address12=challengetoken1&MXPref12=10&TTL12=3600&AssociatedAppTitle12=&FriendlyName12=&IsActive12=true&IsDDNSEnabled12=false&HostName12=_acme-challenge.listrecordset&RecordType12=TXT&HostId13=746377&Address13=challengetoken2&MXPref13=10&TTL13=3600&AssociatedAppTitle13=&FriendlyName13=&IsActive13=true&IsDDNSEnabled13=false&HostName13=_acme-challenge.listrecordset&RecordType13=TXT&HostId14=746367&Address14=challengetoken&MXPref14=10&TTL14=3600&AssociatedAppTitle14=&FriendlyName14=&IsActive14=true&IsDDNSEnabled14=false&HostName14=_acme-challenge.noop&RecordType14=TXT&HostId15=746364&Address15=challengetoken&MXPref15=10&TTL15=3600&AssociatedAppTitle15=&FriendlyName15=&IsActive15=true&IsDDNSEnabled15=false&HostName15=_acme-challenge.test&RecordType15=TXT&HostId16=746368&Address16=challengetoken&MXPref16=10&TTL16=3600&AssociatedAppTitle16=&FriendlyName16=&IsActive16=true&IsDDNSEnabled16=false&HostName16=delete.testfilt&RecordType16=TXT&HostId17=746369&Address17=challengetoken&MXPref17=10&TTL17=3600&AssociatedAppTitle17=&FriendlyName17=&IsActive17=true&IsDDNSEnabled17=false&HostName17=delete.testfqdn&RecordType17=TXT&HostId18=746370&Address18=challengetoken&MXPref18=10&TTL18=3600&AssociatedAppTitle18=&FriendlyName18=&IsActive18=true&IsDDNSEnabled18=false&HostName18=delete.testfull&RecordType18=TXT&HostId19=746371&Address19=challengetoken&MXPref19=10&TTL19=3600&AssociatedAppTitle19=&FriendlyName19=&IsActive19=true&IsDDNSEnabled19=false&HostName19=delete.testid&RecordType19=TXT&HostId20=746383&Address20=challengetoken&MXPref20=10&TTL20=3600&AssociatedAppTitle20=&FriendlyName20=&IsActive20=true&IsDDNSEnabled20=false&HostName20=orig.nameonly.test&RecordType20=TXT&HostId21=746384&Address21=updated&MXPref21=10&TTL21=3600&AssociatedAppTitle21=&FriendlyName21=&IsActive21=true&IsDDNSEnabled21=false&HostName21=orig.nameonly.test&RecordType21=TXT&HostId22=746381&Address22=challengetoken&MXPref22=10&TTL22=3600&AssociatedAppTitle22=&FriendlyName22=&IsActive22=true&IsDDNSEnabled22=false&HostName22=orig.test&RecordType22=TXT&HostId23=746385&Address23=challengetoken&MXPref23=10&TTL23=3600&AssociatedAppTitle23=&FriendlyName23=&IsActive23=true&IsDDNSEnabled23=false&HostName23=orig.testfqdn&RecordType23=TXT&HostId24=746387&Address24=challengetoken&MXPref24=10&TTL24=3600&AssociatedAppTitle24=&FriendlyName24=&IsActive24=true&IsDDNSEnabled24=false&HostName24=orig.testfull&RecordType24=TXT&HostId25=746378&Address25=challengetoken&MXPref25=10&TTL25=3600&AssociatedAppTitle25=&FriendlyName25=&IsActive25=true&IsDDNSEnabled25=false&HostName25=random.fqdntest&RecordType25=TXT&HostId26=746379&Address26=challengetoken&MXPref26=10&TTL26=3600&AssociatedAppTitle26=&FriendlyName26=&IsActive26=true&IsDDNSEnabled26=false&HostName26=random.fulltest&RecordType26=TXT&HostId27=746380&Address27=challengetoken&MXPref27=10&TTL27=3600&AssociatedAppTitle27=&FriendlyName27=&IsActive27=true&IsDDNSEnabled27=false&HostName27=random.test&RecordType27=TXT&HostId28=746382&Address28=challengetoken&MXPref28=10&TTL28=3600&AssociatedAppTitle28=&FriendlyName28=&IsActive28=true&IsDDNSEnabled28=false&HostName28=updated.test&RecordType28=TXT&HostId29=746386&Address29=challengetoken&MXPref29=10&TTL29=3600&AssociatedAppTitle29=&FriendlyName29=&IsActive29=true&IsDDNSEnabled29=false&HostName29=updated.testfqdn&RecordType29=TXT&HostId30=746388&Address30=challengetoken&MXPref30=10&TTL30=3600&AssociatedAppTitle30=&FriendlyName30=&IsActive30=true&IsDDNSEnabled30=false&HostName30=updated.testfull&RecordType30=TXT&HostId31=746354&Address31=http%3A%2F%2Fwww.unittest2.dev%2F&MXPref31=10&TTL31=1800&AssociatedAppTitle31=URL+Forwarding&FriendlyName31=URL+Record&IsActive31=true&IsDDNSEnabled31=false&HostName31=%40&RecordType31=URL&Address32=challengetoken&TTL32=3600&HostName32=_acme-challenge.noop&RecordType32=TXT&SLD=unittest2&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['3935']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '5884'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>1.07</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest2.dev\" IsSuccess=\"true\">\r\n      <Warnings />\r\n    </DomainDNSSetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.685</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['558']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:26 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 18:59:47 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '557'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest2&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
-        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524833\" Name=\"_acme-challenge.noop\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524158\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\"\
-        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524214\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524166\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"\
-        orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524163\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\"\
-        \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524165\" Name=\"random.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524167\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524171\" Name=\"\
-        updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524160\" Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
-        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.949</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest2.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n      <host
+        HostId=\"746360\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746361\" Name=\"docs\" Type=\"CNAME\" Address=\"docs.example.com.\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746355\" Name=\"www\" Type=\"CNAME\"
+        Address=\"parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\"
+        FriendlyName=\"CNAME Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n
+        \     <host HostId=\"746365\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746366\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746372\" Name=\"_acme-challenge.deleterecordinset\"
+        Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746373\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746374\" Name=\"_acme-challenge.deleterecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746375\" Name=\"_acme-challenge.deleterecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746362\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746363\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746376\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746377\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746367\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746364\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746368\" Name=\"delete.testfilt\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746369\" Name=\"delete.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746370\" Name=\"delete.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746371\" Name=\"delete.testid\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746383\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746384\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746381\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746385\" Name=\"orig.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746387\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746378\" Name=\"random.fqdntest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746379\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746380\" Name=\"random.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746382\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746386\" Name=\"updated.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746388\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746354\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest2.dev/\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL
+        Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.685</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4596']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:27 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 18:59:48 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '6601'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/namecheap/IntegrationTests/test_provider_when_calling_delete_record_by_filter_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/namecheap/IntegrationTests/test_provider_when_calling_delete_record_by_filter_should_remove_record.yaml
@@ -2,447 +2,637 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise.com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=unittest2.dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
-        \ Status=\"Ok\" ID=\"277432\" DomainName=\"example-aptise.com\" OwnerName=\"\
-        jvsandbox\" IsOwner=\"true\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
-        \n        <CreatedDate>03/25/2018</CreatedDate>\r\n        <ExpiredDate>03/25/2019</ExpiredDate>\r\
-        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
-        \ />\r\n      <Whoisguard Enabled=\"NotAlloted\">\r\n        <ID>0</ID>\r\n\
-        \      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
-        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
-        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
-        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
-        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"21\" EmailType=\"\
-        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
-        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
-        \n      <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.19</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult
+        Status=\"Ok\" ID=\"589667\" DomainName=\"unittest2.dev\" OwnerName=\"phassberg\"
+        IsOwner=\"true\" IsPremium=\"false\">\r\n      <DomainDetails>\r\n        <CreatedDate>05/20/2020</CreatedDate>\r\n
+        \       <ExpiredDate>05/20/2021</ExpiredDate>\r\n        <NumYears>0</NumYears>\r\n
+        \     </DomainDetails>\r\n      <LockDetails />\r\n      <Whoisguard Enabled=\"True\">\r\n
+        \       <ID>481121</ID>\r\n        <ExpiredDate>05/20/2021</ExpiredDate>\r\n
+        \       <EmailDetails WhoisGuardEmail=\"824017ccbed343119b3459c7d3304ba5.protect@whoisguard.com\"
+        ForwardedTo=\"dr.doddo@gmail.com\" LastAutoEmailChangeDate=\"05/20/2020\"
+        AutoEmailChangeFrequencyDays=\"3\" />\r\n      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n
+        \       <UseAutoRenew>false</UseAutoRenew>\r\n        <SubscriptionId>-1</SubscriptionId>\r\n
+        \       <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n
+        \       <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n
+        \     <DnsDetails ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"31\"
+        EmailType=\"FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\n
+        \       <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\n
+        \     <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.041</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['1492']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:27 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 18:59:50 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '1740'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest2&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
-        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524833\" Name=\"_acme-challenge.noop\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524158\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\"\
-        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524214\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524166\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"\
-        orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524163\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\"\
-        \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524165\" Name=\"random.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524167\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524171\" Name=\"\
-        updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524160\" Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
-        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.613</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest2.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n      <host
+        HostId=\"746360\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746361\" Name=\"docs\" Type=\"CNAME\" Address=\"docs.example.com.\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746355\" Name=\"www\" Type=\"CNAME\"
+        Address=\"parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\"
+        FriendlyName=\"CNAME Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n
+        \     <host HostId=\"746365\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746366\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746372\" Name=\"_acme-challenge.deleterecordinset\"
+        Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746373\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746374\" Name=\"_acme-challenge.deleterecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746375\" Name=\"_acme-challenge.deleterecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746362\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746363\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746376\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746377\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746367\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746364\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746368\" Name=\"delete.testfilt\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746369\" Name=\"delete.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746370\" Name=\"delete.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746371\" Name=\"delete.testid\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746383\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746384\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746381\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746385\" Name=\"orig.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746387\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746378\" Name=\"random.fqdntest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746379\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746380\" Name=\"random.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746382\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746386\" Name=\"updated.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746388\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746354\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest2.dev/\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL
+        Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.541</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4596']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:29 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 18:59:51 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '6601'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'RecordType21=URL&HostId19=524171&RecordType20=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524833&HostId9=524158&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524831&HostId5=524832&HostId6=524156&HostId7=524157&HostId21=524160&HostId20=524173&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=CName+Record&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524166&HostId13=524170&HostId10=524168&HostId11=524214&HostId16=524164&HostId17=524165&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&HostName12=orig.test&HostName13=orig.testfqdn&HostName10=orig.nameonly.test&HostName11=orig.nameonly.test&HostName16=random.fulltest&HostName17=random.test&HostName14=orig.testfull&Address1=127.0.0.1&HostName18=updated.test&HostName19=updated.testfqdn&MXPref5=10&FriendlyName21=URL+Record&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=60&TTL7=60&TTL14=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&Address18=challengetoken&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.fqdn&HostName7=_acme-challenge.full&HostName8=_acme-challenge.noop&HostName9=_acme-challenge.test&Address10=challengetoken&Address11=updated&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName22=delete.testfilt&HostName21=yyy&HostName20=updated.testfull&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=random.fqdntest&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise&MXPref4=10&TTL18=1800&Address21=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524172&AssociatedAppTitle19=&HostId15=524163&HostId18=524167'
+    body: HostId1=746360&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746361&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746355&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746365&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746366&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746372&Address6=challengetoken1&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.deleterecordinset&RecordType6=TXT&HostId7=746373&Address7=challengetoken2&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.deleterecordinset&RecordType7=TXT&HostId8=746374&Address8=challengetoken1&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.deleterecordset&RecordType8=TXT&HostId9=746375&Address9=challengetoken2&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.deleterecordset&RecordType9=TXT&HostId10=746362&Address10=challengetoken&MXPref10=10&TTL10=3600&AssociatedAppTitle10=&FriendlyName10=&IsActive10=true&IsDDNSEnabled10=false&HostName10=_acme-challenge.fqdn&RecordType10=TXT&HostId11=746363&Address11=challengetoken&MXPref11=10&TTL11=3600&AssociatedAppTitle11=&FriendlyName11=&IsActive11=true&IsDDNSEnabled11=false&HostName11=_acme-challenge.full&RecordType11=TXT&HostId12=746376&Address12=challengetoken1&MXPref12=10&TTL12=3600&AssociatedAppTitle12=&FriendlyName12=&IsActive12=true&IsDDNSEnabled12=false&HostName12=_acme-challenge.listrecordset&RecordType12=TXT&HostId13=746377&Address13=challengetoken2&MXPref13=10&TTL13=3600&AssociatedAppTitle13=&FriendlyName13=&IsActive13=true&IsDDNSEnabled13=false&HostName13=_acme-challenge.listrecordset&RecordType13=TXT&HostId14=746367&Address14=challengetoken&MXPref14=10&TTL14=3600&AssociatedAppTitle14=&FriendlyName14=&IsActive14=true&IsDDNSEnabled14=false&HostName14=_acme-challenge.noop&RecordType14=TXT&HostId15=746364&Address15=challengetoken&MXPref15=10&TTL15=3600&AssociatedAppTitle15=&FriendlyName15=&IsActive15=true&IsDDNSEnabled15=false&HostName15=_acme-challenge.test&RecordType15=TXT&HostId16=746368&Address16=challengetoken&MXPref16=10&TTL16=3600&AssociatedAppTitle16=&FriendlyName16=&IsActive16=true&IsDDNSEnabled16=false&HostName16=delete.testfilt&RecordType16=TXT&HostId17=746369&Address17=challengetoken&MXPref17=10&TTL17=3600&AssociatedAppTitle17=&FriendlyName17=&IsActive17=true&IsDDNSEnabled17=false&HostName17=delete.testfqdn&RecordType17=TXT&HostId18=746370&Address18=challengetoken&MXPref18=10&TTL18=3600&AssociatedAppTitle18=&FriendlyName18=&IsActive18=true&IsDDNSEnabled18=false&HostName18=delete.testfull&RecordType18=TXT&HostId19=746371&Address19=challengetoken&MXPref19=10&TTL19=3600&AssociatedAppTitle19=&FriendlyName19=&IsActive19=true&IsDDNSEnabled19=false&HostName19=delete.testid&RecordType19=TXT&HostId20=746383&Address20=challengetoken&MXPref20=10&TTL20=3600&AssociatedAppTitle20=&FriendlyName20=&IsActive20=true&IsDDNSEnabled20=false&HostName20=orig.nameonly.test&RecordType20=TXT&HostId21=746384&Address21=updated&MXPref21=10&TTL21=3600&AssociatedAppTitle21=&FriendlyName21=&IsActive21=true&IsDDNSEnabled21=false&HostName21=orig.nameonly.test&RecordType21=TXT&HostId22=746381&Address22=challengetoken&MXPref22=10&TTL22=3600&AssociatedAppTitle22=&FriendlyName22=&IsActive22=true&IsDDNSEnabled22=false&HostName22=orig.test&RecordType22=TXT&HostId23=746385&Address23=challengetoken&MXPref23=10&TTL23=3600&AssociatedAppTitle23=&FriendlyName23=&IsActive23=true&IsDDNSEnabled23=false&HostName23=orig.testfqdn&RecordType23=TXT&HostId24=746387&Address24=challengetoken&MXPref24=10&TTL24=3600&AssociatedAppTitle24=&FriendlyName24=&IsActive24=true&IsDDNSEnabled24=false&HostName24=orig.testfull&RecordType24=TXT&HostId25=746378&Address25=challengetoken&MXPref25=10&TTL25=3600&AssociatedAppTitle25=&FriendlyName25=&IsActive25=true&IsDDNSEnabled25=false&HostName25=random.fqdntest&RecordType25=TXT&HostId26=746379&Address26=challengetoken&MXPref26=10&TTL26=3600&AssociatedAppTitle26=&FriendlyName26=&IsActive26=true&IsDDNSEnabled26=false&HostName26=random.fulltest&RecordType26=TXT&HostId27=746380&Address27=challengetoken&MXPref27=10&TTL27=3600&AssociatedAppTitle27=&FriendlyName27=&IsActive27=true&IsDDNSEnabled27=false&HostName27=random.test&RecordType27=TXT&HostId28=746382&Address28=challengetoken&MXPref28=10&TTL28=3600&AssociatedAppTitle28=&FriendlyName28=&IsActive28=true&IsDDNSEnabled28=false&HostName28=updated.test&RecordType28=TXT&HostId29=746386&Address29=challengetoken&MXPref29=10&TTL29=3600&AssociatedAppTitle29=&FriendlyName29=&IsActive29=true&IsDDNSEnabled29=false&HostName29=updated.testfqdn&RecordType29=TXT&HostId30=746388&Address30=challengetoken&MXPref30=10&TTL30=3600&AssociatedAppTitle30=&FriendlyName30=&IsActive30=true&IsDDNSEnabled30=false&HostName30=updated.testfull&RecordType30=TXT&HostId31=746354&Address31=http%3A%2F%2Fwww.unittest2.dev%2F&MXPref31=10&TTL31=1800&AssociatedAppTitle31=URL+Forwarding&FriendlyName31=URL+Record&IsActive31=true&IsDDNSEnabled31=false&HostName31=%40&RecordType31=URL&Address32=challengetoken&TTL32=3600&HostName32=delete.testfilt&RecordType32=TXT&SLD=unittest2&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['3930']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '5879'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.733</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest2.dev\" IsSuccess=\"true\">\r\n      <Warnings />\r\n    </DomainDNSSetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>1.274</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['559']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:30 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 18:59:54 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '557'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest2&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
-        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524833\" Name=\"_acme-challenge.noop\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524158\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524834\"\
-        \ Name=\"delete.testfilt\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524214\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
-        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
-        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>1.271</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest2.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n      <host
+        HostId=\"746360\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746361\" Name=\"docs\" Type=\"CNAME\" Address=\"docs.example.com.\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746355\" Name=\"www\" Type=\"CNAME\"
+        Address=\"parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\"
+        FriendlyName=\"CNAME Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n
+        \     <host HostId=\"746365\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746366\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746372\" Name=\"_acme-challenge.deleterecordinset\"
+        Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746373\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746374\" Name=\"_acme-challenge.deleterecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746375\" Name=\"_acme-challenge.deleterecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746362\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746363\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746376\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746377\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746367\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746364\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746368\" Name=\"delete.testfilt\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746369\" Name=\"delete.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746370\" Name=\"delete.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746371\" Name=\"delete.testid\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746383\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746384\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746381\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746385\" Name=\"orig.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746387\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746378\" Name=\"random.fqdntest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746379\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746380\" Name=\"random.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746382\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746386\" Name=\"updated.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746388\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746354\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest2.dev/\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL
+        Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.141</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4786']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:32 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 18:59:54 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '6601'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest2&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
-        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524833\" Name=\"_acme-challenge.noop\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524158\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524834\"\
-        \ Name=\"delete.testfilt\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524214\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
-        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
-        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.653</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest2.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n      <host
+        HostId=\"746360\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746361\" Name=\"docs\" Type=\"CNAME\" Address=\"docs.example.com.\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746355\" Name=\"www\" Type=\"CNAME\"
+        Address=\"parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\"
+        FriendlyName=\"CNAME Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n
+        \     <host HostId=\"746365\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746366\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746372\" Name=\"_acme-challenge.deleterecordinset\"
+        Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746373\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746374\" Name=\"_acme-challenge.deleterecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746375\" Name=\"_acme-challenge.deleterecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746362\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746363\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746376\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746377\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746367\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746364\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746368\" Name=\"delete.testfilt\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746369\" Name=\"delete.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746370\" Name=\"delete.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746371\" Name=\"delete.testid\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746383\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746384\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746381\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746385\" Name=\"orig.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746387\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746378\" Name=\"random.fqdntest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746379\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746380\" Name=\"random.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746382\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746386\" Name=\"updated.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746388\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746354\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest2.dev/\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL
+        Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.578</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4786']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:33 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 18:59:55 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '6601'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'RecordType21=URL&HostId19=524171&RecordType20=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524833&HostId9=524158&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524831&HostId5=524832&HostId6=524156&HostId7=524157&HostId21=524160&HostId20=524173&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=CName+Record&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524166&HostId13=524170&HostId10=524168&HostId11=524214&HostId16=524164&HostId17=524165&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&HostName12=orig.test&HostName13=orig.testfqdn&HostName10=orig.nameonly.test&HostName11=orig.nameonly.test&HostName16=random.fulltest&HostName17=random.test&HostName14=orig.testfull&Address1=127.0.0.1&HostName18=updated.test&HostName19=updated.testfqdn&MXPref5=10&FriendlyName21=URL+Record&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=60&TTL7=60&TTL14=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&Address18=challengetoken&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.fqdn&HostName7=_acme-challenge.full&HostName8=_acme-challenge.noop&HostName9=_acme-challenge.test&Address10=challengetoken&Address11=updated&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName21=yyy&HostName20=updated.testfull&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=random.fqdntest&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise&MXPref4=10&TTL18=1800&Address21=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524172&AssociatedAppTitle19=&HostId15=524163&HostId18=524167'
+    body: HostId1=746360&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746361&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746355&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746365&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746366&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746372&Address6=challengetoken1&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.deleterecordinset&RecordType6=TXT&HostId7=746373&Address7=challengetoken2&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.deleterecordinset&RecordType7=TXT&HostId8=746374&Address8=challengetoken1&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.deleterecordset&RecordType8=TXT&HostId9=746375&Address9=challengetoken2&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.deleterecordset&RecordType9=TXT&HostId10=746362&Address10=challengetoken&MXPref10=10&TTL10=3600&AssociatedAppTitle10=&FriendlyName10=&IsActive10=true&IsDDNSEnabled10=false&HostName10=_acme-challenge.fqdn&RecordType10=TXT&HostId11=746363&Address11=challengetoken&MXPref11=10&TTL11=3600&AssociatedAppTitle11=&FriendlyName11=&IsActive11=true&IsDDNSEnabled11=false&HostName11=_acme-challenge.full&RecordType11=TXT&HostId12=746376&Address12=challengetoken1&MXPref12=10&TTL12=3600&AssociatedAppTitle12=&FriendlyName12=&IsActive12=true&IsDDNSEnabled12=false&HostName12=_acme-challenge.listrecordset&RecordType12=TXT&HostId13=746377&Address13=challengetoken2&MXPref13=10&TTL13=3600&AssociatedAppTitle13=&FriendlyName13=&IsActive13=true&IsDDNSEnabled13=false&HostName13=_acme-challenge.listrecordset&RecordType13=TXT&HostId14=746367&Address14=challengetoken&MXPref14=10&TTL14=3600&AssociatedAppTitle14=&FriendlyName14=&IsActive14=true&IsDDNSEnabled14=false&HostName14=_acme-challenge.noop&RecordType14=TXT&HostId15=746364&Address15=challengetoken&MXPref15=10&TTL15=3600&AssociatedAppTitle15=&FriendlyName15=&IsActive15=true&IsDDNSEnabled15=false&HostName15=_acme-challenge.test&RecordType15=TXT&HostId16=746369&Address16=challengetoken&MXPref16=10&TTL16=3600&AssociatedAppTitle16=&FriendlyName16=&IsActive16=true&IsDDNSEnabled16=false&HostName16=delete.testfqdn&RecordType16=TXT&HostId17=746370&Address17=challengetoken&MXPref17=10&TTL17=3600&AssociatedAppTitle17=&FriendlyName17=&IsActive17=true&IsDDNSEnabled17=false&HostName17=delete.testfull&RecordType17=TXT&HostId18=746371&Address18=challengetoken&MXPref18=10&TTL18=3600&AssociatedAppTitle18=&FriendlyName18=&IsActive18=true&IsDDNSEnabled18=false&HostName18=delete.testid&RecordType18=TXT&HostId19=746383&Address19=challengetoken&MXPref19=10&TTL19=3600&AssociatedAppTitle19=&FriendlyName19=&IsActive19=true&IsDDNSEnabled19=false&HostName19=orig.nameonly.test&RecordType19=TXT&HostId20=746384&Address20=updated&MXPref20=10&TTL20=3600&AssociatedAppTitle20=&FriendlyName20=&IsActive20=true&IsDDNSEnabled20=false&HostName20=orig.nameonly.test&RecordType20=TXT&HostId21=746381&Address21=challengetoken&MXPref21=10&TTL21=3600&AssociatedAppTitle21=&FriendlyName21=&IsActive21=true&IsDDNSEnabled21=false&HostName21=orig.test&RecordType21=TXT&HostId22=746385&Address22=challengetoken&MXPref22=10&TTL22=3600&AssociatedAppTitle22=&FriendlyName22=&IsActive22=true&IsDDNSEnabled22=false&HostName22=orig.testfqdn&RecordType22=TXT&HostId23=746387&Address23=challengetoken&MXPref23=10&TTL23=3600&AssociatedAppTitle23=&FriendlyName23=&IsActive23=true&IsDDNSEnabled23=false&HostName23=orig.testfull&RecordType23=TXT&HostId24=746378&Address24=challengetoken&MXPref24=10&TTL24=3600&AssociatedAppTitle24=&FriendlyName24=&IsActive24=true&IsDDNSEnabled24=false&HostName24=random.fqdntest&RecordType24=TXT&HostId25=746379&Address25=challengetoken&MXPref25=10&TTL25=3600&AssociatedAppTitle25=&FriendlyName25=&IsActive25=true&IsDDNSEnabled25=false&HostName25=random.fulltest&RecordType25=TXT&HostId26=746380&Address26=challengetoken&MXPref26=10&TTL26=3600&AssociatedAppTitle26=&FriendlyName26=&IsActive26=true&IsDDNSEnabled26=false&HostName26=random.test&RecordType26=TXT&HostId27=746382&Address27=challengetoken&MXPref27=10&TTL27=3600&AssociatedAppTitle27=&FriendlyName27=&IsActive27=true&IsDDNSEnabled27=false&HostName27=updated.test&RecordType27=TXT&HostId28=746386&Address28=challengetoken&MXPref28=10&TTL28=3600&AssociatedAppTitle28=&FriendlyName28=&IsActive28=true&IsDDNSEnabled28=false&HostName28=updated.testfqdn&RecordType28=TXT&HostId29=746388&Address29=challengetoken&MXPref29=10&TTL29=3600&AssociatedAppTitle29=&FriendlyName29=&IsActive29=true&IsDDNSEnabled29=false&HostName29=updated.testfull&RecordType29=TXT&HostId30=746354&Address30=http%3A%2F%2Fwww.unittest2.dev%2F&MXPref30=10&TTL30=1800&AssociatedAppTitle30=URL+Forwarding&FriendlyName30=URL+Record&IsActive30=true&IsDDNSEnabled30=false&HostName30=%40&RecordType30=URL&SLD=unittest2&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['3861']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '5615'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>1.109</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest2.dev\" IsSuccess=\"true\">\r\n      <Warnings />\r\n    </DomainDNSSetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.776</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['559']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:35 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 18:59:57 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '557'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest2&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
-        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524833\" Name=\"_acme-challenge.noop\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524158\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\"\
-        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524214\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524166\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"\
-        orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524163\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\"\
-        \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524165\" Name=\"random.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524167\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524171\" Name=\"\
-        updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524160\" Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
-        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.749</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest2.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n      <host
+        HostId=\"746360\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746361\" Name=\"docs\" Type=\"CNAME\" Address=\"docs.example.com.\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746355\" Name=\"www\" Type=\"CNAME\"
+        Address=\"parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\"
+        FriendlyName=\"CNAME Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n
+        \     <host HostId=\"746365\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746366\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746372\" Name=\"_acme-challenge.deleterecordinset\"
+        Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746373\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746374\" Name=\"_acme-challenge.deleterecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746375\" Name=\"_acme-challenge.deleterecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746362\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746363\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746376\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746377\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746367\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746364\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746369\" Name=\"delete.testfqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746370\" Name=\"delete.testfull\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746371\" Name=\"delete.testid\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746383\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746384\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"updated\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746381\" Name=\"orig.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746385\" Name=\"orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746387\" Name=\"orig.testfull\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746378\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746379\" Name=\"random.fulltest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746380\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746382\" Name=\"updated.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746386\" Name=\"updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746388\" Name=\"updated.testfull\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746354\" Name=\"@\" Type=\"URL\" Address=\"http://www.unittest2.dev/\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL
+        Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.311</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4596']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:36 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 18:59:59 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '6411'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/namecheap/IntegrationTests/test_provider_when_calling_delete_record_by_filter_with_fqdn_name_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/namecheap/IntegrationTests/test_provider_when_calling_delete_record_by_filter_with_fqdn_name_should_remove_record.yaml
@@ -2,447 +2,628 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise.com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=unittest2.dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
-        \ Status=\"Ok\" ID=\"277432\" DomainName=\"example-aptise.com\" OwnerName=\"\
-        jvsandbox\" IsOwner=\"true\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
-        \n        <CreatedDate>03/25/2018</CreatedDate>\r\n        <ExpiredDate>03/25/2019</ExpiredDate>\r\
-        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
-        \ />\r\n      <Whoisguard Enabled=\"NotAlloted\">\r\n        <ID>0</ID>\r\n\
-        \      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
-        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
-        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
-        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
-        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"21\" EmailType=\"\
-        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
-        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
-        \n      <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.192</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult
+        Status=\"Ok\" ID=\"589667\" DomainName=\"unittest2.dev\" OwnerName=\"phassberg\"
+        IsOwner=\"true\" IsPremium=\"false\">\r\n      <DomainDetails>\r\n        <CreatedDate>05/20/2020</CreatedDate>\r\n
+        \       <ExpiredDate>05/20/2021</ExpiredDate>\r\n        <NumYears>0</NumYears>\r\n
+        \     </DomainDetails>\r\n      <LockDetails />\r\n      <Whoisguard Enabled=\"True\">\r\n
+        \       <ID>481121</ID>\r\n        <ExpiredDate>05/20/2021</ExpiredDate>\r\n
+        \       <EmailDetails WhoisGuardEmail=\"824017ccbed343119b3459c7d3304ba5.protect@whoisguard.com\"
+        ForwardedTo=\"dr.doddo@gmail.com\" LastAutoEmailChangeDate=\"05/20/2020\"
+        AutoEmailChangeFrequencyDays=\"3\" />\r\n      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n
+        \       <UseAutoRenew>false</UseAutoRenew>\r\n        <SubscriptionId>-1</SubscriptionId>\r\n
+        \       <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n
+        \       <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n
+        \     <DnsDetails ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"30\"
+        EmailType=\"FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\n
+        \       <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\n
+        \     <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.267</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['1493']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:37 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:00:00 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '1740'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest2&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
-        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524833\" Name=\"_acme-challenge.noop\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524158\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\"\
-        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524214\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524166\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"\
-        orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524163\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\"\
-        \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524165\" Name=\"random.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524167\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524171\" Name=\"\
-        updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524160\" Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
-        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.708</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest2.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n      <host
+        HostId=\"746360\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746361\" Name=\"docs\" Type=\"CNAME\" Address=\"docs.example.com.\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746355\" Name=\"www\" Type=\"CNAME\"
+        Address=\"parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\"
+        FriendlyName=\"CNAME Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n
+        \     <host HostId=\"746365\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746366\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746372\" Name=\"_acme-challenge.deleterecordinset\"
+        Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746373\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746374\" Name=\"_acme-challenge.deleterecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746375\" Name=\"_acme-challenge.deleterecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746362\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746363\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746376\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746377\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746367\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746364\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746369\" Name=\"delete.testfqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746370\" Name=\"delete.testfull\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746371\" Name=\"delete.testid\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746383\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746384\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"updated\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746381\" Name=\"orig.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746385\" Name=\"orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746387\" Name=\"orig.testfull\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746378\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746379\" Name=\"random.fulltest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746380\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746382\" Name=\"updated.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746386\" Name=\"updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746388\" Name=\"updated.testfull\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746354\" Name=\"@\" Type=\"URL\" Address=\"http://www.unittest2.dev/\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL
+        Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.605</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4596']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:39 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:00:01 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '6411'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'RecordType21=URL&HostId19=524171&RecordType20=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524833&HostId9=524158&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524831&HostId5=524832&HostId6=524156&HostId7=524157&HostId21=524160&HostId20=524173&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=CName+Record&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524166&HostId13=524170&HostId10=524168&HostId11=524214&HostId16=524164&HostId17=524165&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&HostName12=orig.test&HostName13=orig.testfqdn&HostName10=orig.nameonly.test&HostName11=orig.nameonly.test&HostName16=random.fulltest&HostName17=random.test&HostName14=orig.testfull&Address1=127.0.0.1&HostName18=updated.test&HostName19=updated.testfqdn&MXPref5=10&FriendlyName21=URL+Record&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=60&TTL7=60&TTL14=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&Address18=challengetoken&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.fqdn&HostName7=_acme-challenge.full&HostName8=_acme-challenge.noop&HostName9=_acme-challenge.test&Address10=challengetoken&Address11=updated&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName22=delete.testfqdn&HostName21=yyy&HostName20=updated.testfull&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=random.fqdntest&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise&MXPref4=10&TTL18=1800&Address21=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524172&AssociatedAppTitle19=&HostId15=524163&HostId18=524167'
+    body: HostId1=746360&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746361&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746355&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746365&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746366&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746372&Address6=challengetoken1&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.deleterecordinset&RecordType6=TXT&HostId7=746373&Address7=challengetoken2&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.deleterecordinset&RecordType7=TXT&HostId8=746374&Address8=challengetoken1&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.deleterecordset&RecordType8=TXT&HostId9=746375&Address9=challengetoken2&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.deleterecordset&RecordType9=TXT&HostId10=746362&Address10=challengetoken&MXPref10=10&TTL10=3600&AssociatedAppTitle10=&FriendlyName10=&IsActive10=true&IsDDNSEnabled10=false&HostName10=_acme-challenge.fqdn&RecordType10=TXT&HostId11=746363&Address11=challengetoken&MXPref11=10&TTL11=3600&AssociatedAppTitle11=&FriendlyName11=&IsActive11=true&IsDDNSEnabled11=false&HostName11=_acme-challenge.full&RecordType11=TXT&HostId12=746376&Address12=challengetoken1&MXPref12=10&TTL12=3600&AssociatedAppTitle12=&FriendlyName12=&IsActive12=true&IsDDNSEnabled12=false&HostName12=_acme-challenge.listrecordset&RecordType12=TXT&HostId13=746377&Address13=challengetoken2&MXPref13=10&TTL13=3600&AssociatedAppTitle13=&FriendlyName13=&IsActive13=true&IsDDNSEnabled13=false&HostName13=_acme-challenge.listrecordset&RecordType13=TXT&HostId14=746367&Address14=challengetoken&MXPref14=10&TTL14=3600&AssociatedAppTitle14=&FriendlyName14=&IsActive14=true&IsDDNSEnabled14=false&HostName14=_acme-challenge.noop&RecordType14=TXT&HostId15=746364&Address15=challengetoken&MXPref15=10&TTL15=3600&AssociatedAppTitle15=&FriendlyName15=&IsActive15=true&IsDDNSEnabled15=false&HostName15=_acme-challenge.test&RecordType15=TXT&HostId16=746369&Address16=challengetoken&MXPref16=10&TTL16=3600&AssociatedAppTitle16=&FriendlyName16=&IsActive16=true&IsDDNSEnabled16=false&HostName16=delete.testfqdn&RecordType16=TXT&HostId17=746370&Address17=challengetoken&MXPref17=10&TTL17=3600&AssociatedAppTitle17=&FriendlyName17=&IsActive17=true&IsDDNSEnabled17=false&HostName17=delete.testfull&RecordType17=TXT&HostId18=746371&Address18=challengetoken&MXPref18=10&TTL18=3600&AssociatedAppTitle18=&FriendlyName18=&IsActive18=true&IsDDNSEnabled18=false&HostName18=delete.testid&RecordType18=TXT&HostId19=746383&Address19=challengetoken&MXPref19=10&TTL19=3600&AssociatedAppTitle19=&FriendlyName19=&IsActive19=true&IsDDNSEnabled19=false&HostName19=orig.nameonly.test&RecordType19=TXT&HostId20=746384&Address20=updated&MXPref20=10&TTL20=3600&AssociatedAppTitle20=&FriendlyName20=&IsActive20=true&IsDDNSEnabled20=false&HostName20=orig.nameonly.test&RecordType20=TXT&HostId21=746381&Address21=challengetoken&MXPref21=10&TTL21=3600&AssociatedAppTitle21=&FriendlyName21=&IsActive21=true&IsDDNSEnabled21=false&HostName21=orig.test&RecordType21=TXT&HostId22=746385&Address22=challengetoken&MXPref22=10&TTL22=3600&AssociatedAppTitle22=&FriendlyName22=&IsActive22=true&IsDDNSEnabled22=false&HostName22=orig.testfqdn&RecordType22=TXT&HostId23=746387&Address23=challengetoken&MXPref23=10&TTL23=3600&AssociatedAppTitle23=&FriendlyName23=&IsActive23=true&IsDDNSEnabled23=false&HostName23=orig.testfull&RecordType23=TXT&HostId24=746378&Address24=challengetoken&MXPref24=10&TTL24=3600&AssociatedAppTitle24=&FriendlyName24=&IsActive24=true&IsDDNSEnabled24=false&HostName24=random.fqdntest&RecordType24=TXT&HostId25=746379&Address25=challengetoken&MXPref25=10&TTL25=3600&AssociatedAppTitle25=&FriendlyName25=&IsActive25=true&IsDDNSEnabled25=false&HostName25=random.fulltest&RecordType25=TXT&HostId26=746380&Address26=challengetoken&MXPref26=10&TTL26=3600&AssociatedAppTitle26=&FriendlyName26=&IsActive26=true&IsDDNSEnabled26=false&HostName26=random.test&RecordType26=TXT&HostId27=746382&Address27=challengetoken&MXPref27=10&TTL27=3600&AssociatedAppTitle27=&FriendlyName27=&IsActive27=true&IsDDNSEnabled27=false&HostName27=updated.test&RecordType27=TXT&HostId28=746386&Address28=challengetoken&MXPref28=10&TTL28=3600&AssociatedAppTitle28=&FriendlyName28=&IsActive28=true&IsDDNSEnabled28=false&HostName28=updated.testfqdn&RecordType28=TXT&HostId29=746388&Address29=challengetoken&MXPref29=10&TTL29=3600&AssociatedAppTitle29=&FriendlyName29=&IsActive29=true&IsDDNSEnabled29=false&HostName29=updated.testfull&RecordType29=TXT&HostId30=746354&Address30=http%3A%2F%2Fwww.unittest2.dev%2F&MXPref30=10&TTL30=1800&AssociatedAppTitle30=URL+Forwarding&FriendlyName30=URL+Record&IsActive30=true&IsDDNSEnabled30=false&HostName30=%40&RecordType30=URL&Address31=challengetoken&TTL31=3600&HostName31=delete.testfqdn&RecordType31=TXT&SLD=unittest2&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['3930']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '5695'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.871</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest2.dev\" IsSuccess=\"true\">\r\n      <Warnings />\r\n    </DomainDNSSetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>1.172</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['559']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:40 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:00:04 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '557'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest2&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
-        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524833\" Name=\"_acme-challenge.noop\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524158\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524835\"\
-        \ Name=\"delete.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524214\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
-        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
-        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.794</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest2.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n      <host
+        HostId=\"746360\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746361\" Name=\"docs\" Type=\"CNAME\" Address=\"docs.example.com.\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746355\" Name=\"www\" Type=\"CNAME\"
+        Address=\"parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\"
+        FriendlyName=\"CNAME Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n
+        \     <host HostId=\"746365\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746366\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746372\" Name=\"_acme-challenge.deleterecordinset\"
+        Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746373\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746374\" Name=\"_acme-challenge.deleterecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746375\" Name=\"_acme-challenge.deleterecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746362\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746363\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746376\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746377\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746367\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746364\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746369\" Name=\"delete.testfqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746370\" Name=\"delete.testfull\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746371\" Name=\"delete.testid\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746383\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746384\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"updated\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746381\" Name=\"orig.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746385\" Name=\"orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746387\" Name=\"orig.testfull\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746378\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746379\" Name=\"random.fulltest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746380\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746382\" Name=\"updated.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746386\" Name=\"updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746388\" Name=\"updated.testfull\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746354\" Name=\"@\" Type=\"URL\" Address=\"http://www.unittest2.dev/\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL
+        Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.473</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4786']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:41 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:00:05 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '6411'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest2&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
-        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524833\" Name=\"_acme-challenge.noop\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524158\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524835\"\
-        \ Name=\"delete.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524214\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
-        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
-        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.967</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest2.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n      <host
+        HostId=\"746360\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746361\" Name=\"docs\" Type=\"CNAME\" Address=\"docs.example.com.\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746355\" Name=\"www\" Type=\"CNAME\"
+        Address=\"parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\"
+        FriendlyName=\"CNAME Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n
+        \     <host HostId=\"746365\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746366\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746372\" Name=\"_acme-challenge.deleterecordinset\"
+        Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746373\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746374\" Name=\"_acme-challenge.deleterecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746375\" Name=\"_acme-challenge.deleterecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746362\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746363\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746376\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746377\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746367\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746364\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746369\" Name=\"delete.testfqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746370\" Name=\"delete.testfull\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746371\" Name=\"delete.testid\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746383\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746384\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"updated\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746381\" Name=\"orig.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746385\" Name=\"orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746387\" Name=\"orig.testfull\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746378\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746379\" Name=\"random.fulltest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746380\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746382\" Name=\"updated.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746386\" Name=\"updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746388\" Name=\"updated.testfull\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746354\" Name=\"@\" Type=\"URL\" Address=\"http://www.unittest2.dev/\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL
+        Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.195</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4786']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:42 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:00:06 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '6411'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'RecordType21=URL&HostId19=524171&RecordType20=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524833&HostId9=524158&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524831&HostId5=524832&HostId6=524156&HostId7=524157&HostId21=524160&HostId20=524173&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=CName+Record&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524166&HostId13=524170&HostId10=524168&HostId11=524214&HostId16=524164&HostId17=524165&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&HostName12=orig.test&HostName13=orig.testfqdn&HostName10=orig.nameonly.test&HostName11=orig.nameonly.test&HostName16=random.fulltest&HostName17=random.test&HostName14=orig.testfull&Address1=127.0.0.1&HostName18=updated.test&HostName19=updated.testfqdn&MXPref5=10&FriendlyName21=URL+Record&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=60&TTL7=60&TTL14=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&Address18=challengetoken&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.fqdn&HostName7=_acme-challenge.full&HostName8=_acme-challenge.noop&HostName9=_acme-challenge.test&Address10=challengetoken&Address11=updated&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName21=yyy&HostName20=updated.testfull&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=random.fqdntest&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise&MXPref4=10&TTL18=1800&Address21=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524172&AssociatedAppTitle19=&HostId15=524163&HostId18=524167'
+    body: HostId1=746360&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746361&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746355&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746365&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746366&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746372&Address6=challengetoken1&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.deleterecordinset&RecordType6=TXT&HostId7=746373&Address7=challengetoken2&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.deleterecordinset&RecordType7=TXT&HostId8=746374&Address8=challengetoken1&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.deleterecordset&RecordType8=TXT&HostId9=746375&Address9=challengetoken2&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.deleterecordset&RecordType9=TXT&HostId10=746362&Address10=challengetoken&MXPref10=10&TTL10=3600&AssociatedAppTitle10=&FriendlyName10=&IsActive10=true&IsDDNSEnabled10=false&HostName10=_acme-challenge.fqdn&RecordType10=TXT&HostId11=746363&Address11=challengetoken&MXPref11=10&TTL11=3600&AssociatedAppTitle11=&FriendlyName11=&IsActive11=true&IsDDNSEnabled11=false&HostName11=_acme-challenge.full&RecordType11=TXT&HostId12=746376&Address12=challengetoken1&MXPref12=10&TTL12=3600&AssociatedAppTitle12=&FriendlyName12=&IsActive12=true&IsDDNSEnabled12=false&HostName12=_acme-challenge.listrecordset&RecordType12=TXT&HostId13=746377&Address13=challengetoken2&MXPref13=10&TTL13=3600&AssociatedAppTitle13=&FriendlyName13=&IsActive13=true&IsDDNSEnabled13=false&HostName13=_acme-challenge.listrecordset&RecordType13=TXT&HostId14=746367&Address14=challengetoken&MXPref14=10&TTL14=3600&AssociatedAppTitle14=&FriendlyName14=&IsActive14=true&IsDDNSEnabled14=false&HostName14=_acme-challenge.noop&RecordType14=TXT&HostId15=746364&Address15=challengetoken&MXPref15=10&TTL15=3600&AssociatedAppTitle15=&FriendlyName15=&IsActive15=true&IsDDNSEnabled15=false&HostName15=_acme-challenge.test&RecordType15=TXT&HostId16=746370&Address16=challengetoken&MXPref16=10&TTL16=3600&AssociatedAppTitle16=&FriendlyName16=&IsActive16=true&IsDDNSEnabled16=false&HostName16=delete.testfull&RecordType16=TXT&HostId17=746371&Address17=challengetoken&MXPref17=10&TTL17=3600&AssociatedAppTitle17=&FriendlyName17=&IsActive17=true&IsDDNSEnabled17=false&HostName17=delete.testid&RecordType17=TXT&HostId18=746383&Address18=challengetoken&MXPref18=10&TTL18=3600&AssociatedAppTitle18=&FriendlyName18=&IsActive18=true&IsDDNSEnabled18=false&HostName18=orig.nameonly.test&RecordType18=TXT&HostId19=746384&Address19=updated&MXPref19=10&TTL19=3600&AssociatedAppTitle19=&FriendlyName19=&IsActive19=true&IsDDNSEnabled19=false&HostName19=orig.nameonly.test&RecordType19=TXT&HostId20=746381&Address20=challengetoken&MXPref20=10&TTL20=3600&AssociatedAppTitle20=&FriendlyName20=&IsActive20=true&IsDDNSEnabled20=false&HostName20=orig.test&RecordType20=TXT&HostId21=746385&Address21=challengetoken&MXPref21=10&TTL21=3600&AssociatedAppTitle21=&FriendlyName21=&IsActive21=true&IsDDNSEnabled21=false&HostName21=orig.testfqdn&RecordType21=TXT&HostId22=746387&Address22=challengetoken&MXPref22=10&TTL22=3600&AssociatedAppTitle22=&FriendlyName22=&IsActive22=true&IsDDNSEnabled22=false&HostName22=orig.testfull&RecordType22=TXT&HostId23=746378&Address23=challengetoken&MXPref23=10&TTL23=3600&AssociatedAppTitle23=&FriendlyName23=&IsActive23=true&IsDDNSEnabled23=false&HostName23=random.fqdntest&RecordType23=TXT&HostId24=746379&Address24=challengetoken&MXPref24=10&TTL24=3600&AssociatedAppTitle24=&FriendlyName24=&IsActive24=true&IsDDNSEnabled24=false&HostName24=random.fulltest&RecordType24=TXT&HostId25=746380&Address25=challengetoken&MXPref25=10&TTL25=3600&AssociatedAppTitle25=&FriendlyName25=&IsActive25=true&IsDDNSEnabled25=false&HostName25=random.test&RecordType25=TXT&HostId26=746382&Address26=challengetoken&MXPref26=10&TTL26=3600&AssociatedAppTitle26=&FriendlyName26=&IsActive26=true&IsDDNSEnabled26=false&HostName26=updated.test&RecordType26=TXT&HostId27=746386&Address27=challengetoken&MXPref27=10&TTL27=3600&AssociatedAppTitle27=&FriendlyName27=&IsActive27=true&IsDDNSEnabled27=false&HostName27=updated.testfqdn&RecordType27=TXT&HostId28=746388&Address28=challengetoken&MXPref28=10&TTL28=3600&AssociatedAppTitle28=&FriendlyName28=&IsActive28=true&IsDDNSEnabled28=false&HostName28=updated.testfull&RecordType28=TXT&HostId29=746354&Address29=http%3A%2F%2Fwww.unittest2.dev%2F&MXPref29=10&TTL29=1800&AssociatedAppTitle29=URL+Forwarding&FriendlyName29=URL+Record&IsActive29=true&IsDDNSEnabled29=false&HostName29=%40&RecordType29=URL&SLD=unittest2&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['3861']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '5431'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.681</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest2.dev\" IsSuccess=\"true\">\r\n      <Warnings />\r\n    </DomainDNSSetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>1.294</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['559']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:43 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:00:09 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '557'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest2&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
-        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524833\" Name=\"_acme-challenge.noop\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524158\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\"\
-        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524214\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524166\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"\
-        orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524163\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\"\
-        \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524165\" Name=\"random.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524167\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524171\" Name=\"\
-        updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524160\" Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
-        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.681</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest2.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n      <host
+        HostId=\"746360\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746361\" Name=\"docs\" Type=\"CNAME\" Address=\"docs.example.com.\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746355\" Name=\"www\" Type=\"CNAME\"
+        Address=\"parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\"
+        FriendlyName=\"CNAME Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n
+        \     <host HostId=\"746365\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746366\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746372\" Name=\"_acme-challenge.deleterecordinset\"
+        Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746373\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746374\" Name=\"_acme-challenge.deleterecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746375\" Name=\"_acme-challenge.deleterecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746362\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746363\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746376\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746377\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746367\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746364\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746370\" Name=\"delete.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746371\" Name=\"delete.testid\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746383\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746384\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746381\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746385\" Name=\"orig.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746387\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746378\" Name=\"random.fqdntest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746379\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746380\" Name=\"random.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746382\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746386\" Name=\"updated.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746388\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746354\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest2.dev/\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL
+        Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.639</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4596']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:44 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:00:10 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '6221'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/namecheap/IntegrationTests/test_provider_when_calling_delete_record_by_filter_with_full_name_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/namecheap/IntegrationTests/test_provider_when_calling_delete_record_by_filter_with_full_name_should_remove_record.yaml
@@ -2,447 +2,617 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise.com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=unittest2.dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
-        \ Status=\"Ok\" ID=\"277432\" DomainName=\"example-aptise.com\" OwnerName=\"\
-        jvsandbox\" IsOwner=\"true\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
-        \n        <CreatedDate>03/25/2018</CreatedDate>\r\n        <ExpiredDate>03/25/2019</ExpiredDate>\r\
-        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
-        \ />\r\n      <Whoisguard Enabled=\"NotAlloted\">\r\n        <ID>0</ID>\r\n\
-        \      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
-        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
-        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
-        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
-        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"21\" EmailType=\"\
-        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
-        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
-        \n      <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.029</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult
+        Status=\"Ok\" ID=\"589667\" DomainName=\"unittest2.dev\" OwnerName=\"phassberg\"
+        IsOwner=\"true\" IsPremium=\"false\">\r\n      <DomainDetails>\r\n        <CreatedDate>05/20/2020</CreatedDate>\r\n
+        \       <ExpiredDate>05/20/2021</ExpiredDate>\r\n        <NumYears>0</NumYears>\r\n
+        \     </DomainDetails>\r\n      <LockDetails />\r\n      <Whoisguard Enabled=\"True\">\r\n
+        \       <ID>481121</ID>\r\n        <ExpiredDate>05/20/2021</ExpiredDate>\r\n
+        \       <EmailDetails WhoisGuardEmail=\"824017ccbed343119b3459c7d3304ba5.protect@whoisguard.com\"
+        ForwardedTo=\"dr.doddo@gmail.com\" LastAutoEmailChangeDate=\"05/20/2020\"
+        AutoEmailChangeFrequencyDays=\"3\" />\r\n      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n
+        \       <UseAutoRenew>false</UseAutoRenew>\r\n        <SubscriptionId>-1</SubscriptionId>\r\n
+        \       <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n
+        \       <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n
+        \     <DnsDetails ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"29\"
+        EmailType=\"FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\n
+        \       <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\n
+        \     <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.22</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['1493']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:44 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:00:11 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '1739'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest2&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
-        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524833\" Name=\"_acme-challenge.noop\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524158\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\"\
-        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524214\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524166\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"\
-        orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524163\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\"\
-        \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524165\" Name=\"random.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524167\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524171\" Name=\"\
-        updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524160\" Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
-        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.87</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest2.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n      <host
+        HostId=\"746360\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746361\" Name=\"docs\" Type=\"CNAME\" Address=\"docs.example.com.\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746355\" Name=\"www\" Type=\"CNAME\"
+        Address=\"parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\"
+        FriendlyName=\"CNAME Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n
+        \     <host HostId=\"746365\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746366\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746372\" Name=\"_acme-challenge.deleterecordinset\"
+        Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746373\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746374\" Name=\"_acme-challenge.deleterecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746375\" Name=\"_acme-challenge.deleterecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746362\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746363\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746376\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746377\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746367\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746364\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746370\" Name=\"delete.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746371\" Name=\"delete.testid\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746383\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746384\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746381\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746385\" Name=\"orig.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746387\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746378\" Name=\"random.fqdntest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746379\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746380\" Name=\"random.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746382\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746386\" Name=\"updated.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746388\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746354\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest2.dev/\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL
+        Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.229</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4595']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:46 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:00:12 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '6221'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'RecordType21=URL&HostId19=524171&RecordType20=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524833&HostId9=524158&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524831&HostId5=524832&HostId6=524156&HostId7=524157&HostId21=524160&HostId20=524173&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=CName+Record&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524166&HostId13=524170&HostId10=524168&HostId11=524214&HostId16=524164&HostId17=524165&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&HostName12=orig.test&HostName13=orig.testfqdn&HostName10=orig.nameonly.test&HostName11=orig.nameonly.test&HostName16=random.fulltest&HostName17=random.test&HostName14=orig.testfull&Address1=127.0.0.1&HostName18=updated.test&HostName19=updated.testfqdn&MXPref5=10&FriendlyName21=URL+Record&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=60&TTL7=60&TTL14=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&Address18=challengetoken&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.fqdn&HostName7=_acme-challenge.full&HostName8=_acme-challenge.noop&HostName9=_acme-challenge.test&Address10=challengetoken&Address11=updated&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName22=delete.testfull&HostName21=yyy&HostName20=updated.testfull&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=random.fqdntest&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise&MXPref4=10&TTL18=1800&Address21=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524172&AssociatedAppTitle19=&HostId15=524163&HostId18=524167'
+    body: HostId1=746360&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746361&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746355&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746365&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746366&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746372&Address6=challengetoken1&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.deleterecordinset&RecordType6=TXT&HostId7=746373&Address7=challengetoken2&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.deleterecordinset&RecordType7=TXT&HostId8=746374&Address8=challengetoken1&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.deleterecordset&RecordType8=TXT&HostId9=746375&Address9=challengetoken2&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.deleterecordset&RecordType9=TXT&HostId10=746362&Address10=challengetoken&MXPref10=10&TTL10=3600&AssociatedAppTitle10=&FriendlyName10=&IsActive10=true&IsDDNSEnabled10=false&HostName10=_acme-challenge.fqdn&RecordType10=TXT&HostId11=746363&Address11=challengetoken&MXPref11=10&TTL11=3600&AssociatedAppTitle11=&FriendlyName11=&IsActive11=true&IsDDNSEnabled11=false&HostName11=_acme-challenge.full&RecordType11=TXT&HostId12=746376&Address12=challengetoken1&MXPref12=10&TTL12=3600&AssociatedAppTitle12=&FriendlyName12=&IsActive12=true&IsDDNSEnabled12=false&HostName12=_acme-challenge.listrecordset&RecordType12=TXT&HostId13=746377&Address13=challengetoken2&MXPref13=10&TTL13=3600&AssociatedAppTitle13=&FriendlyName13=&IsActive13=true&IsDDNSEnabled13=false&HostName13=_acme-challenge.listrecordset&RecordType13=TXT&HostId14=746367&Address14=challengetoken&MXPref14=10&TTL14=3600&AssociatedAppTitle14=&FriendlyName14=&IsActive14=true&IsDDNSEnabled14=false&HostName14=_acme-challenge.noop&RecordType14=TXT&HostId15=746364&Address15=challengetoken&MXPref15=10&TTL15=3600&AssociatedAppTitle15=&FriendlyName15=&IsActive15=true&IsDDNSEnabled15=false&HostName15=_acme-challenge.test&RecordType15=TXT&HostId16=746370&Address16=challengetoken&MXPref16=10&TTL16=3600&AssociatedAppTitle16=&FriendlyName16=&IsActive16=true&IsDDNSEnabled16=false&HostName16=delete.testfull&RecordType16=TXT&HostId17=746371&Address17=challengetoken&MXPref17=10&TTL17=3600&AssociatedAppTitle17=&FriendlyName17=&IsActive17=true&IsDDNSEnabled17=false&HostName17=delete.testid&RecordType17=TXT&HostId18=746383&Address18=challengetoken&MXPref18=10&TTL18=3600&AssociatedAppTitle18=&FriendlyName18=&IsActive18=true&IsDDNSEnabled18=false&HostName18=orig.nameonly.test&RecordType18=TXT&HostId19=746384&Address19=updated&MXPref19=10&TTL19=3600&AssociatedAppTitle19=&FriendlyName19=&IsActive19=true&IsDDNSEnabled19=false&HostName19=orig.nameonly.test&RecordType19=TXT&HostId20=746381&Address20=challengetoken&MXPref20=10&TTL20=3600&AssociatedAppTitle20=&FriendlyName20=&IsActive20=true&IsDDNSEnabled20=false&HostName20=orig.test&RecordType20=TXT&HostId21=746385&Address21=challengetoken&MXPref21=10&TTL21=3600&AssociatedAppTitle21=&FriendlyName21=&IsActive21=true&IsDDNSEnabled21=false&HostName21=orig.testfqdn&RecordType21=TXT&HostId22=746387&Address22=challengetoken&MXPref22=10&TTL22=3600&AssociatedAppTitle22=&FriendlyName22=&IsActive22=true&IsDDNSEnabled22=false&HostName22=orig.testfull&RecordType22=TXT&HostId23=746378&Address23=challengetoken&MXPref23=10&TTL23=3600&AssociatedAppTitle23=&FriendlyName23=&IsActive23=true&IsDDNSEnabled23=false&HostName23=random.fqdntest&RecordType23=TXT&HostId24=746379&Address24=challengetoken&MXPref24=10&TTL24=3600&AssociatedAppTitle24=&FriendlyName24=&IsActive24=true&IsDDNSEnabled24=false&HostName24=random.fulltest&RecordType24=TXT&HostId25=746380&Address25=challengetoken&MXPref25=10&TTL25=3600&AssociatedAppTitle25=&FriendlyName25=&IsActive25=true&IsDDNSEnabled25=false&HostName25=random.test&RecordType25=TXT&HostId26=746382&Address26=challengetoken&MXPref26=10&TTL26=3600&AssociatedAppTitle26=&FriendlyName26=&IsActive26=true&IsDDNSEnabled26=false&HostName26=updated.test&RecordType26=TXT&HostId27=746386&Address27=challengetoken&MXPref27=10&TTL27=3600&AssociatedAppTitle27=&FriendlyName27=&IsActive27=true&IsDDNSEnabled27=false&HostName27=updated.testfqdn&RecordType27=TXT&HostId28=746388&Address28=challengetoken&MXPref28=10&TTL28=3600&AssociatedAppTitle28=&FriendlyName28=&IsActive28=true&IsDDNSEnabled28=false&HostName28=updated.testfull&RecordType28=TXT&HostId29=746354&Address29=http%3A%2F%2Fwww.unittest2.dev%2F&MXPref29=10&TTL29=1800&AssociatedAppTitle29=URL+Forwarding&FriendlyName29=URL+Record&IsActive29=true&IsDDNSEnabled29=false&HostName29=%40&RecordType29=URL&Address30=challengetoken&TTL30=3600&HostName30=delete.testfull&RecordType30=TXT&SLD=unittest2&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['3930']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '5511'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>1.204</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest2.dev\" IsSuccess=\"true\">\r\n      <Warnings />\r\n    </DomainDNSSetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.804</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['559']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:48 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:00:14 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '557'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest2&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
-        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524833\" Name=\"_acme-challenge.noop\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524158\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524836\"\
-        \ Name=\"delete.testfull\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524214\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
-        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
-        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.784</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest2.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n      <host
+        HostId=\"746360\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746361\" Name=\"docs\" Type=\"CNAME\" Address=\"docs.example.com.\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746355\" Name=\"www\" Type=\"CNAME\"
+        Address=\"parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\"
+        FriendlyName=\"CNAME Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n
+        \     <host HostId=\"746365\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746366\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746372\" Name=\"_acme-challenge.deleterecordinset\"
+        Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746373\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746374\" Name=\"_acme-challenge.deleterecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746375\" Name=\"_acme-challenge.deleterecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746362\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746363\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746376\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746377\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746367\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746364\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746370\" Name=\"delete.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746371\" Name=\"delete.testid\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746383\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746384\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746381\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746385\" Name=\"orig.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746387\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746378\" Name=\"random.fqdntest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746379\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746380\" Name=\"random.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746382\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746386\" Name=\"updated.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746388\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746354\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest2.dev/\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL
+        Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.697</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4786']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:49 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:00:16 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '6221'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest2&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
-        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524833\" Name=\"_acme-challenge.noop\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524158\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524836\"\
-        \ Name=\"delete.testfull\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524214\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
-        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
-        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.861</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest2.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n      <host
+        HostId=\"746360\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746361\" Name=\"docs\" Type=\"CNAME\" Address=\"docs.example.com.\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746355\" Name=\"www\" Type=\"CNAME\"
+        Address=\"parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\"
+        FriendlyName=\"CNAME Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n
+        \     <host HostId=\"746365\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746366\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746372\" Name=\"_acme-challenge.deleterecordinset\"
+        Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746373\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746374\" Name=\"_acme-challenge.deleterecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746375\" Name=\"_acme-challenge.deleterecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746362\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746363\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746376\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746377\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746367\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746364\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746370\" Name=\"delete.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746371\" Name=\"delete.testid\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746383\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746384\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746381\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746385\" Name=\"orig.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746387\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746378\" Name=\"random.fqdntest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746379\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746380\" Name=\"random.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746382\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746386\" Name=\"updated.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746388\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746354\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest2.dev/\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL
+        Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.568</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4786']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:51 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:00:17 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '6221'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'RecordType21=URL&HostId19=524171&RecordType20=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524833&HostId9=524158&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524831&HostId5=524832&HostId6=524156&HostId7=524157&HostId21=524160&HostId20=524173&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=CName+Record&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524166&HostId13=524170&HostId10=524168&HostId11=524214&HostId16=524164&HostId17=524165&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&HostName12=orig.test&HostName13=orig.testfqdn&HostName10=orig.nameonly.test&HostName11=orig.nameonly.test&HostName16=random.fulltest&HostName17=random.test&HostName14=orig.testfull&Address1=127.0.0.1&HostName18=updated.test&HostName19=updated.testfqdn&MXPref5=10&FriendlyName21=URL+Record&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=60&TTL7=60&TTL14=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&Address18=challengetoken&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.fqdn&HostName7=_acme-challenge.full&HostName8=_acme-challenge.noop&HostName9=_acme-challenge.test&Address10=challengetoken&Address11=updated&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName21=yyy&HostName20=updated.testfull&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=random.fqdntest&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise&MXPref4=10&TTL18=1800&Address21=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524172&AssociatedAppTitle19=&HostId15=524163&HostId18=524167'
+    body: HostId1=746360&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746361&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746355&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746365&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746366&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746372&Address6=challengetoken1&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.deleterecordinset&RecordType6=TXT&HostId7=746373&Address7=challengetoken2&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.deleterecordinset&RecordType7=TXT&HostId8=746374&Address8=challengetoken1&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.deleterecordset&RecordType8=TXT&HostId9=746375&Address9=challengetoken2&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.deleterecordset&RecordType9=TXT&HostId10=746362&Address10=challengetoken&MXPref10=10&TTL10=3600&AssociatedAppTitle10=&FriendlyName10=&IsActive10=true&IsDDNSEnabled10=false&HostName10=_acme-challenge.fqdn&RecordType10=TXT&HostId11=746363&Address11=challengetoken&MXPref11=10&TTL11=3600&AssociatedAppTitle11=&FriendlyName11=&IsActive11=true&IsDDNSEnabled11=false&HostName11=_acme-challenge.full&RecordType11=TXT&HostId12=746376&Address12=challengetoken1&MXPref12=10&TTL12=3600&AssociatedAppTitle12=&FriendlyName12=&IsActive12=true&IsDDNSEnabled12=false&HostName12=_acme-challenge.listrecordset&RecordType12=TXT&HostId13=746377&Address13=challengetoken2&MXPref13=10&TTL13=3600&AssociatedAppTitle13=&FriendlyName13=&IsActive13=true&IsDDNSEnabled13=false&HostName13=_acme-challenge.listrecordset&RecordType13=TXT&HostId14=746367&Address14=challengetoken&MXPref14=10&TTL14=3600&AssociatedAppTitle14=&FriendlyName14=&IsActive14=true&IsDDNSEnabled14=false&HostName14=_acme-challenge.noop&RecordType14=TXT&HostId15=746364&Address15=challengetoken&MXPref15=10&TTL15=3600&AssociatedAppTitle15=&FriendlyName15=&IsActive15=true&IsDDNSEnabled15=false&HostName15=_acme-challenge.test&RecordType15=TXT&HostId16=746371&Address16=challengetoken&MXPref16=10&TTL16=3600&AssociatedAppTitle16=&FriendlyName16=&IsActive16=true&IsDDNSEnabled16=false&HostName16=delete.testid&RecordType16=TXT&HostId17=746383&Address17=challengetoken&MXPref17=10&TTL17=3600&AssociatedAppTitle17=&FriendlyName17=&IsActive17=true&IsDDNSEnabled17=false&HostName17=orig.nameonly.test&RecordType17=TXT&HostId18=746384&Address18=updated&MXPref18=10&TTL18=3600&AssociatedAppTitle18=&FriendlyName18=&IsActive18=true&IsDDNSEnabled18=false&HostName18=orig.nameonly.test&RecordType18=TXT&HostId19=746381&Address19=challengetoken&MXPref19=10&TTL19=3600&AssociatedAppTitle19=&FriendlyName19=&IsActive19=true&IsDDNSEnabled19=false&HostName19=orig.test&RecordType19=TXT&HostId20=746385&Address20=challengetoken&MXPref20=10&TTL20=3600&AssociatedAppTitle20=&FriendlyName20=&IsActive20=true&IsDDNSEnabled20=false&HostName20=orig.testfqdn&RecordType20=TXT&HostId21=746387&Address21=challengetoken&MXPref21=10&TTL21=3600&AssociatedAppTitle21=&FriendlyName21=&IsActive21=true&IsDDNSEnabled21=false&HostName21=orig.testfull&RecordType21=TXT&HostId22=746378&Address22=challengetoken&MXPref22=10&TTL22=3600&AssociatedAppTitle22=&FriendlyName22=&IsActive22=true&IsDDNSEnabled22=false&HostName22=random.fqdntest&RecordType22=TXT&HostId23=746379&Address23=challengetoken&MXPref23=10&TTL23=3600&AssociatedAppTitle23=&FriendlyName23=&IsActive23=true&IsDDNSEnabled23=false&HostName23=random.fulltest&RecordType23=TXT&HostId24=746380&Address24=challengetoken&MXPref24=10&TTL24=3600&AssociatedAppTitle24=&FriendlyName24=&IsActive24=true&IsDDNSEnabled24=false&HostName24=random.test&RecordType24=TXT&HostId25=746382&Address25=challengetoken&MXPref25=10&TTL25=3600&AssociatedAppTitle25=&FriendlyName25=&IsActive25=true&IsDDNSEnabled25=false&HostName25=updated.test&RecordType25=TXT&HostId26=746386&Address26=challengetoken&MXPref26=10&TTL26=3600&AssociatedAppTitle26=&FriendlyName26=&IsActive26=true&IsDDNSEnabled26=false&HostName26=updated.testfqdn&RecordType26=TXT&HostId27=746388&Address27=challengetoken&MXPref27=10&TTL27=3600&AssociatedAppTitle27=&FriendlyName27=&IsActive27=true&IsDDNSEnabled27=false&HostName27=updated.testfull&RecordType27=TXT&HostId28=746354&Address28=http%3A%2F%2Fwww.unittest2.dev%2F&MXPref28=10&TTL28=1800&AssociatedAppTitle28=URL+Forwarding&FriendlyName28=URL+Record&IsActive28=true&IsDDNSEnabled28=false&HostName28=%40&RecordType28=URL&SLD=unittest2&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['3861']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '5247'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.745</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest2.dev\" IsSuccess=\"true\">\r\n      <Warnings />\r\n    </DomainDNSSetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.902</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['559']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:52 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:00:19 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '557'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest2&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
-        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524833\" Name=\"_acme-challenge.noop\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524158\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\"\
-        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524214\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524166\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"\
-        orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524163\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\"\
-        \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524165\" Name=\"random.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524167\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524171\" Name=\"\
-        updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524160\" Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
-        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.886</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest2.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n      <host
+        HostId=\"746360\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746361\" Name=\"docs\" Type=\"CNAME\" Address=\"docs.example.com.\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746355\" Name=\"www\" Type=\"CNAME\"
+        Address=\"parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\"
+        FriendlyName=\"CNAME Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n
+        \     <host HostId=\"746365\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746366\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746372\" Name=\"_acme-challenge.deleterecordinset\"
+        Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746373\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746374\" Name=\"_acme-challenge.deleterecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746375\" Name=\"_acme-challenge.deleterecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746362\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746363\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746376\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746377\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746367\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746364\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746371\" Name=\"delete.testid\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746383\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746384\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"updated\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746381\" Name=\"orig.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746385\" Name=\"orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746387\" Name=\"orig.testfull\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746378\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746379\" Name=\"random.fulltest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746380\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746382\" Name=\"updated.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746386\" Name=\"updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746388\" Name=\"updated.testfull\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746354\" Name=\"@\" Type=\"URL\" Address=\"http://www.unittest2.dev/\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL
+        Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.183</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4596']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:53 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:00:20 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '6031'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/namecheap/IntegrationTests/test_provider_when_calling_delete_record_by_identifier_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/namecheap/IntegrationTests/test_provider_when_calling_delete_record_by_identifier_should_remove_record.yaml
@@ -2,535 +2,723 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise.com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=unittest2.dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
-        \ Status=\"Ok\" ID=\"277432\" DomainName=\"example-aptise.com\" OwnerName=\"\
-        jvsandbox\" IsOwner=\"true\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
-        \n        <CreatedDate>03/25/2018</CreatedDate>\r\n        <ExpiredDate>03/25/2019</ExpiredDate>\r\
-        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
-        \ />\r\n      <Whoisguard Enabled=\"NotAlloted\">\r\n        <ID>0</ID>\r\n\
-        \      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
-        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
-        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
-        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
-        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"21\" EmailType=\"\
-        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
-        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
-        \n      <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.028</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult
+        Status=\"Ok\" ID=\"589667\" DomainName=\"unittest2.dev\" OwnerName=\"phassberg\"
+        IsOwner=\"true\" IsPremium=\"false\">\r\n      <DomainDetails>\r\n        <CreatedDate>05/20/2020</CreatedDate>\r\n
+        \       <ExpiredDate>05/20/2021</ExpiredDate>\r\n        <NumYears>0</NumYears>\r\n
+        \     </DomainDetails>\r\n      <LockDetails />\r\n      <Whoisguard Enabled=\"True\">\r\n
+        \       <ID>481121</ID>\r\n        <ExpiredDate>05/20/2021</ExpiredDate>\r\n
+        \       <EmailDetails WhoisGuardEmail=\"824017ccbed343119b3459c7d3304ba5.protect@whoisguard.com\"
+        ForwardedTo=\"dr.doddo@gmail.com\" LastAutoEmailChangeDate=\"05/20/2020\"
+        AutoEmailChangeFrequencyDays=\"3\" />\r\n      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n
+        \       <UseAutoRenew>false</UseAutoRenew>\r\n        <SubscriptionId>-1</SubscriptionId>\r\n
+        \       <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n
+        \       <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n
+        \     <DnsDetails ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"28\"
+        EmailType=\"FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\n
+        \       <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\n
+        \     <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.201</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['1493']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:53 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:00:22 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '1740'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest2&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
-        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524833\" Name=\"_acme-challenge.noop\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524158\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\"\
-        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524214\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524166\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"\
-        orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524163\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\"\
-        \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524165\" Name=\"random.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524167\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524171\" Name=\"\
-        updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524160\" Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
-        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.856</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest2.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n      <host
+        HostId=\"746360\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746361\" Name=\"docs\" Type=\"CNAME\" Address=\"docs.example.com.\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746355\" Name=\"www\" Type=\"CNAME\"
+        Address=\"parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\"
+        FriendlyName=\"CNAME Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n
+        \     <host HostId=\"746365\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746366\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746372\" Name=\"_acme-challenge.deleterecordinset\"
+        Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746373\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746374\" Name=\"_acme-challenge.deleterecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746375\" Name=\"_acme-challenge.deleterecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746362\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746363\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746376\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746377\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746367\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746364\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746371\" Name=\"delete.testid\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746383\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746384\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"updated\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746381\" Name=\"orig.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746385\" Name=\"orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746387\" Name=\"orig.testfull\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746378\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746379\" Name=\"random.fulltest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746380\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746382\" Name=\"updated.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746386\" Name=\"updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746388\" Name=\"updated.testfull\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746354\" Name=\"@\" Type=\"URL\" Address=\"http://www.unittest2.dev/\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL
+        Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.662</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4596']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:55 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:00:23 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '6031'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'RecordType21=URL&HostId19=524171&RecordType20=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524833&HostId9=524158&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524831&HostId5=524832&HostId6=524156&HostId7=524157&HostId21=524160&HostId20=524173&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=CName+Record&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524166&HostId13=524170&HostId10=524168&HostId11=524214&HostId16=524164&HostId17=524165&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&HostName12=orig.test&HostName13=orig.testfqdn&HostName10=orig.nameonly.test&HostName11=orig.nameonly.test&HostName16=random.fulltest&HostName17=random.test&HostName14=orig.testfull&Address1=127.0.0.1&HostName18=updated.test&HostName19=updated.testfqdn&MXPref5=10&FriendlyName21=URL+Record&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=60&TTL7=60&TTL14=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&Address18=challengetoken&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.fqdn&HostName7=_acme-challenge.full&HostName8=_acme-challenge.noop&HostName9=_acme-challenge.test&Address10=challengetoken&Address11=updated&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName22=delete.testid&HostName21=yyy&HostName20=updated.testfull&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=random.fqdntest&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise&MXPref4=10&TTL18=1800&Address21=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524172&AssociatedAppTitle19=&HostId15=524163&HostId18=524167'
+    body: HostId1=746360&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746361&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746355&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746365&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746366&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746372&Address6=challengetoken1&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.deleterecordinset&RecordType6=TXT&HostId7=746373&Address7=challengetoken2&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.deleterecordinset&RecordType7=TXT&HostId8=746374&Address8=challengetoken1&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.deleterecordset&RecordType8=TXT&HostId9=746375&Address9=challengetoken2&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.deleterecordset&RecordType9=TXT&HostId10=746362&Address10=challengetoken&MXPref10=10&TTL10=3600&AssociatedAppTitle10=&FriendlyName10=&IsActive10=true&IsDDNSEnabled10=false&HostName10=_acme-challenge.fqdn&RecordType10=TXT&HostId11=746363&Address11=challengetoken&MXPref11=10&TTL11=3600&AssociatedAppTitle11=&FriendlyName11=&IsActive11=true&IsDDNSEnabled11=false&HostName11=_acme-challenge.full&RecordType11=TXT&HostId12=746376&Address12=challengetoken1&MXPref12=10&TTL12=3600&AssociatedAppTitle12=&FriendlyName12=&IsActive12=true&IsDDNSEnabled12=false&HostName12=_acme-challenge.listrecordset&RecordType12=TXT&HostId13=746377&Address13=challengetoken2&MXPref13=10&TTL13=3600&AssociatedAppTitle13=&FriendlyName13=&IsActive13=true&IsDDNSEnabled13=false&HostName13=_acme-challenge.listrecordset&RecordType13=TXT&HostId14=746367&Address14=challengetoken&MXPref14=10&TTL14=3600&AssociatedAppTitle14=&FriendlyName14=&IsActive14=true&IsDDNSEnabled14=false&HostName14=_acme-challenge.noop&RecordType14=TXT&HostId15=746364&Address15=challengetoken&MXPref15=10&TTL15=3600&AssociatedAppTitle15=&FriendlyName15=&IsActive15=true&IsDDNSEnabled15=false&HostName15=_acme-challenge.test&RecordType15=TXT&HostId16=746371&Address16=challengetoken&MXPref16=10&TTL16=3600&AssociatedAppTitle16=&FriendlyName16=&IsActive16=true&IsDDNSEnabled16=false&HostName16=delete.testid&RecordType16=TXT&HostId17=746383&Address17=challengetoken&MXPref17=10&TTL17=3600&AssociatedAppTitle17=&FriendlyName17=&IsActive17=true&IsDDNSEnabled17=false&HostName17=orig.nameonly.test&RecordType17=TXT&HostId18=746384&Address18=updated&MXPref18=10&TTL18=3600&AssociatedAppTitle18=&FriendlyName18=&IsActive18=true&IsDDNSEnabled18=false&HostName18=orig.nameonly.test&RecordType18=TXT&HostId19=746381&Address19=challengetoken&MXPref19=10&TTL19=3600&AssociatedAppTitle19=&FriendlyName19=&IsActive19=true&IsDDNSEnabled19=false&HostName19=orig.test&RecordType19=TXT&HostId20=746385&Address20=challengetoken&MXPref20=10&TTL20=3600&AssociatedAppTitle20=&FriendlyName20=&IsActive20=true&IsDDNSEnabled20=false&HostName20=orig.testfqdn&RecordType20=TXT&HostId21=746387&Address21=challengetoken&MXPref21=10&TTL21=3600&AssociatedAppTitle21=&FriendlyName21=&IsActive21=true&IsDDNSEnabled21=false&HostName21=orig.testfull&RecordType21=TXT&HostId22=746378&Address22=challengetoken&MXPref22=10&TTL22=3600&AssociatedAppTitle22=&FriendlyName22=&IsActive22=true&IsDDNSEnabled22=false&HostName22=random.fqdntest&RecordType22=TXT&HostId23=746379&Address23=challengetoken&MXPref23=10&TTL23=3600&AssociatedAppTitle23=&FriendlyName23=&IsActive23=true&IsDDNSEnabled23=false&HostName23=random.fulltest&RecordType23=TXT&HostId24=746380&Address24=challengetoken&MXPref24=10&TTL24=3600&AssociatedAppTitle24=&FriendlyName24=&IsActive24=true&IsDDNSEnabled24=false&HostName24=random.test&RecordType24=TXT&HostId25=746382&Address25=challengetoken&MXPref25=10&TTL25=3600&AssociatedAppTitle25=&FriendlyName25=&IsActive25=true&IsDDNSEnabled25=false&HostName25=updated.test&RecordType25=TXT&HostId26=746386&Address26=challengetoken&MXPref26=10&TTL26=3600&AssociatedAppTitle26=&FriendlyName26=&IsActive26=true&IsDDNSEnabled26=false&HostName26=updated.testfqdn&RecordType26=TXT&HostId27=746388&Address27=challengetoken&MXPref27=10&TTL27=3600&AssociatedAppTitle27=&FriendlyName27=&IsActive27=true&IsDDNSEnabled27=false&HostName27=updated.testfull&RecordType27=TXT&HostId28=746354&Address28=http%3A%2F%2Fwww.unittest2.dev%2F&MXPref28=10&TTL28=1800&AssociatedAppTitle28=URL+Forwarding&FriendlyName28=URL+Record&IsActive28=true&IsDDNSEnabled28=false&HostName28=%40&RecordType28=URL&Address29=challengetoken&TTL29=3600&HostName29=delete.testid&RecordType29=TXT&SLD=unittest2&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['3928']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '5325'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.76</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest2.dev\" IsSuccess=\"true\">\r\n      <Warnings />\r\n    </DomainDNSSetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.934</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['558']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:57 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:00:25 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '557'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest2&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
-        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524833\" Name=\"_acme-challenge.noop\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524158\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524837\"\
-        \ Name=\"delete.testid\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524214\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
-        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
-        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.845</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest2.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n      <host
+        HostId=\"746360\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746361\" Name=\"docs\" Type=\"CNAME\" Address=\"docs.example.com.\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746355\" Name=\"www\" Type=\"CNAME\"
+        Address=\"parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\"
+        FriendlyName=\"CNAME Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n
+        \     <host HostId=\"746365\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746366\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746372\" Name=\"_acme-challenge.deleterecordinset\"
+        Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746373\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746374\" Name=\"_acme-challenge.deleterecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746375\" Name=\"_acme-challenge.deleterecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746362\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746363\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746376\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746377\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746367\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746364\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746371\" Name=\"delete.testid\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746383\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746384\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"updated\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746381\" Name=\"orig.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746385\" Name=\"orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746387\" Name=\"orig.testfull\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746378\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746379\" Name=\"random.fulltest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746380\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746382\" Name=\"updated.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746386\" Name=\"updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746388\" Name=\"updated.testfull\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746354\" Name=\"@\" Type=\"URL\" Address=\"http://www.unittest2.dev/\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL
+        Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.336</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4784']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:58 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:00:25 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '6031'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest2&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
-        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524833\" Name=\"_acme-challenge.noop\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524158\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524837\"\
-        \ Name=\"delete.testid\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524214\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
-        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
-        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.742</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest2.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n      <host
+        HostId=\"746360\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746361\" Name=\"docs\" Type=\"CNAME\" Address=\"docs.example.com.\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746355\" Name=\"www\" Type=\"CNAME\"
+        Address=\"parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\"
+        FriendlyName=\"CNAME Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n
+        \     <host HostId=\"746365\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746366\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746372\" Name=\"_acme-challenge.deleterecordinset\"
+        Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746373\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746374\" Name=\"_acme-challenge.deleterecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746375\" Name=\"_acme-challenge.deleterecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746362\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746363\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746376\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746377\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746367\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746364\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746371\" Name=\"delete.testid\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746383\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746384\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"updated\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746381\" Name=\"orig.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746385\" Name=\"orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746387\" Name=\"orig.testfull\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746378\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746379\" Name=\"random.fulltest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746380\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746382\" Name=\"updated.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746386\" Name=\"updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746388\" Name=\"updated.testfull\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746354\" Name=\"@\" Type=\"URL\" Address=\"http://www.unittest2.dev/\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL
+        Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.349</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4784']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:42:00 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:00:27 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '6031'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest2&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
-        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524833\" Name=\"_acme-challenge.noop\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524158\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524837\"\
-        \ Name=\"delete.testid\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524214\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
-        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
-        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.976</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest2.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n      <host
+        HostId=\"746360\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746361\" Name=\"docs\" Type=\"CNAME\" Address=\"docs.example.com.\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746355\" Name=\"www\" Type=\"CNAME\"
+        Address=\"parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\"
+        FriendlyName=\"CNAME Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n
+        \     <host HostId=\"746365\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746366\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746372\" Name=\"_acme-challenge.deleterecordinset\"
+        Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746373\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746374\" Name=\"_acme-challenge.deleterecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746375\" Name=\"_acme-challenge.deleterecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746362\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746363\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746376\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746377\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746367\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746364\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746371\" Name=\"delete.testid\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746383\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746384\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"updated\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746381\" Name=\"orig.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746385\" Name=\"orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746387\" Name=\"orig.testfull\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746378\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746379\" Name=\"random.fulltest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746380\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746382\" Name=\"updated.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746386\" Name=\"updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746388\" Name=\"updated.testfull\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746354\" Name=\"@\" Type=\"URL\" Address=\"http://www.unittest2.dev/\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL
+        Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.463</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4784']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:42:01 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:00:28 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '6031'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'RecordType21=URL&HostId19=524171&RecordType20=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524833&HostId9=524158&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524831&HostId5=524832&HostId6=524156&HostId7=524157&HostId21=524160&HostId20=524173&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=CName+Record&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524166&HostId13=524170&HostId10=524168&HostId11=524214&HostId16=524164&HostId17=524165&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&HostName12=orig.test&HostName13=orig.testfqdn&HostName10=orig.nameonly.test&HostName11=orig.nameonly.test&HostName16=random.fulltest&HostName17=random.test&HostName14=orig.testfull&Address1=127.0.0.1&HostName18=updated.test&HostName19=updated.testfqdn&MXPref5=10&FriendlyName21=URL+Record&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=60&TTL7=60&TTL14=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&Address18=challengetoken&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.fqdn&HostName7=_acme-challenge.full&HostName8=_acme-challenge.noop&HostName9=_acme-challenge.test&Address10=challengetoken&Address11=updated&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName21=yyy&HostName20=updated.testfull&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=random.fqdntest&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise&MXPref4=10&TTL18=1800&Address21=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524172&AssociatedAppTitle19=&HostId15=524163&HostId18=524167'
+    body: HostId1=746360&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746361&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746355&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746365&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746366&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746372&Address6=challengetoken1&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.deleterecordinset&RecordType6=TXT&HostId7=746373&Address7=challengetoken2&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.deleterecordinset&RecordType7=TXT&HostId8=746374&Address8=challengetoken1&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.deleterecordset&RecordType8=TXT&HostId9=746375&Address9=challengetoken2&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.deleterecordset&RecordType9=TXT&HostId10=746362&Address10=challengetoken&MXPref10=10&TTL10=3600&AssociatedAppTitle10=&FriendlyName10=&IsActive10=true&IsDDNSEnabled10=false&HostName10=_acme-challenge.fqdn&RecordType10=TXT&HostId11=746363&Address11=challengetoken&MXPref11=10&TTL11=3600&AssociatedAppTitle11=&FriendlyName11=&IsActive11=true&IsDDNSEnabled11=false&HostName11=_acme-challenge.full&RecordType11=TXT&HostId12=746376&Address12=challengetoken1&MXPref12=10&TTL12=3600&AssociatedAppTitle12=&FriendlyName12=&IsActive12=true&IsDDNSEnabled12=false&HostName12=_acme-challenge.listrecordset&RecordType12=TXT&HostId13=746377&Address13=challengetoken2&MXPref13=10&TTL13=3600&AssociatedAppTitle13=&FriendlyName13=&IsActive13=true&IsDDNSEnabled13=false&HostName13=_acme-challenge.listrecordset&RecordType13=TXT&HostId14=746367&Address14=challengetoken&MXPref14=10&TTL14=3600&AssociatedAppTitle14=&FriendlyName14=&IsActive14=true&IsDDNSEnabled14=false&HostName14=_acme-challenge.noop&RecordType14=TXT&HostId15=746364&Address15=challengetoken&MXPref15=10&TTL15=3600&AssociatedAppTitle15=&FriendlyName15=&IsActive15=true&IsDDNSEnabled15=false&HostName15=_acme-challenge.test&RecordType15=TXT&HostId16=746383&Address16=challengetoken&MXPref16=10&TTL16=3600&AssociatedAppTitle16=&FriendlyName16=&IsActive16=true&IsDDNSEnabled16=false&HostName16=orig.nameonly.test&RecordType16=TXT&HostId17=746384&Address17=updated&MXPref17=10&TTL17=3600&AssociatedAppTitle17=&FriendlyName17=&IsActive17=true&IsDDNSEnabled17=false&HostName17=orig.nameonly.test&RecordType17=TXT&HostId18=746381&Address18=challengetoken&MXPref18=10&TTL18=3600&AssociatedAppTitle18=&FriendlyName18=&IsActive18=true&IsDDNSEnabled18=false&HostName18=orig.test&RecordType18=TXT&HostId19=746385&Address19=challengetoken&MXPref19=10&TTL19=3600&AssociatedAppTitle19=&FriendlyName19=&IsActive19=true&IsDDNSEnabled19=false&HostName19=orig.testfqdn&RecordType19=TXT&HostId20=746387&Address20=challengetoken&MXPref20=10&TTL20=3600&AssociatedAppTitle20=&FriendlyName20=&IsActive20=true&IsDDNSEnabled20=false&HostName20=orig.testfull&RecordType20=TXT&HostId21=746378&Address21=challengetoken&MXPref21=10&TTL21=3600&AssociatedAppTitle21=&FriendlyName21=&IsActive21=true&IsDDNSEnabled21=false&HostName21=random.fqdntest&RecordType21=TXT&HostId22=746379&Address22=challengetoken&MXPref22=10&TTL22=3600&AssociatedAppTitle22=&FriendlyName22=&IsActive22=true&IsDDNSEnabled22=false&HostName22=random.fulltest&RecordType22=TXT&HostId23=746380&Address23=challengetoken&MXPref23=10&TTL23=3600&AssociatedAppTitle23=&FriendlyName23=&IsActive23=true&IsDDNSEnabled23=false&HostName23=random.test&RecordType23=TXT&HostId24=746382&Address24=challengetoken&MXPref24=10&TTL24=3600&AssociatedAppTitle24=&FriendlyName24=&IsActive24=true&IsDDNSEnabled24=false&HostName24=updated.test&RecordType24=TXT&HostId25=746386&Address25=challengetoken&MXPref25=10&TTL25=3600&AssociatedAppTitle25=&FriendlyName25=&IsActive25=true&IsDDNSEnabled25=false&HostName25=updated.testfqdn&RecordType25=TXT&HostId26=746388&Address26=challengetoken&MXPref26=10&TTL26=3600&AssociatedAppTitle26=&FriendlyName26=&IsActive26=true&IsDDNSEnabled26=false&HostName26=updated.testfull&RecordType26=TXT&HostId27=746354&Address27=http%3A%2F%2Fwww.unittest2.dev%2F&MXPref27=10&TTL27=1800&AssociatedAppTitle27=URL+Forwarding&FriendlyName27=URL+Record&IsActive27=true&IsDDNSEnabled27=false&HostName27=%40&RecordType27=URL&SLD=unittest2&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['3861']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '5065'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.688</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest2.dev\" IsSuccess=\"true\">\r\n      <Warnings />\r\n    </DomainDNSSetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.905</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['559']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:42:02 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:00:30 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '557'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest2&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
-        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524833\" Name=\"_acme-challenge.noop\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524158\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\"\
-        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524214\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524166\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"\
-        orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524163\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\"\
-        \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524165\" Name=\"random.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524167\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524171\" Name=\"\
-        updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524160\" Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
-        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.956</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest2.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n      <host
+        HostId=\"746360\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746361\" Name=\"docs\" Type=\"CNAME\" Address=\"docs.example.com.\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746355\" Name=\"www\" Type=\"CNAME\"
+        Address=\"parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\"
+        FriendlyName=\"CNAME Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n
+        \     <host HostId=\"746365\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746366\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746372\" Name=\"_acme-challenge.deleterecordinset\"
+        Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746373\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746374\" Name=\"_acme-challenge.deleterecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746375\" Name=\"_acme-challenge.deleterecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746362\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746363\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746376\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746377\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746367\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746364\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746383\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746384\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746381\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746385\" Name=\"orig.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746387\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746378\" Name=\"random.fqdntest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746379\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746380\" Name=\"random.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746382\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746386\" Name=\"updated.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746388\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746354\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest2.dev/\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL
+        Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.159</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4596']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:42:03 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:00:31 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '5843'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/namecheap/IntegrationTests/test_provider_when_calling_delete_record_with_record_set_by_content_should_leave_others_untouched.yaml
+++ b/tests/fixtures/cassettes/namecheap/IntegrationTests/test_provider_when_calling_delete_record_with_record_set_by_content_should_leave_others_untouched.yaml
@@ -2,574 +2,754 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise.com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=unittest2.dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
-        \ Status=\"Ok\" ID=\"277432\" DomainName=\"example-aptise.com\" OwnerName=\"\
-        jvsandbox\" IsOwner=\"true\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
-        \n        <CreatedDate>03/25/2018</CreatedDate>\r\n        <ExpiredDate>03/25/2019</ExpiredDate>\r\
-        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
-        \ />\r\n      <Whoisguard Enabled=\"NotAlloted\">\r\n        <ID>0</ID>\r\n\
-        \      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
-        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
-        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
-        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
-        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"21\" EmailType=\"\
-        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
-        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
-        \n      <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.375</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult
+        Status=\"Ok\" ID=\"589667\" DomainName=\"unittest2.dev\" OwnerName=\"phassberg\"
+        IsOwner=\"true\" IsPremium=\"false\">\r\n      <DomainDetails>\r\n        <CreatedDate>05/20/2020</CreatedDate>\r\n
+        \       <ExpiredDate>05/20/2021</ExpiredDate>\r\n        <NumYears>0</NumYears>\r\n
+        \     </DomainDetails>\r\n      <LockDetails />\r\n      <Whoisguard Enabled=\"True\">\r\n
+        \       <ID>481121</ID>\r\n        <ExpiredDate>05/20/2021</ExpiredDate>\r\n
+        \       <EmailDetails WhoisGuardEmail=\"824017ccbed343119b3459c7d3304ba5.protect@whoisguard.com\"
+        ForwardedTo=\"dr.doddo@gmail.com\" LastAutoEmailChangeDate=\"05/20/2020\"
+        AutoEmailChangeFrequencyDays=\"3\" />\r\n      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n
+        \       <UseAutoRenew>false</UseAutoRenew>\r\n        <SubscriptionId>-1</SubscriptionId>\r\n
+        \       <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n
+        \       <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n
+        \     <DnsDetails ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"27\"
+        EmailType=\"FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\n
+        \       <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\n
+        \     <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.182</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['1493']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:42:05 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:00:31 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '1740'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest2&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
-        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524833\" Name=\"_acme-challenge.noop\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524158\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\"\
-        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524214\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524166\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"\
-        orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524163\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\"\
-        \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524165\" Name=\"random.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524167\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524171\" Name=\"\
-        updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524160\" Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
-        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.803</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest2.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n      <host
+        HostId=\"746360\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746361\" Name=\"docs\" Type=\"CNAME\" Address=\"docs.example.com.\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746355\" Name=\"www\" Type=\"CNAME\"
+        Address=\"parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\"
+        FriendlyName=\"CNAME Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n
+        \     <host HostId=\"746365\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746366\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746372\" Name=\"_acme-challenge.deleterecordinset\"
+        Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746373\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746374\" Name=\"_acme-challenge.deleterecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746375\" Name=\"_acme-challenge.deleterecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746362\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746363\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746376\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746377\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746367\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746364\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746383\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746384\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746381\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746385\" Name=\"orig.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746387\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746378\" Name=\"random.fqdntest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746379\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746380\" Name=\"random.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746382\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746386\" Name=\"updated.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746388\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746354\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest2.dev/\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL
+        Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.308</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4596']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:42:06 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:00:33 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '5843'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'RecordType21=URL&HostId19=524171&RecordType20=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524833&HostId9=524158&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524831&HostId5=524832&HostId6=524156&HostId7=524157&HostId21=524160&HostId20=524173&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=CName+Record&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524166&HostId13=524170&HostId10=524168&HostId11=524214&HostId16=524164&HostId17=524165&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken1&HostName12=orig.test&HostName13=orig.testfqdn&HostName10=orig.nameonly.test&HostName11=orig.nameonly.test&HostName16=random.fulltest&HostName17=random.test&HostName14=orig.testfull&Address1=127.0.0.1&HostName18=updated.test&HostName19=updated.testfqdn&MXPref5=10&FriendlyName21=URL+Record&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=60&TTL7=60&TTL14=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&Address18=challengetoken&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.fqdn&HostName7=_acme-challenge.full&HostName8=_acme-challenge.noop&HostName9=_acme-challenge.test&Address10=challengetoken&Address11=updated&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName22=_acme-challenge.deleterecordinset&HostName21=yyy&HostName20=updated.testfull&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=random.fqdntest&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise&MXPref4=10&TTL18=1800&Address21=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524172&AssociatedAppTitle19=&HostId15=524163&HostId18=524167'
+    body: HostId1=746360&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746361&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746355&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746365&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746366&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746372&Address6=challengetoken1&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.deleterecordinset&RecordType6=TXT&HostId7=746373&Address7=challengetoken2&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.deleterecordinset&RecordType7=TXT&HostId8=746374&Address8=challengetoken1&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.deleterecordset&RecordType8=TXT&HostId9=746375&Address9=challengetoken2&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.deleterecordset&RecordType9=TXT&HostId10=746362&Address10=challengetoken&MXPref10=10&TTL10=3600&AssociatedAppTitle10=&FriendlyName10=&IsActive10=true&IsDDNSEnabled10=false&HostName10=_acme-challenge.fqdn&RecordType10=TXT&HostId11=746363&Address11=challengetoken&MXPref11=10&TTL11=3600&AssociatedAppTitle11=&FriendlyName11=&IsActive11=true&IsDDNSEnabled11=false&HostName11=_acme-challenge.full&RecordType11=TXT&HostId12=746376&Address12=challengetoken1&MXPref12=10&TTL12=3600&AssociatedAppTitle12=&FriendlyName12=&IsActive12=true&IsDDNSEnabled12=false&HostName12=_acme-challenge.listrecordset&RecordType12=TXT&HostId13=746377&Address13=challengetoken2&MXPref13=10&TTL13=3600&AssociatedAppTitle13=&FriendlyName13=&IsActive13=true&IsDDNSEnabled13=false&HostName13=_acme-challenge.listrecordset&RecordType13=TXT&HostId14=746367&Address14=challengetoken&MXPref14=10&TTL14=3600&AssociatedAppTitle14=&FriendlyName14=&IsActive14=true&IsDDNSEnabled14=false&HostName14=_acme-challenge.noop&RecordType14=TXT&HostId15=746364&Address15=challengetoken&MXPref15=10&TTL15=3600&AssociatedAppTitle15=&FriendlyName15=&IsActive15=true&IsDDNSEnabled15=false&HostName15=_acme-challenge.test&RecordType15=TXT&HostId16=746383&Address16=challengetoken&MXPref16=10&TTL16=3600&AssociatedAppTitle16=&FriendlyName16=&IsActive16=true&IsDDNSEnabled16=false&HostName16=orig.nameonly.test&RecordType16=TXT&HostId17=746384&Address17=updated&MXPref17=10&TTL17=3600&AssociatedAppTitle17=&FriendlyName17=&IsActive17=true&IsDDNSEnabled17=false&HostName17=orig.nameonly.test&RecordType17=TXT&HostId18=746381&Address18=challengetoken&MXPref18=10&TTL18=3600&AssociatedAppTitle18=&FriendlyName18=&IsActive18=true&IsDDNSEnabled18=false&HostName18=orig.test&RecordType18=TXT&HostId19=746385&Address19=challengetoken&MXPref19=10&TTL19=3600&AssociatedAppTitle19=&FriendlyName19=&IsActive19=true&IsDDNSEnabled19=false&HostName19=orig.testfqdn&RecordType19=TXT&HostId20=746387&Address20=challengetoken&MXPref20=10&TTL20=3600&AssociatedAppTitle20=&FriendlyName20=&IsActive20=true&IsDDNSEnabled20=false&HostName20=orig.testfull&RecordType20=TXT&HostId21=746378&Address21=challengetoken&MXPref21=10&TTL21=3600&AssociatedAppTitle21=&FriendlyName21=&IsActive21=true&IsDDNSEnabled21=false&HostName21=random.fqdntest&RecordType21=TXT&HostId22=746379&Address22=challengetoken&MXPref22=10&TTL22=3600&AssociatedAppTitle22=&FriendlyName22=&IsActive22=true&IsDDNSEnabled22=false&HostName22=random.fulltest&RecordType22=TXT&HostId23=746380&Address23=challengetoken&MXPref23=10&TTL23=3600&AssociatedAppTitle23=&FriendlyName23=&IsActive23=true&IsDDNSEnabled23=false&HostName23=random.test&RecordType23=TXT&HostId24=746382&Address24=challengetoken&MXPref24=10&TTL24=3600&AssociatedAppTitle24=&FriendlyName24=&IsActive24=true&IsDDNSEnabled24=false&HostName24=updated.test&RecordType24=TXT&HostId25=746386&Address25=challengetoken&MXPref25=10&TTL25=3600&AssociatedAppTitle25=&FriendlyName25=&IsActive25=true&IsDDNSEnabled25=false&HostName25=updated.testfqdn&RecordType25=TXT&HostId26=746388&Address26=challengetoken&MXPref26=10&TTL26=3600&AssociatedAppTitle26=&FriendlyName26=&IsActive26=true&IsDDNSEnabled26=false&HostName26=updated.testfull&RecordType26=TXT&HostId27=746354&Address27=http%3A%2F%2Fwww.unittest2.dev%2F&MXPref27=10&TTL27=1800&AssociatedAppTitle27=URL+Forwarding&FriendlyName27=URL+Record&IsActive27=true&IsDDNSEnabled27=false&HostName27=%40&RecordType27=URL&Address28=challengetoken1&TTL28=3600&HostName28=_acme-challenge.deleterecordinset&RecordType28=TXT&SLD=unittest2&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['3949']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '5164'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>1.141</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest2.dev\" IsSuccess=\"true\">\r\n      <Warnings />\r\n    </DomainDNSSetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.896</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['559']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:42:07 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:00:35 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '557'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest2&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524838\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
-        TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
-        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524833\" Name=\"_acme-challenge.noop\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524158\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\"\
-        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524214\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524166\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"\
-        orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524163\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\"\
-        \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524165\" Name=\"random.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524167\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524171\" Name=\"\
-        updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524160\" Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
-        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.744</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest2.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n      <host
+        HostId=\"746360\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746361\" Name=\"docs\" Type=\"CNAME\" Address=\"docs.example.com.\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746355\" Name=\"www\" Type=\"CNAME\"
+        Address=\"parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\"
+        FriendlyName=\"CNAME Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n
+        \     <host HostId=\"746365\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746366\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746372\" Name=\"_acme-challenge.deleterecordinset\"
+        Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746373\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746374\" Name=\"_acme-challenge.deleterecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746375\" Name=\"_acme-challenge.deleterecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746362\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746363\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746376\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746377\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746367\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746364\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746383\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746384\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746381\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746385\" Name=\"orig.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746387\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746378\" Name=\"random.fqdntest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746379\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746380\" Name=\"random.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746382\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746386\" Name=\"updated.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746388\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746354\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest2.dev/\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL
+        Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.475</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4805']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:42:08 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:00:36 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '5843'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'RecordType21=TXT&HostId19=524167&RecordType20=TXT&RecordType23=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524157&HostId9=524833&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524831&HostId5=524832&HostId6=524838&HostId7=524156&IsDDNSEnabled22=false&HostId22=524160&HostId21=524173&HostId20=524171&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=CName+Record&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524214&HostId13=524166&HostId10=524158&HostId11=524168&HostId16=524163&HostId17=524164&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=URL&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=URL+Record&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&HostName12=orig.nameonly.test&HostName13=orig.test&HostName10=_acme-challenge.test&HostName11=orig.nameonly.test&HostName16=random.fqdntest&HostName17=random.fulltest&HostName14=orig.testfqdn&Address1=127.0.0.1&HostName18=random.test&HostName19=updated.test&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=60&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=60&TTL14=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=updated&AssociatedAppTitle22=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.noop&Address10=challengetoken&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName23=_acme-challenge.deleterecordinset&HostName22=yyy&HostName21=updated.testfull&HostName20=updated.testfqdn&TTL10=1800&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.testfull&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken1&SLD=example-aptise&MXPref4=10&Address23=challengetoken2&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524170&AssociatedAppTitle19=&HostId15=524172&HostId18=524165'
+    body: HostId1=746360&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746361&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746355&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746365&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746366&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746372&Address6=challengetoken1&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.deleterecordinset&RecordType6=TXT&HostId7=746373&Address7=challengetoken2&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.deleterecordinset&RecordType7=TXT&HostId8=746374&Address8=challengetoken1&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.deleterecordset&RecordType8=TXT&HostId9=746375&Address9=challengetoken2&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.deleterecordset&RecordType9=TXT&HostId10=746362&Address10=challengetoken&MXPref10=10&TTL10=3600&AssociatedAppTitle10=&FriendlyName10=&IsActive10=true&IsDDNSEnabled10=false&HostName10=_acme-challenge.fqdn&RecordType10=TXT&HostId11=746363&Address11=challengetoken&MXPref11=10&TTL11=3600&AssociatedAppTitle11=&FriendlyName11=&IsActive11=true&IsDDNSEnabled11=false&HostName11=_acme-challenge.full&RecordType11=TXT&HostId12=746376&Address12=challengetoken1&MXPref12=10&TTL12=3600&AssociatedAppTitle12=&FriendlyName12=&IsActive12=true&IsDDNSEnabled12=false&HostName12=_acme-challenge.listrecordset&RecordType12=TXT&HostId13=746377&Address13=challengetoken2&MXPref13=10&TTL13=3600&AssociatedAppTitle13=&FriendlyName13=&IsActive13=true&IsDDNSEnabled13=false&HostName13=_acme-challenge.listrecordset&RecordType13=TXT&HostId14=746367&Address14=challengetoken&MXPref14=10&TTL14=3600&AssociatedAppTitle14=&FriendlyName14=&IsActive14=true&IsDDNSEnabled14=false&HostName14=_acme-challenge.noop&RecordType14=TXT&HostId15=746364&Address15=challengetoken&MXPref15=10&TTL15=3600&AssociatedAppTitle15=&FriendlyName15=&IsActive15=true&IsDDNSEnabled15=false&HostName15=_acme-challenge.test&RecordType15=TXT&HostId16=746383&Address16=challengetoken&MXPref16=10&TTL16=3600&AssociatedAppTitle16=&FriendlyName16=&IsActive16=true&IsDDNSEnabled16=false&HostName16=orig.nameonly.test&RecordType16=TXT&HostId17=746384&Address17=updated&MXPref17=10&TTL17=3600&AssociatedAppTitle17=&FriendlyName17=&IsActive17=true&IsDDNSEnabled17=false&HostName17=orig.nameonly.test&RecordType17=TXT&HostId18=746381&Address18=challengetoken&MXPref18=10&TTL18=3600&AssociatedAppTitle18=&FriendlyName18=&IsActive18=true&IsDDNSEnabled18=false&HostName18=orig.test&RecordType18=TXT&HostId19=746385&Address19=challengetoken&MXPref19=10&TTL19=3600&AssociatedAppTitle19=&FriendlyName19=&IsActive19=true&IsDDNSEnabled19=false&HostName19=orig.testfqdn&RecordType19=TXT&HostId20=746387&Address20=challengetoken&MXPref20=10&TTL20=3600&AssociatedAppTitle20=&FriendlyName20=&IsActive20=true&IsDDNSEnabled20=false&HostName20=orig.testfull&RecordType20=TXT&HostId21=746378&Address21=challengetoken&MXPref21=10&TTL21=3600&AssociatedAppTitle21=&FriendlyName21=&IsActive21=true&IsDDNSEnabled21=false&HostName21=random.fqdntest&RecordType21=TXT&HostId22=746379&Address22=challengetoken&MXPref22=10&TTL22=3600&AssociatedAppTitle22=&FriendlyName22=&IsActive22=true&IsDDNSEnabled22=false&HostName22=random.fulltest&RecordType22=TXT&HostId23=746380&Address23=challengetoken&MXPref23=10&TTL23=3600&AssociatedAppTitle23=&FriendlyName23=&IsActive23=true&IsDDNSEnabled23=false&HostName23=random.test&RecordType23=TXT&HostId24=746382&Address24=challengetoken&MXPref24=10&TTL24=3600&AssociatedAppTitle24=&FriendlyName24=&IsActive24=true&IsDDNSEnabled24=false&HostName24=updated.test&RecordType24=TXT&HostId25=746386&Address25=challengetoken&MXPref25=10&TTL25=3600&AssociatedAppTitle25=&FriendlyName25=&IsActive25=true&IsDDNSEnabled25=false&HostName25=updated.testfqdn&RecordType25=TXT&HostId26=746388&Address26=challengetoken&MXPref26=10&TTL26=3600&AssociatedAppTitle26=&FriendlyName26=&IsActive26=true&IsDDNSEnabled26=false&HostName26=updated.testfull&RecordType26=TXT&HostId27=746354&Address27=http%3A%2F%2Fwww.unittest2.dev%2F&MXPref27=10&TTL27=1800&AssociatedAppTitle27=URL+Forwarding&FriendlyName27=URL+Record&IsActive27=true&IsDDNSEnabled27=false&HostName27=%40&RecordType27=URL&Address28=challengetoken2&TTL28=3600&HostName28=_acme-challenge.deleterecordinset&RecordType28=TXT&SLD=unittest2&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['4152']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '5164'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.802</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest2.dev\" IsSuccess=\"true\">\r\n      <Warnings />\r\n    </DomainDNSSetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>1.194</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['559']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:42:10 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:00:39 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '557'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest2&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524838\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
-        TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
-        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524833\" Name=\"_acme-challenge.noop\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524158\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\"\
-        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524214\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524166\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"\
-        orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524163\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\"\
-        \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524165\" Name=\"random.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524167\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524171\" Name=\"\
-        updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524160\" Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
-        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>1.175</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest2.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n      <host
+        HostId=\"746360\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746361\" Name=\"docs\" Type=\"CNAME\" Address=\"docs.example.com.\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746355\" Name=\"www\" Type=\"CNAME\"
+        Address=\"parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\"
+        FriendlyName=\"CNAME Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n
+        \     <host HostId=\"746365\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746366\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746372\" Name=\"_acme-challenge.deleterecordinset\"
+        Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746373\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746374\" Name=\"_acme-challenge.deleterecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746375\" Name=\"_acme-challenge.deleterecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746362\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746363\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746376\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746377\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746367\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746364\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746383\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746384\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746381\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746385\" Name=\"orig.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746387\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746378\" Name=\"random.fqdntest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746379\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746380\" Name=\"random.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746382\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746386\" Name=\"updated.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746388\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746354\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest2.dev/\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL
+        Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.377</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['5014']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:42:11 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:00:40 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '5843'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest2&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524838\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
-        TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
-        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524833\" Name=\"_acme-challenge.noop\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524158\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\"\
-        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524214\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524166\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"\
-        orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524163\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\"\
-        \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524165\" Name=\"random.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524167\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524171\" Name=\"\
-        updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524160\" Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
-        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>1.179</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest2.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n      <host
+        HostId=\"746360\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746361\" Name=\"docs\" Type=\"CNAME\" Address=\"docs.example.com.\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746355\" Name=\"www\" Type=\"CNAME\"
+        Address=\"parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\"
+        FriendlyName=\"CNAME Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n
+        \     <host HostId=\"746365\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746366\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746372\" Name=\"_acme-challenge.deleterecordinset\"
+        Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746373\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746374\" Name=\"_acme-challenge.deleterecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746375\" Name=\"_acme-challenge.deleterecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746362\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746363\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746376\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746377\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746367\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746364\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746383\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746384\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746381\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746385\" Name=\"orig.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746387\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746378\" Name=\"random.fqdntest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746379\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746380\" Name=\"random.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746382\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746386\" Name=\"updated.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746388\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746354\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest2.dev/\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL
+        Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.311</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['5014']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:42:13 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:00:41 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '5843'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'RecordType21=TXT&HostId19=524167&RecordType20=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524157&HostId9=524833&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524831&HostId5=524832&HostId6=524839&HostId7=524156&IsDDNSEnabled22=false&HostId22=524160&HostId21=524173&HostId20=524171&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=CName+Record&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524214&HostId13=524166&HostId10=524158&HostId11=524168&HostId16=524163&HostId17=524164&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=URL&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=URL+Record&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&HostName12=orig.nameonly.test&HostName13=orig.test&HostName10=_acme-challenge.test&HostName11=orig.nameonly.test&HostName16=random.fqdntest&HostName17=random.fulltest&HostName14=orig.testfqdn&Address1=127.0.0.1&HostName18=random.test&HostName19=updated.test&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=60&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=60&TTL14=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=updated&AssociatedAppTitle22=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.noop&Address10=challengetoken&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName22=yyy&HostName21=updated.testfull&HostName20=updated.testfqdn&TTL10=1800&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.testfull&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&SLD=example-aptise&MXPref4=10&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524170&AssociatedAppTitle19=&HostId15=524172&HostId18=524165'
+    body: HostId1=746360&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746361&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746355&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746365&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746366&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746373&Address6=challengetoken2&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.deleterecordinset&RecordType6=TXT&HostId7=746374&Address7=challengetoken1&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.deleterecordset&RecordType7=TXT&HostId8=746375&Address8=challengetoken2&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.deleterecordset&RecordType8=TXT&HostId9=746362&Address9=challengetoken&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.fqdn&RecordType9=TXT&HostId10=746363&Address10=challengetoken&MXPref10=10&TTL10=3600&AssociatedAppTitle10=&FriendlyName10=&IsActive10=true&IsDDNSEnabled10=false&HostName10=_acme-challenge.full&RecordType10=TXT&HostId11=746376&Address11=challengetoken1&MXPref11=10&TTL11=3600&AssociatedAppTitle11=&FriendlyName11=&IsActive11=true&IsDDNSEnabled11=false&HostName11=_acme-challenge.listrecordset&RecordType11=TXT&HostId12=746377&Address12=challengetoken2&MXPref12=10&TTL12=3600&AssociatedAppTitle12=&FriendlyName12=&IsActive12=true&IsDDNSEnabled12=false&HostName12=_acme-challenge.listrecordset&RecordType12=TXT&HostId13=746367&Address13=challengetoken&MXPref13=10&TTL13=3600&AssociatedAppTitle13=&FriendlyName13=&IsActive13=true&IsDDNSEnabled13=false&HostName13=_acme-challenge.noop&RecordType13=TXT&HostId14=746364&Address14=challengetoken&MXPref14=10&TTL14=3600&AssociatedAppTitle14=&FriendlyName14=&IsActive14=true&IsDDNSEnabled14=false&HostName14=_acme-challenge.test&RecordType14=TXT&HostId15=746383&Address15=challengetoken&MXPref15=10&TTL15=3600&AssociatedAppTitle15=&FriendlyName15=&IsActive15=true&IsDDNSEnabled15=false&HostName15=orig.nameonly.test&RecordType15=TXT&HostId16=746384&Address16=updated&MXPref16=10&TTL16=3600&AssociatedAppTitle16=&FriendlyName16=&IsActive16=true&IsDDNSEnabled16=false&HostName16=orig.nameonly.test&RecordType16=TXT&HostId17=746381&Address17=challengetoken&MXPref17=10&TTL17=3600&AssociatedAppTitle17=&FriendlyName17=&IsActive17=true&IsDDNSEnabled17=false&HostName17=orig.test&RecordType17=TXT&HostId18=746385&Address18=challengetoken&MXPref18=10&TTL18=3600&AssociatedAppTitle18=&FriendlyName18=&IsActive18=true&IsDDNSEnabled18=false&HostName18=orig.testfqdn&RecordType18=TXT&HostId19=746387&Address19=challengetoken&MXPref19=10&TTL19=3600&AssociatedAppTitle19=&FriendlyName19=&IsActive19=true&IsDDNSEnabled19=false&HostName19=orig.testfull&RecordType19=TXT&HostId20=746378&Address20=challengetoken&MXPref20=10&TTL20=3600&AssociatedAppTitle20=&FriendlyName20=&IsActive20=true&IsDDNSEnabled20=false&HostName20=random.fqdntest&RecordType20=TXT&HostId21=746379&Address21=challengetoken&MXPref21=10&TTL21=3600&AssociatedAppTitle21=&FriendlyName21=&IsActive21=true&IsDDNSEnabled21=false&HostName21=random.fulltest&RecordType21=TXT&HostId22=746380&Address22=challengetoken&MXPref22=10&TTL22=3600&AssociatedAppTitle22=&FriendlyName22=&IsActive22=true&IsDDNSEnabled22=false&HostName22=random.test&RecordType22=TXT&HostId23=746382&Address23=challengetoken&MXPref23=10&TTL23=3600&AssociatedAppTitle23=&FriendlyName23=&IsActive23=true&IsDDNSEnabled23=false&HostName23=updated.test&RecordType23=TXT&HostId24=746386&Address24=challengetoken&MXPref24=10&TTL24=3600&AssociatedAppTitle24=&FriendlyName24=&IsActive24=true&IsDDNSEnabled24=false&HostName24=updated.testfqdn&RecordType24=TXT&HostId25=746388&Address25=challengetoken&MXPref25=10&TTL25=3600&AssociatedAppTitle25=&FriendlyName25=&IsActive25=true&IsDDNSEnabled25=false&HostName25=updated.testfull&RecordType25=TXT&HostId26=746354&Address26=http%3A%2F%2Fwww.unittest2.dev%2F&MXPref26=10&TTL26=1800&AssociatedAppTitle26=URL+Forwarding&FriendlyName26=URL+Record&IsActive26=true&IsDDNSEnabled26=false&HostName26=%40&RecordType26=URL&SLD=unittest2&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['4064']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '4862'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.816</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest2.dev\" IsSuccess=\"true\">\r\n      <Warnings />\r\n    </DomainDNSSetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.91</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['559']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:42:14 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:00:42 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '556'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest2&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
-        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524833\" Name=\"_acme-challenge.noop\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524158\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\"\
-        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524214\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524166\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"\
-        orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524163\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\"\
-        \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524165\" Name=\"random.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524167\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524171\" Name=\"\
-        updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524160\" Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
-        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>1.122</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest2.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n      <host
+        HostId=\"746360\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746361\" Name=\"docs\" Type=\"CNAME\" Address=\"docs.example.com.\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746355\" Name=\"www\" Type=\"CNAME\"
+        Address=\"parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\"
+        FriendlyName=\"CNAME Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n
+        \     <host HostId=\"746365\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746366\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746373\" Name=\"_acme-challenge.deleterecordinset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746374\" Name=\"_acme-challenge.deleterecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746375\" Name=\"_acme-challenge.deleterecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746362\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746363\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746376\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746377\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746367\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746364\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746383\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746384\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746381\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746385\" Name=\"orig.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746387\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746378\" Name=\"random.fqdntest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746379\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746380\" Name=\"random.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746382\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746386\" Name=\"updated.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746388\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746354\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest2.dev/\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL
+        Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>1.087</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4805']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:42:15 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:00:45 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '5634'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/namecheap/IntegrationTests/test_provider_when_calling_delete_record_with_record_set_name_remove_all.yaml
+++ b/tests/fixtures/cassettes/namecheap/IntegrationTests/test_provider_when_calling_delete_record_with_record_set_name_remove_all.yaml
@@ -2,707 +2,890 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise.com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=unittest2.dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
-        \ Status=\"Ok\" ID=\"277432\" DomainName=\"example-aptise.com\" OwnerName=\"\
-        jvsandbox\" IsOwner=\"true\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
-        \n        <CreatedDate>03/25/2018</CreatedDate>\r\n        <ExpiredDate>03/25/2019</ExpiredDate>\r\
-        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
-        \ />\r\n      <Whoisguard Enabled=\"NotAlloted\">\r\n        <ID>0</ID>\r\n\
-        \      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
-        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
-        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
-        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
-        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"22\" EmailType=\"\
-        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
-        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
-        \n      <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.309</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult
+        Status=\"Ok\" ID=\"589667\" DomainName=\"unittest2.dev\" OwnerName=\"phassberg\"
+        IsOwner=\"true\" IsPremium=\"false\">\r\n      <DomainDetails>\r\n        <CreatedDate>05/20/2020</CreatedDate>\r\n
+        \       <ExpiredDate>05/20/2021</ExpiredDate>\r\n        <NumYears>0</NumYears>\r\n
+        \     </DomainDetails>\r\n      <LockDetails />\r\n      <Whoisguard Enabled=\"True\">\r\n
+        \       <ID>481121</ID>\r\n        <ExpiredDate>05/20/2021</ExpiredDate>\r\n
+        \       <EmailDetails WhoisGuardEmail=\"824017ccbed343119b3459c7d3304ba5.protect@whoisguard.com\"
+        ForwardedTo=\"dr.doddo@gmail.com\" LastAutoEmailChangeDate=\"05/20/2020\"
+        AutoEmailChangeFrequencyDays=\"3\" />\r\n      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n
+        \       <UseAutoRenew>false</UseAutoRenew>\r\n        <SubscriptionId>-1</SubscriptionId>\r\n
+        \       <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n
+        \       <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n
+        \     <DnsDetails ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"26\"
+        EmailType=\"FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\n
+        \       <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\n
+        \     <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.182</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['1493']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:42:17 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:00:46 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '1740'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest2&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
-        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524833\" Name=\"_acme-challenge.noop\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524158\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\"\
-        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524214\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524166\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"\
-        orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524163\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\"\
-        \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524165\" Name=\"random.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524167\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524171\" Name=\"\
-        updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524160\" Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
-        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.916</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest2.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n      <host
+        HostId=\"746360\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746361\" Name=\"docs\" Type=\"CNAME\" Address=\"docs.example.com.\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746355\" Name=\"www\" Type=\"CNAME\"
+        Address=\"parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\"
+        FriendlyName=\"CNAME Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n
+        \     <host HostId=\"746365\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746366\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746373\" Name=\"_acme-challenge.deleterecordinset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746374\" Name=\"_acme-challenge.deleterecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746375\" Name=\"_acme-challenge.deleterecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746362\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746363\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746376\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746377\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746367\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746364\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746383\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746384\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746381\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746385\" Name=\"orig.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746387\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746378\" Name=\"random.fqdntest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746379\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746380\" Name=\"random.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746382\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746386\" Name=\"updated.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746388\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746354\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest2.dev/\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL
+        Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.401</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4805']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:42:19 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:00:47 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '5634'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'RecordType21=TXT&HostId19=524167&RecordType20=TXT&RecordType23=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524157&HostId9=524833&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524831&HostId5=524832&HostId6=524839&HostId7=524156&IsDDNSEnabled22=false&HostId22=524160&HostId21=524173&HostId20=524171&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=CName+Record&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524214&HostId13=524166&HostId10=524158&HostId11=524168&HostId16=524163&HostId17=524164&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=URL&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=URL+Record&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&HostName12=orig.nameonly.test&HostName13=orig.test&HostName10=_acme-challenge.test&HostName11=orig.nameonly.test&HostName16=random.fqdntest&HostName17=random.fulltest&HostName14=orig.testfqdn&Address1=127.0.0.1&HostName18=random.test&HostName19=updated.test&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=60&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=60&TTL14=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=updated&AssociatedAppTitle22=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.noop&Address10=challengetoken&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName23=_acme-challenge.deleterecordset&HostName22=yyy&HostName21=updated.testfull&HostName20=updated.testfqdn&TTL10=1800&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.testfull&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&SLD=example-aptise&MXPref4=10&Address23=challengetoken1&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524170&AssociatedAppTitle19=&HostId15=524172&HostId18=524165'
+    body: HostId1=746360&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746361&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746355&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746365&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746366&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746373&Address6=challengetoken2&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.deleterecordinset&RecordType6=TXT&HostId7=746374&Address7=challengetoken1&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.deleterecordset&RecordType7=TXT&HostId8=746375&Address8=challengetoken2&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.deleterecordset&RecordType8=TXT&HostId9=746362&Address9=challengetoken&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.fqdn&RecordType9=TXT&HostId10=746363&Address10=challengetoken&MXPref10=10&TTL10=3600&AssociatedAppTitle10=&FriendlyName10=&IsActive10=true&IsDDNSEnabled10=false&HostName10=_acme-challenge.full&RecordType10=TXT&HostId11=746376&Address11=challengetoken1&MXPref11=10&TTL11=3600&AssociatedAppTitle11=&FriendlyName11=&IsActive11=true&IsDDNSEnabled11=false&HostName11=_acme-challenge.listrecordset&RecordType11=TXT&HostId12=746377&Address12=challengetoken2&MXPref12=10&TTL12=3600&AssociatedAppTitle12=&FriendlyName12=&IsActive12=true&IsDDNSEnabled12=false&HostName12=_acme-challenge.listrecordset&RecordType12=TXT&HostId13=746367&Address13=challengetoken&MXPref13=10&TTL13=3600&AssociatedAppTitle13=&FriendlyName13=&IsActive13=true&IsDDNSEnabled13=false&HostName13=_acme-challenge.noop&RecordType13=TXT&HostId14=746364&Address14=challengetoken&MXPref14=10&TTL14=3600&AssociatedAppTitle14=&FriendlyName14=&IsActive14=true&IsDDNSEnabled14=false&HostName14=_acme-challenge.test&RecordType14=TXT&HostId15=746383&Address15=challengetoken&MXPref15=10&TTL15=3600&AssociatedAppTitle15=&FriendlyName15=&IsActive15=true&IsDDNSEnabled15=false&HostName15=orig.nameonly.test&RecordType15=TXT&HostId16=746384&Address16=updated&MXPref16=10&TTL16=3600&AssociatedAppTitle16=&FriendlyName16=&IsActive16=true&IsDDNSEnabled16=false&HostName16=orig.nameonly.test&RecordType16=TXT&HostId17=746381&Address17=challengetoken&MXPref17=10&TTL17=3600&AssociatedAppTitle17=&FriendlyName17=&IsActive17=true&IsDDNSEnabled17=false&HostName17=orig.test&RecordType17=TXT&HostId18=746385&Address18=challengetoken&MXPref18=10&TTL18=3600&AssociatedAppTitle18=&FriendlyName18=&IsActive18=true&IsDDNSEnabled18=false&HostName18=orig.testfqdn&RecordType18=TXT&HostId19=746387&Address19=challengetoken&MXPref19=10&TTL19=3600&AssociatedAppTitle19=&FriendlyName19=&IsActive19=true&IsDDNSEnabled19=false&HostName19=orig.testfull&RecordType19=TXT&HostId20=746378&Address20=challengetoken&MXPref20=10&TTL20=3600&AssociatedAppTitle20=&FriendlyName20=&IsActive20=true&IsDDNSEnabled20=false&HostName20=random.fqdntest&RecordType20=TXT&HostId21=746379&Address21=challengetoken&MXPref21=10&TTL21=3600&AssociatedAppTitle21=&FriendlyName21=&IsActive21=true&IsDDNSEnabled21=false&HostName21=random.fulltest&RecordType21=TXT&HostId22=746380&Address22=challengetoken&MXPref22=10&TTL22=3600&AssociatedAppTitle22=&FriendlyName22=&IsActive22=true&IsDDNSEnabled22=false&HostName22=random.test&RecordType22=TXT&HostId23=746382&Address23=challengetoken&MXPref23=10&TTL23=3600&AssociatedAppTitle23=&FriendlyName23=&IsActive23=true&IsDDNSEnabled23=false&HostName23=updated.test&RecordType23=TXT&HostId24=746386&Address24=challengetoken&MXPref24=10&TTL24=3600&AssociatedAppTitle24=&FriendlyName24=&IsActive24=true&IsDDNSEnabled24=false&HostName24=updated.testfqdn&RecordType24=TXT&HostId25=746388&Address25=challengetoken&MXPref25=10&TTL25=3600&AssociatedAppTitle25=&FriendlyName25=&IsActive25=true&IsDDNSEnabled25=false&HostName25=updated.testfull&RecordType25=TXT&HostId26=746354&Address26=http%3A%2F%2Fwww.unittest2.dev%2F&MXPref26=10&TTL26=1800&AssociatedAppTitle26=URL+Forwarding&FriendlyName26=URL+Record&IsActive26=true&IsDDNSEnabled26=false&HostName26=%40&RecordType26=URL&Address27=challengetoken1&TTL27=3600&HostName27=_acme-challenge.deleterecordset&RecordType27=TXT&SLD=unittest2&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['4150']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '4959'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.896</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest2.dev\" IsSuccess=\"true\">\r\n      <Warnings />\r\n    </DomainDNSSetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.77</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['559']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:42:20 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:00:49 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '556'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest2&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524840\" Name=\"_acme-challenge.deleterecordset\" Type=\"\
-        TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
-        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524833\" Name=\"_acme-challenge.noop\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524158\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\"\
-        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524214\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524166\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"\
-        orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524163\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\"\
-        \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524165\" Name=\"random.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524167\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524171\" Name=\"\
-        updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524160\" Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
-        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.829</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest2.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n      <host
+        HostId=\"746360\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746361\" Name=\"docs\" Type=\"CNAME\" Address=\"docs.example.com.\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746355\" Name=\"www\" Type=\"CNAME\"
+        Address=\"parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\"
+        FriendlyName=\"CNAME Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n
+        \     <host HostId=\"746365\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746366\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746373\" Name=\"_acme-challenge.deleterecordinset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746374\" Name=\"_acme-challenge.deleterecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746375\" Name=\"_acme-challenge.deleterecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746362\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746363\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746376\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746377\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746367\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746364\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746383\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746384\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746381\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746385\" Name=\"orig.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746387\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746378\" Name=\"random.fqdntest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746379\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746380\" Name=\"random.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746382\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746386\" Name=\"updated.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746388\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746354\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest2.dev/\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL
+        Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.437</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['5012']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:42:21 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:00:50 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '5634'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'RecordType21=TXT&HostId19=524165&RecordType20=TXT&RecordType23=URL&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&IsDDNSEnabled23=false&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524156&HostId9=524157&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524831&HostId5=524832&HostId6=524839&HostId7=524840&IsDDNSEnabled22=false&MXPref23=10&HostId23=524160&HostId22=524173&HostId21=524171&HostId20=524167&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=CName+Record&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524168&HostId13=524214&HostId10=524833&HostId11=524158&HostId16=524172&HostId17=524163&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=&FriendlyName23=URL+Record&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&AssociatedAppTitle23=&HostName12=orig.nameonly.test&HostName13=orig.nameonly.test&HostName10=_acme-challenge.noop&HostName11=_acme-challenge.test&HostName16=orig.testfull&HostName17=random.fqdntest&HostName14=orig.test&Address1=127.0.0.1&HostName18=random.fulltest&HostName19=random.test&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken1&TTL8=60&TTL9=60&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&RecordType24=TXT&TTL23=1800&Address13=updated&TTL21=1800&TTL20=1800&HostName24=_acme-challenge.deleterecordset&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&AssociatedAppTitle22=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.deleterecordset&HostName8=_acme-challenge.fqdn&HostName9=_acme-challenge.full&Address10=challengetoken&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName23=yyy&HostName22=updated.testfull&HostName21=updated.testfqdn&HostName20=updated.test&TTL10=1800&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&IsActive23=true&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.testfqdn&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&SLD=example-aptise&MXPref4=10&Address24=challengetoken2&Address23=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524166&AssociatedAppTitle19=&HostId15=524170&HostId18=524164'
+    body: HostId1=746360&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746361&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746355&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746365&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746366&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746373&Address6=challengetoken2&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.deleterecordinset&RecordType6=TXT&HostId7=746374&Address7=challengetoken1&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.deleterecordset&RecordType7=TXT&HostId8=746375&Address8=challengetoken2&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.deleterecordset&RecordType8=TXT&HostId9=746362&Address9=challengetoken&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.fqdn&RecordType9=TXT&HostId10=746363&Address10=challengetoken&MXPref10=10&TTL10=3600&AssociatedAppTitle10=&FriendlyName10=&IsActive10=true&IsDDNSEnabled10=false&HostName10=_acme-challenge.full&RecordType10=TXT&HostId11=746376&Address11=challengetoken1&MXPref11=10&TTL11=3600&AssociatedAppTitle11=&FriendlyName11=&IsActive11=true&IsDDNSEnabled11=false&HostName11=_acme-challenge.listrecordset&RecordType11=TXT&HostId12=746377&Address12=challengetoken2&MXPref12=10&TTL12=3600&AssociatedAppTitle12=&FriendlyName12=&IsActive12=true&IsDDNSEnabled12=false&HostName12=_acme-challenge.listrecordset&RecordType12=TXT&HostId13=746367&Address13=challengetoken&MXPref13=10&TTL13=3600&AssociatedAppTitle13=&FriendlyName13=&IsActive13=true&IsDDNSEnabled13=false&HostName13=_acme-challenge.noop&RecordType13=TXT&HostId14=746364&Address14=challengetoken&MXPref14=10&TTL14=3600&AssociatedAppTitle14=&FriendlyName14=&IsActive14=true&IsDDNSEnabled14=false&HostName14=_acme-challenge.test&RecordType14=TXT&HostId15=746383&Address15=challengetoken&MXPref15=10&TTL15=3600&AssociatedAppTitle15=&FriendlyName15=&IsActive15=true&IsDDNSEnabled15=false&HostName15=orig.nameonly.test&RecordType15=TXT&HostId16=746384&Address16=updated&MXPref16=10&TTL16=3600&AssociatedAppTitle16=&FriendlyName16=&IsActive16=true&IsDDNSEnabled16=false&HostName16=orig.nameonly.test&RecordType16=TXT&HostId17=746381&Address17=challengetoken&MXPref17=10&TTL17=3600&AssociatedAppTitle17=&FriendlyName17=&IsActive17=true&IsDDNSEnabled17=false&HostName17=orig.test&RecordType17=TXT&HostId18=746385&Address18=challengetoken&MXPref18=10&TTL18=3600&AssociatedAppTitle18=&FriendlyName18=&IsActive18=true&IsDDNSEnabled18=false&HostName18=orig.testfqdn&RecordType18=TXT&HostId19=746387&Address19=challengetoken&MXPref19=10&TTL19=3600&AssociatedAppTitle19=&FriendlyName19=&IsActive19=true&IsDDNSEnabled19=false&HostName19=orig.testfull&RecordType19=TXT&HostId20=746378&Address20=challengetoken&MXPref20=10&TTL20=3600&AssociatedAppTitle20=&FriendlyName20=&IsActive20=true&IsDDNSEnabled20=false&HostName20=random.fqdntest&RecordType20=TXT&HostId21=746379&Address21=challengetoken&MXPref21=10&TTL21=3600&AssociatedAppTitle21=&FriendlyName21=&IsActive21=true&IsDDNSEnabled21=false&HostName21=random.fulltest&RecordType21=TXT&HostId22=746380&Address22=challengetoken&MXPref22=10&TTL22=3600&AssociatedAppTitle22=&FriendlyName22=&IsActive22=true&IsDDNSEnabled22=false&HostName22=random.test&RecordType22=TXT&HostId23=746382&Address23=challengetoken&MXPref23=10&TTL23=3600&AssociatedAppTitle23=&FriendlyName23=&IsActive23=true&IsDDNSEnabled23=false&HostName23=updated.test&RecordType23=TXT&HostId24=746386&Address24=challengetoken&MXPref24=10&TTL24=3600&AssociatedAppTitle24=&FriendlyName24=&IsActive24=true&IsDDNSEnabled24=false&HostName24=updated.testfqdn&RecordType24=TXT&HostId25=746388&Address25=challengetoken&MXPref25=10&TTL25=3600&AssociatedAppTitle25=&FriendlyName25=&IsActive25=true&IsDDNSEnabled25=false&HostName25=updated.testfull&RecordType25=TXT&HostId26=746354&Address26=http%3A%2F%2Fwww.unittest2.dev%2F&MXPref26=10&TTL26=1800&AssociatedAppTitle26=URL+Forwarding&FriendlyName26=URL+Record&IsActive26=true&IsDDNSEnabled26=false&HostName26=%40&RecordType26=URL&Address27=challengetoken2&TTL27=3600&HostName27=_acme-challenge.deleterecordset&RecordType27=TXT&SLD=unittest2&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['4351']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '4959'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>1.066</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest2.dev\" IsSuccess=\"true\">\r\n      <Warnings />\r\n    </DomainDNSSetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>1.04</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['559']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:42:23 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:00:53 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '556'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest2&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524840\" Name=\"_acme-challenge.deleterecordset\" Type=\"\
-        TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524841\" Name=\"_acme-challenge.deleterecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
-        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524833\" Name=\"_acme-challenge.noop\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524158\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\"\
-        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524214\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524166\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"\
-        orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524163\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\"\
-        \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524165\" Name=\"random.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524167\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524171\" Name=\"\
-        updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524160\" Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
-        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.817</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest2.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n      <host
+        HostId=\"746360\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746361\" Name=\"docs\" Type=\"CNAME\" Address=\"docs.example.com.\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746355\" Name=\"www\" Type=\"CNAME\"
+        Address=\"parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\"
+        FriendlyName=\"CNAME Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n
+        \     <host HostId=\"746365\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746366\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746373\" Name=\"_acme-challenge.deleterecordinset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746374\" Name=\"_acme-challenge.deleterecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746375\" Name=\"_acme-challenge.deleterecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746362\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746363\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746376\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746377\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746367\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746364\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746383\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746384\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746381\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746385\" Name=\"orig.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746387\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746378\" Name=\"random.fqdntest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746379\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746380\" Name=\"random.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746382\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746386\" Name=\"updated.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746388\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746354\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest2.dev/\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL
+        Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.413</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['5219']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:42:25 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:00:53 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '5634'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest2&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524840\" Name=\"_acme-challenge.deleterecordset\" Type=\"\
-        TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524841\" Name=\"_acme-challenge.deleterecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
-        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524833\" Name=\"_acme-challenge.noop\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524158\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\"\
-        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524214\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524166\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"\
-        orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524163\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\"\
-        \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524165\" Name=\"random.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524167\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524171\" Name=\"\
-        updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524160\" Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
-        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.655</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest2.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n      <host
+        HostId=\"746360\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746361\" Name=\"docs\" Type=\"CNAME\" Address=\"docs.example.com.\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746355\" Name=\"www\" Type=\"CNAME\"
+        Address=\"parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\"
+        FriendlyName=\"CNAME Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n
+        \     <host HostId=\"746365\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746366\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746373\" Name=\"_acme-challenge.deleterecordinset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746374\" Name=\"_acme-challenge.deleterecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746375\" Name=\"_acme-challenge.deleterecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746362\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746363\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746376\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746377\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746367\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746364\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746383\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746384\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746381\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746385\" Name=\"orig.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746387\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746378\" Name=\"random.fqdntest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746379\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746380\" Name=\"random.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746382\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746386\" Name=\"updated.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746388\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746354\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest2.dev/\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL
+        Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.209</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['5219']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:42:26 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:00:55 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '5634'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'RecordType21=TXT&HostId19=524165&RecordType20=TXT&RecordType23=URL&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&IsDDNSEnabled23=false&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524156&HostId9=524157&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524831&HostId5=524832&HostId6=524839&HostId7=524841&IsDDNSEnabled22=false&MXPref23=10&HostId23=524160&HostId22=524173&HostId21=524171&HostId20=524167&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=CName+Record&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524168&HostId13=524214&HostId10=524833&HostId11=524158&HostId16=524172&HostId17=524163&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=&FriendlyName23=URL+Record&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&AssociatedAppTitle23=&HostName12=orig.nameonly.test&HostName13=orig.nameonly.test&HostName10=_acme-challenge.noop&HostName11=_acme-challenge.test&HostName16=orig.testfull&HostName17=random.fqdntest&HostName14=orig.test&Address1=127.0.0.1&HostName18=random.fulltest&HostName19=random.test&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken2&TTL8=60&TTL9=60&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&TTL23=1800&Address13=updated&TTL21=1800&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&AssociatedAppTitle22=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.deleterecordset&HostName8=_acme-challenge.fqdn&HostName9=_acme-challenge.full&Address10=challengetoken&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName23=yyy&HostName22=updated.testfull&HostName21=updated.testfqdn&HostName20=updated.test&TTL10=1800&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&IsActive23=true&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.testfqdn&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&SLD=example-aptise&MXPref4=10&Address23=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524166&AssociatedAppTitle19=&HostId15=524170&HostId18=524164'
+    body: HostId1=746360&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746361&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746355&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746365&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746366&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746373&Address6=challengetoken2&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.deleterecordinset&RecordType6=TXT&HostId7=746375&Address7=challengetoken2&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.deleterecordset&RecordType7=TXT&HostId8=746362&Address8=challengetoken&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.fqdn&RecordType8=TXT&HostId9=746363&Address9=challengetoken&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.full&RecordType9=TXT&HostId10=746376&Address10=challengetoken1&MXPref10=10&TTL10=3600&AssociatedAppTitle10=&FriendlyName10=&IsActive10=true&IsDDNSEnabled10=false&HostName10=_acme-challenge.listrecordset&RecordType10=TXT&HostId11=746377&Address11=challengetoken2&MXPref11=10&TTL11=3600&AssociatedAppTitle11=&FriendlyName11=&IsActive11=true&IsDDNSEnabled11=false&HostName11=_acme-challenge.listrecordset&RecordType11=TXT&HostId12=746367&Address12=challengetoken&MXPref12=10&TTL12=3600&AssociatedAppTitle12=&FriendlyName12=&IsActive12=true&IsDDNSEnabled12=false&HostName12=_acme-challenge.noop&RecordType12=TXT&HostId13=746364&Address13=challengetoken&MXPref13=10&TTL13=3600&AssociatedAppTitle13=&FriendlyName13=&IsActive13=true&IsDDNSEnabled13=false&HostName13=_acme-challenge.test&RecordType13=TXT&HostId14=746383&Address14=challengetoken&MXPref14=10&TTL14=3600&AssociatedAppTitle14=&FriendlyName14=&IsActive14=true&IsDDNSEnabled14=false&HostName14=orig.nameonly.test&RecordType14=TXT&HostId15=746384&Address15=updated&MXPref15=10&TTL15=3600&AssociatedAppTitle15=&FriendlyName15=&IsActive15=true&IsDDNSEnabled15=false&HostName15=orig.nameonly.test&RecordType15=TXT&HostId16=746381&Address16=challengetoken&MXPref16=10&TTL16=3600&AssociatedAppTitle16=&FriendlyName16=&IsActive16=true&IsDDNSEnabled16=false&HostName16=orig.test&RecordType16=TXT&HostId17=746385&Address17=challengetoken&MXPref17=10&TTL17=3600&AssociatedAppTitle17=&FriendlyName17=&IsActive17=true&IsDDNSEnabled17=false&HostName17=orig.testfqdn&RecordType17=TXT&HostId18=746387&Address18=challengetoken&MXPref18=10&TTL18=3600&AssociatedAppTitle18=&FriendlyName18=&IsActive18=true&IsDDNSEnabled18=false&HostName18=orig.testfull&RecordType18=TXT&HostId19=746378&Address19=challengetoken&MXPref19=10&TTL19=3600&AssociatedAppTitle19=&FriendlyName19=&IsActive19=true&IsDDNSEnabled19=false&HostName19=random.fqdntest&RecordType19=TXT&HostId20=746379&Address20=challengetoken&MXPref20=10&TTL20=3600&AssociatedAppTitle20=&FriendlyName20=&IsActive20=true&IsDDNSEnabled20=false&HostName20=random.fulltest&RecordType20=TXT&HostId21=746380&Address21=challengetoken&MXPref21=10&TTL21=3600&AssociatedAppTitle21=&FriendlyName21=&IsActive21=true&IsDDNSEnabled21=false&HostName21=random.test&RecordType21=TXT&HostId22=746382&Address22=challengetoken&MXPref22=10&TTL22=3600&AssociatedAppTitle22=&FriendlyName22=&IsActive22=true&IsDDNSEnabled22=false&HostName22=updated.test&RecordType22=TXT&HostId23=746386&Address23=challengetoken&MXPref23=10&TTL23=3600&AssociatedAppTitle23=&FriendlyName23=&IsActive23=true&IsDDNSEnabled23=false&HostName23=updated.testfqdn&RecordType23=TXT&HostId24=746388&Address24=challengetoken&MXPref24=10&TTL24=3600&AssociatedAppTitle24=&FriendlyName24=&IsActive24=true&IsDDNSEnabled24=false&HostName24=updated.testfull&RecordType24=TXT&HostId25=746354&Address25=http%3A%2F%2Fwww.unittest2.dev%2F&MXPref25=10&TTL25=1800&AssociatedAppTitle25=URL+Forwarding&FriendlyName25=URL+Record&IsActive25=true&IsDDNSEnabled25=false&HostName25=%40&RecordType25=URL&SLD=unittest2&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['4265']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '4661'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.764</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest2.dev\" IsSuccess=\"true\">\r\n      <Warnings />\r\n    </DomainDNSSetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.752</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['559']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:42:27 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:00:56 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '557'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest2&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524841\" Name=\"_acme-challenge.deleterecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
-        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524833\" Name=\"_acme-challenge.noop\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524158\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\"\
-        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524214\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524166\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"\
-        orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524163\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\"\
-        \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524165\" Name=\"random.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524167\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524171\" Name=\"\
-        updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524160\" Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
-        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>1.227</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest2.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n      <host
+        HostId=\"746360\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746361\" Name=\"docs\" Type=\"CNAME\" Address=\"docs.example.com.\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746355\" Name=\"www\" Type=\"CNAME\"
+        Address=\"parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\"
+        FriendlyName=\"CNAME Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n
+        \     <host HostId=\"746365\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746366\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746373\" Name=\"_acme-challenge.deleterecordinset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746375\" Name=\"_acme-challenge.deleterecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746362\" Name=\"_acme-challenge.fqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746363\" Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746376\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746377\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746367\" Name=\"_acme-challenge.noop\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746364\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746383\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746384\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"updated\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746381\" Name=\"orig.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746385\" Name=\"orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746387\" Name=\"orig.testfull\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746378\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746379\" Name=\"random.fulltest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746380\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746382\" Name=\"updated.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746386\" Name=\"updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746388\" Name=\"updated.testfull\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746354\" Name=\"@\" Type=\"URL\" Address=\"http://www.unittest2.dev/\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL
+        Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.6</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['5012']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:42:28 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:00:57 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '5425'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'RecordType21=TXT&HostId19=524167&RecordType20=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524157&HostId9=524833&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524831&HostId5=524832&HostId6=524839&HostId7=524156&IsDDNSEnabled22=false&HostId22=524160&HostId21=524173&HostId20=524171&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=CName+Record&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524214&HostId13=524166&HostId10=524158&HostId11=524168&HostId16=524163&HostId17=524164&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=URL&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=URL+Record&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&HostName12=orig.nameonly.test&HostName13=orig.test&HostName10=_acme-challenge.test&HostName11=orig.nameonly.test&HostName16=random.fqdntest&HostName17=random.fulltest&HostName14=orig.testfqdn&Address1=127.0.0.1&HostName18=random.test&HostName19=updated.test&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=60&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=60&TTL14=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=updated&AssociatedAppTitle22=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.noop&Address10=challengetoken&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName22=yyy&HostName21=updated.testfull&HostName20=updated.testfqdn&TTL10=1800&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.testfull&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&SLD=example-aptise&MXPref4=10&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524170&AssociatedAppTitle19=&HostId15=524172&HostId18=524165'
+    body: HostId1=746360&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746361&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746355&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746365&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746366&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746373&Address6=challengetoken2&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.deleterecordinset&RecordType6=TXT&HostId7=746362&Address7=challengetoken&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.fqdn&RecordType7=TXT&HostId8=746363&Address8=challengetoken&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.full&RecordType8=TXT&HostId9=746376&Address9=challengetoken1&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.listrecordset&RecordType9=TXT&HostId10=746377&Address10=challengetoken2&MXPref10=10&TTL10=3600&AssociatedAppTitle10=&FriendlyName10=&IsActive10=true&IsDDNSEnabled10=false&HostName10=_acme-challenge.listrecordset&RecordType10=TXT&HostId11=746367&Address11=challengetoken&MXPref11=10&TTL11=3600&AssociatedAppTitle11=&FriendlyName11=&IsActive11=true&IsDDNSEnabled11=false&HostName11=_acme-challenge.noop&RecordType11=TXT&HostId12=746364&Address12=challengetoken&MXPref12=10&TTL12=3600&AssociatedAppTitle12=&FriendlyName12=&IsActive12=true&IsDDNSEnabled12=false&HostName12=_acme-challenge.test&RecordType12=TXT&HostId13=746383&Address13=challengetoken&MXPref13=10&TTL13=3600&AssociatedAppTitle13=&FriendlyName13=&IsActive13=true&IsDDNSEnabled13=false&HostName13=orig.nameonly.test&RecordType13=TXT&HostId14=746384&Address14=updated&MXPref14=10&TTL14=3600&AssociatedAppTitle14=&FriendlyName14=&IsActive14=true&IsDDNSEnabled14=false&HostName14=orig.nameonly.test&RecordType14=TXT&HostId15=746381&Address15=challengetoken&MXPref15=10&TTL15=3600&AssociatedAppTitle15=&FriendlyName15=&IsActive15=true&IsDDNSEnabled15=false&HostName15=orig.test&RecordType15=TXT&HostId16=746385&Address16=challengetoken&MXPref16=10&TTL16=3600&AssociatedAppTitle16=&FriendlyName16=&IsActive16=true&IsDDNSEnabled16=false&HostName16=orig.testfqdn&RecordType16=TXT&HostId17=746387&Address17=challengetoken&MXPref17=10&TTL17=3600&AssociatedAppTitle17=&FriendlyName17=&IsActive17=true&IsDDNSEnabled17=false&HostName17=orig.testfull&RecordType17=TXT&HostId18=746378&Address18=challengetoken&MXPref18=10&TTL18=3600&AssociatedAppTitle18=&FriendlyName18=&IsActive18=true&IsDDNSEnabled18=false&HostName18=random.fqdntest&RecordType18=TXT&HostId19=746379&Address19=challengetoken&MXPref19=10&TTL19=3600&AssociatedAppTitle19=&FriendlyName19=&IsActive19=true&IsDDNSEnabled19=false&HostName19=random.fulltest&RecordType19=TXT&HostId20=746380&Address20=challengetoken&MXPref20=10&TTL20=3600&AssociatedAppTitle20=&FriendlyName20=&IsActive20=true&IsDDNSEnabled20=false&HostName20=random.test&RecordType20=TXT&HostId21=746382&Address21=challengetoken&MXPref21=10&TTL21=3600&AssociatedAppTitle21=&FriendlyName21=&IsActive21=true&IsDDNSEnabled21=false&HostName21=updated.test&RecordType21=TXT&HostId22=746386&Address22=challengetoken&MXPref22=10&TTL22=3600&AssociatedAppTitle22=&FriendlyName22=&IsActive22=true&IsDDNSEnabled22=false&HostName22=updated.testfqdn&RecordType22=TXT&HostId23=746388&Address23=challengetoken&MXPref23=10&TTL23=3600&AssociatedAppTitle23=&FriendlyName23=&IsActive23=true&IsDDNSEnabled23=false&HostName23=updated.testfull&RecordType23=TXT&HostId24=746354&Address24=http%3A%2F%2Fwww.unittest2.dev%2F&MXPref24=10&TTL24=1800&AssociatedAppTitle24=URL+Forwarding&FriendlyName24=URL+Record&IsActive24=true&IsDDNSEnabled24=false&HostName24=%40&RecordType24=URL&SLD=unittest2&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['4064']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '4460'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.797</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest2.dev\" IsSuccess=\"true\">\r\n      <Warnings />\r\n    </DomainDNSSetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.93</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['559']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:42:30 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:01:00 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '556'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest2&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
-        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524833\" Name=\"_acme-challenge.noop\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524158\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\"\
-        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524214\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524166\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"\
-        orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524163\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\"\
-        \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524165\" Name=\"random.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524167\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524171\" Name=\"\
-        updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524160\" Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
-        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.753</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest2.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n      <host
+        HostId=\"746360\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746361\" Name=\"docs\" Type=\"CNAME\" Address=\"docs.example.com.\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746355\" Name=\"www\" Type=\"CNAME\"
+        Address=\"parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\"
+        FriendlyName=\"CNAME Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n
+        \     <host HostId=\"746365\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746366\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746373\" Name=\"_acme-challenge.deleterecordinset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746362\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746363\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746376\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746377\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746367\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746364\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746383\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746384\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746381\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746385\" Name=\"orig.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746387\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746378\" Name=\"random.fqdntest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746379\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746380\" Name=\"random.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746382\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746386\" Name=\"updated.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746388\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746354\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest2.dev/\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL
+        Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.145</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4805']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:42:31 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:01:01 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '5220'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/namecheap/IntegrationTests/test_provider_when_calling_list_records_should_handle_record_sets.yaml
+++ b/tests/fixtures/cassettes/namecheap/IntegrationTests/test_provider_when_calling_list_records_should_handle_record_sets.yaml
@@ -2,374 +2,463 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise.com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=unittest2.dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
-        \ Status=\"Ok\" ID=\"277432\" DomainName=\"example-aptise.com\" OwnerName=\"\
-        jvsandbox\" IsOwner=\"true\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
-        \n        <CreatedDate>03/25/2018</CreatedDate>\r\n        <ExpiredDate>03/25/2019</ExpiredDate>\r\
-        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
-        \ />\r\n      <Whoisguard Enabled=\"NotAlloted\">\r\n        <ID>0</ID>\r\n\
-        \      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
-        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
-        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
-        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
-        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"22\" EmailType=\"\
-        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
-        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
-        \n      <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.029</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult
+        Status=\"Ok\" ID=\"589667\" DomainName=\"unittest2.dev\" OwnerName=\"phassberg\"
+        IsOwner=\"true\" IsPremium=\"false\">\r\n      <DomainDetails>\r\n        <CreatedDate>05/20/2020</CreatedDate>\r\n
+        \       <ExpiredDate>05/20/2021</ExpiredDate>\r\n        <NumYears>0</NumYears>\r\n
+        \     </DomainDetails>\r\n      <LockDetails />\r\n      <Whoisguard Enabled=\"True\">\r\n
+        \       <ID>481121</ID>\r\n        <ExpiredDate>05/20/2021</ExpiredDate>\r\n
+        \       <EmailDetails WhoisGuardEmail=\"824017ccbed343119b3459c7d3304ba5.protect@whoisguard.com\"
+        ForwardedTo=\"dr.doddo@gmail.com\" LastAutoEmailChangeDate=\"05/20/2020\"
+        AutoEmailChangeFrequencyDays=\"3\" />\r\n      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n
+        \       <UseAutoRenew>false</UseAutoRenew>\r\n        <SubscriptionId>-1</SubscriptionId>\r\n
+        \       <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n
+        \       <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n
+        \     <DnsDetails ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"24\"
+        EmailType=\"FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\n
+        \       <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\n
+        \     <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.178</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['1493']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:42:31 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:01:02 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '1740'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest2&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
-        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524833\" Name=\"_acme-challenge.noop\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524158\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\"\
-        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524214\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524166\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"\
-        orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524163\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\"\
-        \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524165\" Name=\"random.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524167\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524171\" Name=\"\
-        updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524160\" Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
-        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.737</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest2.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n      <host
+        HostId=\"746360\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746361\" Name=\"docs\" Type=\"CNAME\" Address=\"docs.example.com.\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746355\" Name=\"www\" Type=\"CNAME\"
+        Address=\"parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\"
+        FriendlyName=\"CNAME Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n
+        \     <host HostId=\"746365\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746366\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746373\" Name=\"_acme-challenge.deleterecordinset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746362\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746363\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746376\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746377\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746367\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746364\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746383\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746384\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746381\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746385\" Name=\"orig.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746387\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746378\" Name=\"random.fqdntest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746379\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746380\" Name=\"random.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746382\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746386\" Name=\"updated.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746388\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746354\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest2.dev/\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL
+        Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.299</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4805']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:42:33 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:01:04 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '5220'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'RecordType21=TXT&HostId19=524167&RecordType20=TXT&RecordType23=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524157&HostId9=524833&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524831&HostId5=524832&HostId6=524839&HostId7=524156&IsDDNSEnabled22=false&HostId22=524160&HostId21=524173&HostId20=524171&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=CName+Record&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524214&HostId13=524166&HostId10=524158&HostId11=524168&HostId16=524163&HostId17=524164&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=URL&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=URL+Record&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&HostName12=orig.nameonly.test&HostName13=orig.test&HostName10=_acme-challenge.test&HostName11=orig.nameonly.test&HostName16=random.fqdntest&HostName17=random.fulltest&HostName14=orig.testfqdn&Address1=127.0.0.1&HostName18=random.test&HostName19=updated.test&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=60&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=60&TTL14=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=updated&AssociatedAppTitle22=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.noop&Address10=challengetoken&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName23=_acme-challenge.listrecordset&HostName22=yyy&HostName21=updated.testfull&HostName20=updated.testfqdn&TTL10=1800&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.testfull&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&SLD=example-aptise&MXPref4=10&Address23=challengetoken1&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524170&AssociatedAppTitle19=&HostId15=524172&HostId18=524165'
+    body: HostId1=746360&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746361&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746355&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746365&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746366&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746373&Address6=challengetoken2&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.deleterecordinset&RecordType6=TXT&HostId7=746362&Address7=challengetoken&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.fqdn&RecordType7=TXT&HostId8=746363&Address8=challengetoken&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.full&RecordType8=TXT&HostId9=746376&Address9=challengetoken1&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.listrecordset&RecordType9=TXT&HostId10=746377&Address10=challengetoken2&MXPref10=10&TTL10=3600&AssociatedAppTitle10=&FriendlyName10=&IsActive10=true&IsDDNSEnabled10=false&HostName10=_acme-challenge.listrecordset&RecordType10=TXT&HostId11=746367&Address11=challengetoken&MXPref11=10&TTL11=3600&AssociatedAppTitle11=&FriendlyName11=&IsActive11=true&IsDDNSEnabled11=false&HostName11=_acme-challenge.noop&RecordType11=TXT&HostId12=746364&Address12=challengetoken&MXPref12=10&TTL12=3600&AssociatedAppTitle12=&FriendlyName12=&IsActive12=true&IsDDNSEnabled12=false&HostName12=_acme-challenge.test&RecordType12=TXT&HostId13=746383&Address13=challengetoken&MXPref13=10&TTL13=3600&AssociatedAppTitle13=&FriendlyName13=&IsActive13=true&IsDDNSEnabled13=false&HostName13=orig.nameonly.test&RecordType13=TXT&HostId14=746384&Address14=updated&MXPref14=10&TTL14=3600&AssociatedAppTitle14=&FriendlyName14=&IsActive14=true&IsDDNSEnabled14=false&HostName14=orig.nameonly.test&RecordType14=TXT&HostId15=746381&Address15=challengetoken&MXPref15=10&TTL15=3600&AssociatedAppTitle15=&FriendlyName15=&IsActive15=true&IsDDNSEnabled15=false&HostName15=orig.test&RecordType15=TXT&HostId16=746385&Address16=challengetoken&MXPref16=10&TTL16=3600&AssociatedAppTitle16=&FriendlyName16=&IsActive16=true&IsDDNSEnabled16=false&HostName16=orig.testfqdn&RecordType16=TXT&HostId17=746387&Address17=challengetoken&MXPref17=10&TTL17=3600&AssociatedAppTitle17=&FriendlyName17=&IsActive17=true&IsDDNSEnabled17=false&HostName17=orig.testfull&RecordType17=TXT&HostId18=746378&Address18=challengetoken&MXPref18=10&TTL18=3600&AssociatedAppTitle18=&FriendlyName18=&IsActive18=true&IsDDNSEnabled18=false&HostName18=random.fqdntest&RecordType18=TXT&HostId19=746379&Address19=challengetoken&MXPref19=10&TTL19=3600&AssociatedAppTitle19=&FriendlyName19=&IsActive19=true&IsDDNSEnabled19=false&HostName19=random.fulltest&RecordType19=TXT&HostId20=746380&Address20=challengetoken&MXPref20=10&TTL20=3600&AssociatedAppTitle20=&FriendlyName20=&IsActive20=true&IsDDNSEnabled20=false&HostName20=random.test&RecordType20=TXT&HostId21=746382&Address21=challengetoken&MXPref21=10&TTL21=3600&AssociatedAppTitle21=&FriendlyName21=&IsActive21=true&IsDDNSEnabled21=false&HostName21=updated.test&RecordType21=TXT&HostId22=746386&Address22=challengetoken&MXPref22=10&TTL22=3600&AssociatedAppTitle22=&FriendlyName22=&IsActive22=true&IsDDNSEnabled22=false&HostName22=updated.testfqdn&RecordType22=TXT&HostId23=746388&Address23=challengetoken&MXPref23=10&TTL23=3600&AssociatedAppTitle23=&FriendlyName23=&IsActive23=true&IsDDNSEnabled23=false&HostName23=updated.testfull&RecordType23=TXT&HostId24=746354&Address24=http%3A%2F%2Fwww.unittest2.dev%2F&MXPref24=10&TTL24=1800&AssociatedAppTitle24=URL+Forwarding&FriendlyName24=URL+Record&IsActive24=true&IsDDNSEnabled24=false&HostName24=%40&RecordType24=URL&Address25=challengetoken1&TTL25=3600&HostName25=_acme-challenge.listrecordset&RecordType25=TXT&SLD=unittest2&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['4148']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '4555'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>1.287</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest2.dev\" IsSuccess=\"true\">\r\n      <Warnings />\r\n    </DomainDNSSetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.796</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['559']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:42:35 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:01:05 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '557'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest2&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
-        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524842\" Name=\"_acme-challenge.listrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524833\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524158\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524214\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
-        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
-        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.88</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest2.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n      <host
+        HostId=\"746360\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746361\" Name=\"docs\" Type=\"CNAME\" Address=\"docs.example.com.\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746355\" Name=\"www\" Type=\"CNAME\"
+        Address=\"parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\"
+        FriendlyName=\"CNAME Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n
+        \     <host HostId=\"746365\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746366\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746373\" Name=\"_acme-challenge.deleterecordinset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746362\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746363\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746376\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746377\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746367\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746364\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746383\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746384\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746381\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746385\" Name=\"orig.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746387\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746378\" Name=\"random.fqdntest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746379\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746380\" Name=\"random.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746382\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746386\" Name=\"updated.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746388\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746354\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest2.dev/\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL
+        Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.443</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['5009']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:42:36 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:01:06 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '5220'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'RecordType21=TXT&HostId19=524165&RecordType20=TXT&RecordType23=URL&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&IsDDNSEnabled23=false&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524157&HostId9=524842&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524831&HostId5=524832&HostId6=524839&HostId7=524156&IsDDNSEnabled22=false&MXPref23=10&HostId23=524160&HostId22=524173&HostId21=524171&HostId20=524167&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=CName+Record&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524168&HostId13=524214&HostId10=524833&HostId11=524158&HostId16=524172&HostId17=524163&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken1&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=&FriendlyName23=URL+Record&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&AssociatedAppTitle23=&HostName12=orig.nameonly.test&HostName13=orig.nameonly.test&HostName10=_acme-challenge.noop&HostName11=_acme-challenge.test&HostName16=orig.testfull&HostName17=random.fqdntest&HostName14=orig.test&Address1=127.0.0.1&HostName18=random.fulltest&HostName19=random.test&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=60&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=60&TTL14=1800&RecordType24=TXT&TTL23=1800&Address13=updated&TTL21=1800&TTL20=1800&HostName24=_acme-challenge.listrecordset&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&AssociatedAppTitle22=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.listrecordset&Address10=challengetoken&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName23=yyy&HostName22=updated.testfull&HostName21=updated.testfqdn&HostName20=updated.test&TTL10=1800&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&IsActive23=true&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.testfqdn&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&SLD=example-aptise&MXPref4=10&Address24=challengetoken2&Address23=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524166&AssociatedAppTitle19=&HostId15=524170&HostId18=524164'
+    body: HostId1=746360&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746361&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746355&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746365&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746366&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746373&Address6=challengetoken2&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.deleterecordinset&RecordType6=TXT&HostId7=746362&Address7=challengetoken&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.fqdn&RecordType7=TXT&HostId8=746363&Address8=challengetoken&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.full&RecordType8=TXT&HostId9=746376&Address9=challengetoken1&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.listrecordset&RecordType9=TXT&HostId10=746377&Address10=challengetoken2&MXPref10=10&TTL10=3600&AssociatedAppTitle10=&FriendlyName10=&IsActive10=true&IsDDNSEnabled10=false&HostName10=_acme-challenge.listrecordset&RecordType10=TXT&HostId11=746367&Address11=challengetoken&MXPref11=10&TTL11=3600&AssociatedAppTitle11=&FriendlyName11=&IsActive11=true&IsDDNSEnabled11=false&HostName11=_acme-challenge.noop&RecordType11=TXT&HostId12=746364&Address12=challengetoken&MXPref12=10&TTL12=3600&AssociatedAppTitle12=&FriendlyName12=&IsActive12=true&IsDDNSEnabled12=false&HostName12=_acme-challenge.test&RecordType12=TXT&HostId13=746383&Address13=challengetoken&MXPref13=10&TTL13=3600&AssociatedAppTitle13=&FriendlyName13=&IsActive13=true&IsDDNSEnabled13=false&HostName13=orig.nameonly.test&RecordType13=TXT&HostId14=746384&Address14=updated&MXPref14=10&TTL14=3600&AssociatedAppTitle14=&FriendlyName14=&IsActive14=true&IsDDNSEnabled14=false&HostName14=orig.nameonly.test&RecordType14=TXT&HostId15=746381&Address15=challengetoken&MXPref15=10&TTL15=3600&AssociatedAppTitle15=&FriendlyName15=&IsActive15=true&IsDDNSEnabled15=false&HostName15=orig.test&RecordType15=TXT&HostId16=746385&Address16=challengetoken&MXPref16=10&TTL16=3600&AssociatedAppTitle16=&FriendlyName16=&IsActive16=true&IsDDNSEnabled16=false&HostName16=orig.testfqdn&RecordType16=TXT&HostId17=746387&Address17=challengetoken&MXPref17=10&TTL17=3600&AssociatedAppTitle17=&FriendlyName17=&IsActive17=true&IsDDNSEnabled17=false&HostName17=orig.testfull&RecordType17=TXT&HostId18=746378&Address18=challengetoken&MXPref18=10&TTL18=3600&AssociatedAppTitle18=&FriendlyName18=&IsActive18=true&IsDDNSEnabled18=false&HostName18=random.fqdntest&RecordType18=TXT&HostId19=746379&Address19=challengetoken&MXPref19=10&TTL19=3600&AssociatedAppTitle19=&FriendlyName19=&IsActive19=true&IsDDNSEnabled19=false&HostName19=random.fulltest&RecordType19=TXT&HostId20=746380&Address20=challengetoken&MXPref20=10&TTL20=3600&AssociatedAppTitle20=&FriendlyName20=&IsActive20=true&IsDDNSEnabled20=false&HostName20=random.test&RecordType20=TXT&HostId21=746382&Address21=challengetoken&MXPref21=10&TTL21=3600&AssociatedAppTitle21=&FriendlyName21=&IsActive21=true&IsDDNSEnabled21=false&HostName21=updated.test&RecordType21=TXT&HostId22=746386&Address22=challengetoken&MXPref22=10&TTL22=3600&AssociatedAppTitle22=&FriendlyName22=&IsActive22=true&IsDDNSEnabled22=false&HostName22=updated.testfqdn&RecordType22=TXT&HostId23=746388&Address23=challengetoken&MXPref23=10&TTL23=3600&AssociatedAppTitle23=&FriendlyName23=&IsActive23=true&IsDDNSEnabled23=false&HostName23=updated.testfull&RecordType23=TXT&HostId24=746354&Address24=http%3A%2F%2Fwww.unittest2.dev%2F&MXPref24=10&TTL24=1800&AssociatedAppTitle24=URL+Forwarding&FriendlyName24=URL+Record&IsActive24=true&IsDDNSEnabled24=false&HostName24=%40&RecordType24=URL&Address25=challengetoken2&TTL25=3600&HostName25=_acme-challenge.listrecordset&RecordType25=TXT&SLD=unittest2&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['4347']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '4555'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.993</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest2.dev\" IsSuccess=\"true\">\r\n      <Warnings />\r\n    </DomainDNSSetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.636</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['559']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:42:37 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:01:09 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '557'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest2&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
-        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524842\" Name=\"_acme-challenge.listrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524843\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524833\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524158\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524214\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
-        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
-        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.74</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest2.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n      <host
+        HostId=\"746360\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746361\" Name=\"docs\" Type=\"CNAME\" Address=\"docs.example.com.\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746355\" Name=\"www\" Type=\"CNAME\"
+        Address=\"parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\"
+        FriendlyName=\"CNAME Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n
+        \     <host HostId=\"746365\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746366\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746373\" Name=\"_acme-challenge.deleterecordinset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746362\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746363\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746376\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746377\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746367\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746364\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746383\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746384\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746381\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746385\" Name=\"orig.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746387\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746378\" Name=\"random.fqdntest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746379\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746380\" Name=\"random.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746382\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746386\" Name=\"updated.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746388\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746354\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest2.dev/\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL
+        Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.331</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['5214']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:42:38 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:01:08 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '5220'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/namecheap/IntegrationTests/test_provider_when_calling_list_records_with_fqdn_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/namecheap/IntegrationTests/test_provider_when_calling_list_records_with_fqdn_name_filter_should_return_record.yaml
@@ -2,259 +2,313 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise.com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=unittest2.dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
-        \ Status=\"Ok\" ID=\"277432\" DomainName=\"example-aptise.com\" OwnerName=\"\
-        jvsandbox\" IsOwner=\"true\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
-        \n        <CreatedDate>03/25/2018</CreatedDate>\r\n        <ExpiredDate>03/25/2019</ExpiredDate>\r\
-        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
-        \ />\r\n      <Whoisguard Enabled=\"NotAlloted\">\r\n        <ID>0</ID>\r\n\
-        \      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
-        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
-        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
-        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
-        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"24\" EmailType=\"\
-        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
-        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
-        \n      <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.059</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult
+        Status=\"Ok\" ID=\"589667\" DomainName=\"unittest2.dev\" OwnerName=\"phassberg\"
+        IsOwner=\"true\" IsPremium=\"false\">\r\n      <DomainDetails>\r\n        <CreatedDate>05/20/2020</CreatedDate>\r\n
+        \       <ExpiredDate>05/20/2021</ExpiredDate>\r\n        <NumYears>0</NumYears>\r\n
+        \     </DomainDetails>\r\n      <LockDetails />\r\n      <Whoisguard Enabled=\"True\">\r\n
+        \       <ID>481121</ID>\r\n        <ExpiredDate>05/20/2021</ExpiredDate>\r\n
+        \       <EmailDetails WhoisGuardEmail=\"824017ccbed343119b3459c7d3304ba5.protect@whoisguard.com\"
+        ForwardedTo=\"dr.doddo@gmail.com\" LastAutoEmailChangeDate=\"05/20/2020\"
+        AutoEmailChangeFrequencyDays=\"3\" />\r\n      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n
+        \       <UseAutoRenew>false</UseAutoRenew>\r\n        <SubscriptionId>-1</SubscriptionId>\r\n
+        \       <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n
+        \       <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n
+        \     <DnsDetails ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"24\"
+        EmailType=\"FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\n
+        \       <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\n
+        \     <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.219</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['1493']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:42:39 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:01:11 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '1740'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest2&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
-        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524842\" Name=\"_acme-challenge.listrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524843\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524833\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524158\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524214\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
-        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
-        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.716</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest2.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n      <host
+        HostId=\"746360\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746361\" Name=\"docs\" Type=\"CNAME\" Address=\"docs.example.com.\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746355\" Name=\"www\" Type=\"CNAME\"
+        Address=\"parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\"
+        FriendlyName=\"CNAME Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n
+        \     <host HostId=\"746365\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746366\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746373\" Name=\"_acme-challenge.deleterecordinset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746362\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746363\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746376\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746377\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746367\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746364\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746383\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746384\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746381\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746385\" Name=\"orig.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746387\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746378\" Name=\"random.fqdntest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746379\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746380\" Name=\"random.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746382\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746386\" Name=\"updated.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746388\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746354\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest2.dev/\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL
+        Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.415</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['5215']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:42:41 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:01:11 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '5220'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'RecordType21=TXT&HostId19=524164&RecordType20=TXT&RecordType23=TXT&MXPref24=10&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&IsDDNSEnabled23=false&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524157&HostId9=524842&IsDDNSEnabled24=false&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524831&HostId5=524832&HostId6=524839&HostId7=524156&IsDDNSEnabled22=false&MXPref23=10&HostId24=524160&HostId23=524173&HostId22=524171&HostId21=524167&HostId20=524165&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=CName+Record&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524158&HostId13=524168&HostId10=524843&HostId11=524833&HostId16=524170&HostId17=524172&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken1&FriendlyName24=URL+Record&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=&FriendlyName23=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&AssociatedAppTitle23=&HostName12=_acme-challenge.test&HostName13=orig.nameonly.test&HostName10=_acme-challenge.listrecordset&HostName11=_acme-challenge.noop&HostName16=orig.testfqdn&HostName17=orig.testfull&HostName14=orig.nameonly.test&Address1=127.0.0.1&HostName18=random.fqdntest&HostName19=random.fulltest&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=60&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=60&TTL14=1800&RecordType24=URL&TTL24=1800&TTL23=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&HostName24=yyy&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&AssociatedAppTitle22=&AssociatedAppTitle24=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&RecordType25=TXT&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.listrecordset&Address10=challengetoken2&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=updated&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName23=updated.testfull&HostName22=updated.testfqdn&HostName21=updated.test&HostName20=random.test&TTL10=1800&HostName25=random.fqdntest&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&IsActive23=true&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&IsActive24=true&SLD=example-aptise&MXPref4=10&Address25=challengetoken&Address24=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&Address23=challengetoken&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524214&AssociatedAppTitle19=&HostId15=524166&HostId18=524163'
+    body: HostId1=746360&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746361&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746355&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746365&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746366&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746373&Address6=challengetoken2&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.deleterecordinset&RecordType6=TXT&HostId7=746362&Address7=challengetoken&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.fqdn&RecordType7=TXT&HostId8=746363&Address8=challengetoken&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.full&RecordType8=TXT&HostId9=746376&Address9=challengetoken1&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.listrecordset&RecordType9=TXT&HostId10=746377&Address10=challengetoken2&MXPref10=10&TTL10=3600&AssociatedAppTitle10=&FriendlyName10=&IsActive10=true&IsDDNSEnabled10=false&HostName10=_acme-challenge.listrecordset&RecordType10=TXT&HostId11=746367&Address11=challengetoken&MXPref11=10&TTL11=3600&AssociatedAppTitle11=&FriendlyName11=&IsActive11=true&IsDDNSEnabled11=false&HostName11=_acme-challenge.noop&RecordType11=TXT&HostId12=746364&Address12=challengetoken&MXPref12=10&TTL12=3600&AssociatedAppTitle12=&FriendlyName12=&IsActive12=true&IsDDNSEnabled12=false&HostName12=_acme-challenge.test&RecordType12=TXT&HostId13=746383&Address13=challengetoken&MXPref13=10&TTL13=3600&AssociatedAppTitle13=&FriendlyName13=&IsActive13=true&IsDDNSEnabled13=false&HostName13=orig.nameonly.test&RecordType13=TXT&HostId14=746384&Address14=updated&MXPref14=10&TTL14=3600&AssociatedAppTitle14=&FriendlyName14=&IsActive14=true&IsDDNSEnabled14=false&HostName14=orig.nameonly.test&RecordType14=TXT&HostId15=746381&Address15=challengetoken&MXPref15=10&TTL15=3600&AssociatedAppTitle15=&FriendlyName15=&IsActive15=true&IsDDNSEnabled15=false&HostName15=orig.test&RecordType15=TXT&HostId16=746385&Address16=challengetoken&MXPref16=10&TTL16=3600&AssociatedAppTitle16=&FriendlyName16=&IsActive16=true&IsDDNSEnabled16=false&HostName16=orig.testfqdn&RecordType16=TXT&HostId17=746387&Address17=challengetoken&MXPref17=10&TTL17=3600&AssociatedAppTitle17=&FriendlyName17=&IsActive17=true&IsDDNSEnabled17=false&HostName17=orig.testfull&RecordType17=TXT&HostId18=746378&Address18=challengetoken&MXPref18=10&TTL18=3600&AssociatedAppTitle18=&FriendlyName18=&IsActive18=true&IsDDNSEnabled18=false&HostName18=random.fqdntest&RecordType18=TXT&HostId19=746379&Address19=challengetoken&MXPref19=10&TTL19=3600&AssociatedAppTitle19=&FriendlyName19=&IsActive19=true&IsDDNSEnabled19=false&HostName19=random.fulltest&RecordType19=TXT&HostId20=746380&Address20=challengetoken&MXPref20=10&TTL20=3600&AssociatedAppTitle20=&FriendlyName20=&IsActive20=true&IsDDNSEnabled20=false&HostName20=random.test&RecordType20=TXT&HostId21=746382&Address21=challengetoken&MXPref21=10&TTL21=3600&AssociatedAppTitle21=&FriendlyName21=&IsActive21=true&IsDDNSEnabled21=false&HostName21=updated.test&RecordType21=TXT&HostId22=746386&Address22=challengetoken&MXPref22=10&TTL22=3600&AssociatedAppTitle22=&FriendlyName22=&IsActive22=true&IsDDNSEnabled22=false&HostName22=updated.testfqdn&RecordType22=TXT&HostId23=746388&Address23=challengetoken&MXPref23=10&TTL23=3600&AssociatedAppTitle23=&FriendlyName23=&IsActive23=true&IsDDNSEnabled23=false&HostName23=updated.testfull&RecordType23=TXT&HostId24=746354&Address24=http%3A%2F%2Fwww.unittest2.dev%2F&MXPref24=10&TTL24=1800&AssociatedAppTitle24=URL+Forwarding&FriendlyName24=URL+Record&IsActive24=true&IsDDNSEnabled24=false&HostName24=%40&RecordType24=URL&Address25=challengetoken&TTL25=3600&HostName25=random.fqdntest&RecordType25=TXT&SLD=unittest2&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['4531']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '4540'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.88</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest2.dev\" IsSuccess=\"true\">\r\n      <Warnings />\r\n    </DomainDNSSetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.829</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['558']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:42:42 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:01:13 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '557'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest2&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
-        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524842\" Name=\"_acme-challenge.listrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524843\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524833\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524158\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524214\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
-        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
-        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.759</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest2.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n      <host
+        HostId=\"746360\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746361\" Name=\"docs\" Type=\"CNAME\" Address=\"docs.example.com.\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746355\" Name=\"www\" Type=\"CNAME\"
+        Address=\"parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\"
+        FriendlyName=\"CNAME Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n
+        \     <host HostId=\"746365\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746366\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746373\" Name=\"_acme-challenge.deleterecordinset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746362\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746363\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746376\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746377\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746367\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746364\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746383\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746384\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746381\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746385\" Name=\"orig.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746387\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746378\" Name=\"random.fqdntest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746379\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746380\" Name=\"random.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746382\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746386\" Name=\"updated.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746388\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746354\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest2.dev/\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL
+        Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.312</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['5215']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:42:44 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:01:15 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '5220'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/namecheap/IntegrationTests/test_provider_when_calling_list_records_with_full_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/namecheap/IntegrationTests/test_provider_when_calling_list_records_with_full_name_filter_should_return_record.yaml
@@ -2,259 +2,313 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise.com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=unittest2.dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
-        \ Status=\"Ok\" ID=\"277432\" DomainName=\"example-aptise.com\" OwnerName=\"\
-        jvsandbox\" IsOwner=\"true\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
-        \n        <CreatedDate>03/25/2018</CreatedDate>\r\n        <ExpiredDate>03/25/2019</ExpiredDate>\r\
-        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
-        \ />\r\n      <Whoisguard Enabled=\"NotAlloted\">\r\n        <ID>0</ID>\r\n\
-        \      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
-        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
-        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
-        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
-        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"24\" EmailType=\"\
-        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
-        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
-        \n      <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.038</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult
+        Status=\"Ok\" ID=\"589667\" DomainName=\"unittest2.dev\" OwnerName=\"phassberg\"
+        IsOwner=\"true\" IsPremium=\"false\">\r\n      <DomainDetails>\r\n        <CreatedDate>05/20/2020</CreatedDate>\r\n
+        \       <ExpiredDate>05/20/2021</ExpiredDate>\r\n        <NumYears>0</NumYears>\r\n
+        \     </DomainDetails>\r\n      <LockDetails />\r\n      <Whoisguard Enabled=\"True\">\r\n
+        \       <ID>481121</ID>\r\n        <ExpiredDate>05/20/2021</ExpiredDate>\r\n
+        \       <EmailDetails WhoisGuardEmail=\"824017ccbed343119b3459c7d3304ba5.protect@whoisguard.com\"
+        ForwardedTo=\"dr.doddo@gmail.com\" LastAutoEmailChangeDate=\"05/20/2020\"
+        AutoEmailChangeFrequencyDays=\"3\" />\r\n      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n
+        \       <UseAutoRenew>false</UseAutoRenew>\r\n        <SubscriptionId>-1</SubscriptionId>\r\n
+        \       <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n
+        \       <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n
+        \     <DnsDetails ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"24\"
+        EmailType=\"FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\n
+        \       <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\n
+        \     <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.178</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['1493']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:42:44 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:01:15 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '1740'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest2&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
-        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524842\" Name=\"_acme-challenge.listrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524843\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524833\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524158\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524214\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
-        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
-        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.913</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest2.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n      <host
+        HostId=\"746360\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746361\" Name=\"docs\" Type=\"CNAME\" Address=\"docs.example.com.\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746355\" Name=\"www\" Type=\"CNAME\"
+        Address=\"parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\"
+        FriendlyName=\"CNAME Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n
+        \     <host HostId=\"746365\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746366\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746373\" Name=\"_acme-challenge.deleterecordinset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746362\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746363\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746376\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746377\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746367\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746364\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746383\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746384\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746381\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746385\" Name=\"orig.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746387\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746378\" Name=\"random.fqdntest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746379\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746380\" Name=\"random.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746382\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746386\" Name=\"updated.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746388\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746354\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest2.dev/\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL
+        Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.154</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['5215']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:42:46 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:01:16 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '5220'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'RecordType21=TXT&HostId19=524164&RecordType20=TXT&RecordType23=TXT&MXPref24=10&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&IsDDNSEnabled23=false&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524157&HostId9=524842&IsDDNSEnabled24=false&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524831&HostId5=524832&HostId6=524839&HostId7=524156&IsDDNSEnabled22=false&MXPref23=10&HostId24=524160&HostId23=524173&HostId22=524171&HostId21=524167&HostId20=524165&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=CName+Record&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524158&HostId13=524168&HostId10=524843&HostId11=524833&HostId16=524170&HostId17=524172&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken1&FriendlyName24=URL+Record&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=&FriendlyName23=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&AssociatedAppTitle23=&HostName12=_acme-challenge.test&HostName13=orig.nameonly.test&HostName10=_acme-challenge.listrecordset&HostName11=_acme-challenge.noop&HostName16=orig.testfqdn&HostName17=orig.testfull&HostName14=orig.nameonly.test&Address1=127.0.0.1&HostName18=random.fqdntest&HostName19=random.fulltest&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=60&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=60&TTL14=1800&RecordType24=URL&TTL24=1800&TTL23=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&HostName24=yyy&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&AssociatedAppTitle22=&AssociatedAppTitle24=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&RecordType25=TXT&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.listrecordset&Address10=challengetoken2&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=updated&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName23=updated.testfull&HostName22=updated.testfqdn&HostName21=updated.test&HostName20=random.test&TTL10=1800&HostName25=random.fulltest&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&IsActive23=true&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&IsActive24=true&SLD=example-aptise&MXPref4=10&Address25=challengetoken&Address24=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&Address23=challengetoken&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524214&AssociatedAppTitle19=&HostId15=524166&HostId18=524163'
+    body: HostId1=746360&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746361&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746355&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746365&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746366&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746373&Address6=challengetoken2&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.deleterecordinset&RecordType6=TXT&HostId7=746362&Address7=challengetoken&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.fqdn&RecordType7=TXT&HostId8=746363&Address8=challengetoken&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.full&RecordType8=TXT&HostId9=746376&Address9=challengetoken1&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.listrecordset&RecordType9=TXT&HostId10=746377&Address10=challengetoken2&MXPref10=10&TTL10=3600&AssociatedAppTitle10=&FriendlyName10=&IsActive10=true&IsDDNSEnabled10=false&HostName10=_acme-challenge.listrecordset&RecordType10=TXT&HostId11=746367&Address11=challengetoken&MXPref11=10&TTL11=3600&AssociatedAppTitle11=&FriendlyName11=&IsActive11=true&IsDDNSEnabled11=false&HostName11=_acme-challenge.noop&RecordType11=TXT&HostId12=746364&Address12=challengetoken&MXPref12=10&TTL12=3600&AssociatedAppTitle12=&FriendlyName12=&IsActive12=true&IsDDNSEnabled12=false&HostName12=_acme-challenge.test&RecordType12=TXT&HostId13=746383&Address13=challengetoken&MXPref13=10&TTL13=3600&AssociatedAppTitle13=&FriendlyName13=&IsActive13=true&IsDDNSEnabled13=false&HostName13=orig.nameonly.test&RecordType13=TXT&HostId14=746384&Address14=updated&MXPref14=10&TTL14=3600&AssociatedAppTitle14=&FriendlyName14=&IsActive14=true&IsDDNSEnabled14=false&HostName14=orig.nameonly.test&RecordType14=TXT&HostId15=746381&Address15=challengetoken&MXPref15=10&TTL15=3600&AssociatedAppTitle15=&FriendlyName15=&IsActive15=true&IsDDNSEnabled15=false&HostName15=orig.test&RecordType15=TXT&HostId16=746385&Address16=challengetoken&MXPref16=10&TTL16=3600&AssociatedAppTitle16=&FriendlyName16=&IsActive16=true&IsDDNSEnabled16=false&HostName16=orig.testfqdn&RecordType16=TXT&HostId17=746387&Address17=challengetoken&MXPref17=10&TTL17=3600&AssociatedAppTitle17=&FriendlyName17=&IsActive17=true&IsDDNSEnabled17=false&HostName17=orig.testfull&RecordType17=TXT&HostId18=746378&Address18=challengetoken&MXPref18=10&TTL18=3600&AssociatedAppTitle18=&FriendlyName18=&IsActive18=true&IsDDNSEnabled18=false&HostName18=random.fqdntest&RecordType18=TXT&HostId19=746379&Address19=challengetoken&MXPref19=10&TTL19=3600&AssociatedAppTitle19=&FriendlyName19=&IsActive19=true&IsDDNSEnabled19=false&HostName19=random.fulltest&RecordType19=TXT&HostId20=746380&Address20=challengetoken&MXPref20=10&TTL20=3600&AssociatedAppTitle20=&FriendlyName20=&IsActive20=true&IsDDNSEnabled20=false&HostName20=random.test&RecordType20=TXT&HostId21=746382&Address21=challengetoken&MXPref21=10&TTL21=3600&AssociatedAppTitle21=&FriendlyName21=&IsActive21=true&IsDDNSEnabled21=false&HostName21=updated.test&RecordType21=TXT&HostId22=746386&Address22=challengetoken&MXPref22=10&TTL22=3600&AssociatedAppTitle22=&FriendlyName22=&IsActive22=true&IsDDNSEnabled22=false&HostName22=updated.testfqdn&RecordType22=TXT&HostId23=746388&Address23=challengetoken&MXPref23=10&TTL23=3600&AssociatedAppTitle23=&FriendlyName23=&IsActive23=true&IsDDNSEnabled23=false&HostName23=updated.testfull&RecordType23=TXT&HostId24=746354&Address24=http%3A%2F%2Fwww.unittest2.dev%2F&MXPref24=10&TTL24=1800&AssociatedAppTitle24=URL+Forwarding&FriendlyName24=URL+Record&IsActive24=true&IsDDNSEnabled24=false&HostName24=%40&RecordType24=URL&Address25=challengetoken&TTL25=3600&HostName25=random.fulltest&RecordType25=TXT&SLD=unittest2&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['4531']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '4540'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>1.267</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest2.dev\" IsSuccess=\"true\">\r\n      <Warnings />\r\n    </DomainDNSSetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.73</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['559']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:42:48 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:01:17 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '556'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest2&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
-        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524842\" Name=\"_acme-challenge.listrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524843\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524833\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524158\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524214\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
-        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
-        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.844</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest2.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n      <host
+        HostId=\"746360\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746361\" Name=\"docs\" Type=\"CNAME\" Address=\"docs.example.com.\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746355\" Name=\"www\" Type=\"CNAME\"
+        Address=\"parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\"
+        FriendlyName=\"CNAME Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n
+        \     <host HostId=\"746365\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746366\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746373\" Name=\"_acme-challenge.deleterecordinset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746362\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746363\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746376\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746377\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746367\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746364\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746383\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746384\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746381\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746385\" Name=\"orig.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746387\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746378\" Name=\"random.fqdntest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746379\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746380\" Name=\"random.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746382\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746386\" Name=\"updated.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746388\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746354\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest2.dev/\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL
+        Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.447</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['5215']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:42:49 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:01:19 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '5220'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/namecheap/IntegrationTests/test_provider_when_calling_list_records_with_invalid_filter_should_be_empty_list.yaml
+++ b/tests/fixtures/cassettes/namecheap/IntegrationTests/test_provider_when_calling_list_records_with_invalid_filter_should_be_empty_list.yaml
@@ -2,135 +2,163 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise.com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=unittest2.dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
-        \ Status=\"Ok\" ID=\"277432\" DomainName=\"example-aptise.com\" OwnerName=\"\
-        jvsandbox\" IsOwner=\"true\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
-        \n        <CreatedDate>03/25/2018</CreatedDate>\r\n        <ExpiredDate>03/25/2019</ExpiredDate>\r\
-        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
-        \ />\r\n      <Whoisguard Enabled=\"NotAlloted\">\r\n        <ID>0</ID>\r\n\
-        \      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
-        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
-        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
-        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
-        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"24\" EmailType=\"\
-        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
-        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
-        \n      <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.201</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult
+        Status=\"Ok\" ID=\"589667\" DomainName=\"unittest2.dev\" OwnerName=\"phassberg\"
+        IsOwner=\"true\" IsPremium=\"false\">\r\n      <DomainDetails>\r\n        <CreatedDate>05/20/2020</CreatedDate>\r\n
+        \       <ExpiredDate>05/20/2021</ExpiredDate>\r\n        <NumYears>0</NumYears>\r\n
+        \     </DomainDetails>\r\n      <LockDetails />\r\n      <Whoisguard Enabled=\"True\">\r\n
+        \       <ID>481121</ID>\r\n        <ExpiredDate>05/20/2021</ExpiredDate>\r\n
+        \       <EmailDetails WhoisGuardEmail=\"824017ccbed343119b3459c7d3304ba5.protect@whoisguard.com\"
+        ForwardedTo=\"dr.doddo@gmail.com\" LastAutoEmailChangeDate=\"05/20/2020\"
+        AutoEmailChangeFrequencyDays=\"3\" />\r\n      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n
+        \       <UseAutoRenew>false</UseAutoRenew>\r\n        <SubscriptionId>-1</SubscriptionId>\r\n
+        \       <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n
+        \       <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n
+        \     <DnsDetails ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"24\"
+        EmailType=\"FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\n
+        \       <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\n
+        \     <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.199</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['1493']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:42:49 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:01:21 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '1740'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest2&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
-        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524842\" Name=\"_acme-challenge.listrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524843\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524833\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524158\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524214\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
-        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
-        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.721</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest2.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n      <host
+        HostId=\"746360\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746361\" Name=\"docs\" Type=\"CNAME\" Address=\"docs.example.com.\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746355\" Name=\"www\" Type=\"CNAME\"
+        Address=\"parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\"
+        FriendlyName=\"CNAME Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n
+        \     <host HostId=\"746365\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746366\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746373\" Name=\"_acme-challenge.deleterecordinset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746362\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746363\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746376\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746377\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746367\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746364\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746383\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746384\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746381\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746385\" Name=\"orig.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746387\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746378\" Name=\"random.fqdntest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746379\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746380\" Name=\"random.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746382\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746386\" Name=\"updated.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746388\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746354\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest2.dev/\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL
+        Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.138</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['5215']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:42:52 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:01:22 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '5220'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/namecheap/IntegrationTests/test_provider_when_calling_list_records_with_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/namecheap/IntegrationTests/test_provider_when_calling_list_records_with_name_filter_should_return_record.yaml
@@ -2,259 +2,313 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise.com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=unittest2.dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
-        \ Status=\"Ok\" ID=\"277432\" DomainName=\"example-aptise.com\" OwnerName=\"\
-        jvsandbox\" IsOwner=\"true\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
-        \n        <CreatedDate>03/25/2018</CreatedDate>\r\n        <ExpiredDate>03/25/2019</ExpiredDate>\r\
-        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
-        \ />\r\n      <Whoisguard Enabled=\"NotAlloted\">\r\n        <ID>0</ID>\r\n\
-        \      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
-        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
-        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
-        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
-        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"24\" EmailType=\"\
-        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
-        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
-        \n      <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.031</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult
+        Status=\"Ok\" ID=\"589667\" DomainName=\"unittest2.dev\" OwnerName=\"phassberg\"
+        IsOwner=\"true\" IsPremium=\"false\">\r\n      <DomainDetails>\r\n        <CreatedDate>05/20/2020</CreatedDate>\r\n
+        \       <ExpiredDate>05/20/2021</ExpiredDate>\r\n        <NumYears>0</NumYears>\r\n
+        \     </DomainDetails>\r\n      <LockDetails />\r\n      <Whoisguard Enabled=\"True\">\r\n
+        \       <ID>481121</ID>\r\n        <ExpiredDate>05/20/2021</ExpiredDate>\r\n
+        \       <EmailDetails WhoisGuardEmail=\"824017ccbed343119b3459c7d3304ba5.protect@whoisguard.com\"
+        ForwardedTo=\"dr.doddo@gmail.com\" LastAutoEmailChangeDate=\"05/20/2020\"
+        AutoEmailChangeFrequencyDays=\"3\" />\r\n      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n
+        \       <UseAutoRenew>false</UseAutoRenew>\r\n        <SubscriptionId>-1</SubscriptionId>\r\n
+        \       <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n
+        \       <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n
+        \     <DnsDetails ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"24\"
+        EmailType=\"FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\n
+        \       <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\n
+        \     <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.245</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['1493']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:42:52 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:01:23 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '1740'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest2&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
-        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524842\" Name=\"_acme-challenge.listrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524843\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524833\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524158\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524214\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
-        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
-        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.878</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest2.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n      <host
+        HostId=\"746360\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746361\" Name=\"docs\" Type=\"CNAME\" Address=\"docs.example.com.\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746355\" Name=\"www\" Type=\"CNAME\"
+        Address=\"parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\"
+        FriendlyName=\"CNAME Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n
+        \     <host HostId=\"746365\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746366\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746373\" Name=\"_acme-challenge.deleterecordinset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746362\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746363\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746376\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746377\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746367\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746364\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746383\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746384\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746381\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746385\" Name=\"orig.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746387\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746378\" Name=\"random.fqdntest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746379\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746380\" Name=\"random.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746382\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746386\" Name=\"updated.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746388\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746354\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest2.dev/\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL
+        Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.312</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['5215']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:42:54 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:01:23 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '5220'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'RecordType21=TXT&HostId19=524164&RecordType20=TXT&RecordType23=TXT&MXPref24=10&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&IsDDNSEnabled23=false&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524157&HostId9=524842&IsDDNSEnabled24=false&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524831&HostId5=524832&HostId6=524839&HostId7=524156&IsDDNSEnabled22=false&MXPref23=10&HostId24=524160&HostId23=524173&HostId22=524171&HostId21=524167&HostId20=524165&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=CName+Record&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524158&HostId13=524168&HostId10=524843&HostId11=524833&HostId16=524170&HostId17=524172&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken1&FriendlyName24=URL+Record&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=&FriendlyName23=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&AssociatedAppTitle23=&HostName12=_acme-challenge.test&HostName13=orig.nameonly.test&HostName10=_acme-challenge.listrecordset&HostName11=_acme-challenge.noop&HostName16=orig.testfqdn&HostName17=orig.testfull&HostName14=orig.nameonly.test&Address1=127.0.0.1&HostName18=random.fqdntest&HostName19=random.fulltest&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=60&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=60&TTL14=1800&RecordType24=URL&TTL24=1800&TTL23=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&HostName24=yyy&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&AssociatedAppTitle22=&AssociatedAppTitle24=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&RecordType25=TXT&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.listrecordset&Address10=challengetoken2&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=updated&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName23=updated.testfull&HostName22=updated.testfqdn&HostName21=updated.test&HostName20=random.test&TTL10=1800&HostName25=random.test&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&IsActive23=true&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&IsActive24=true&SLD=example-aptise&MXPref4=10&Address25=challengetoken&Address24=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&Address23=challengetoken&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524214&AssociatedAppTitle19=&HostId15=524166&HostId18=524163'
+    body: HostId1=746360&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746361&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746355&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746365&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746366&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746373&Address6=challengetoken2&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.deleterecordinset&RecordType6=TXT&HostId7=746362&Address7=challengetoken&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.fqdn&RecordType7=TXT&HostId8=746363&Address8=challengetoken&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.full&RecordType8=TXT&HostId9=746376&Address9=challengetoken1&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.listrecordset&RecordType9=TXT&HostId10=746377&Address10=challengetoken2&MXPref10=10&TTL10=3600&AssociatedAppTitle10=&FriendlyName10=&IsActive10=true&IsDDNSEnabled10=false&HostName10=_acme-challenge.listrecordset&RecordType10=TXT&HostId11=746367&Address11=challengetoken&MXPref11=10&TTL11=3600&AssociatedAppTitle11=&FriendlyName11=&IsActive11=true&IsDDNSEnabled11=false&HostName11=_acme-challenge.noop&RecordType11=TXT&HostId12=746364&Address12=challengetoken&MXPref12=10&TTL12=3600&AssociatedAppTitle12=&FriendlyName12=&IsActive12=true&IsDDNSEnabled12=false&HostName12=_acme-challenge.test&RecordType12=TXT&HostId13=746383&Address13=challengetoken&MXPref13=10&TTL13=3600&AssociatedAppTitle13=&FriendlyName13=&IsActive13=true&IsDDNSEnabled13=false&HostName13=orig.nameonly.test&RecordType13=TXT&HostId14=746384&Address14=updated&MXPref14=10&TTL14=3600&AssociatedAppTitle14=&FriendlyName14=&IsActive14=true&IsDDNSEnabled14=false&HostName14=orig.nameonly.test&RecordType14=TXT&HostId15=746381&Address15=challengetoken&MXPref15=10&TTL15=3600&AssociatedAppTitle15=&FriendlyName15=&IsActive15=true&IsDDNSEnabled15=false&HostName15=orig.test&RecordType15=TXT&HostId16=746385&Address16=challengetoken&MXPref16=10&TTL16=3600&AssociatedAppTitle16=&FriendlyName16=&IsActive16=true&IsDDNSEnabled16=false&HostName16=orig.testfqdn&RecordType16=TXT&HostId17=746387&Address17=challengetoken&MXPref17=10&TTL17=3600&AssociatedAppTitle17=&FriendlyName17=&IsActive17=true&IsDDNSEnabled17=false&HostName17=orig.testfull&RecordType17=TXT&HostId18=746378&Address18=challengetoken&MXPref18=10&TTL18=3600&AssociatedAppTitle18=&FriendlyName18=&IsActive18=true&IsDDNSEnabled18=false&HostName18=random.fqdntest&RecordType18=TXT&HostId19=746379&Address19=challengetoken&MXPref19=10&TTL19=3600&AssociatedAppTitle19=&FriendlyName19=&IsActive19=true&IsDDNSEnabled19=false&HostName19=random.fulltest&RecordType19=TXT&HostId20=746380&Address20=challengetoken&MXPref20=10&TTL20=3600&AssociatedAppTitle20=&FriendlyName20=&IsActive20=true&IsDDNSEnabled20=false&HostName20=random.test&RecordType20=TXT&HostId21=746382&Address21=challengetoken&MXPref21=10&TTL21=3600&AssociatedAppTitle21=&FriendlyName21=&IsActive21=true&IsDDNSEnabled21=false&HostName21=updated.test&RecordType21=TXT&HostId22=746386&Address22=challengetoken&MXPref22=10&TTL22=3600&AssociatedAppTitle22=&FriendlyName22=&IsActive22=true&IsDDNSEnabled22=false&HostName22=updated.testfqdn&RecordType22=TXT&HostId23=746388&Address23=challengetoken&MXPref23=10&TTL23=3600&AssociatedAppTitle23=&FriendlyName23=&IsActive23=true&IsDDNSEnabled23=false&HostName23=updated.testfull&RecordType23=TXT&HostId24=746354&Address24=http%3A%2F%2Fwww.unittest2.dev%2F&MXPref24=10&TTL24=1800&AssociatedAppTitle24=URL+Forwarding&FriendlyName24=URL+Record&IsActive24=true&IsDDNSEnabled24=false&HostName24=%40&RecordType24=URL&Address25=challengetoken&TTL25=3600&HostName25=random.test&RecordType25=TXT&SLD=unittest2&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['4527']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '4536'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.952</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest2.dev\" IsSuccess=\"true\">\r\n      <Warnings />\r\n    </DomainDNSSetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.708</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['559']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:42:55 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:01:25 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '557'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest2&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
-        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524842\" Name=\"_acme-challenge.listrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524843\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524833\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524158\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524214\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
-        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
-        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.819</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest2.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n      <host
+        HostId=\"746360\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746361\" Name=\"docs\" Type=\"CNAME\" Address=\"docs.example.com.\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746355\" Name=\"www\" Type=\"CNAME\"
+        Address=\"parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\"
+        FriendlyName=\"CNAME Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n
+        \     <host HostId=\"746365\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746366\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746373\" Name=\"_acme-challenge.deleterecordinset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746362\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746363\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746376\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746377\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746367\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746364\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746383\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746384\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746381\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746385\" Name=\"orig.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746387\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746378\" Name=\"random.fqdntest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746379\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746380\" Name=\"random.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746382\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746386\" Name=\"updated.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746388\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746354\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest2.dev/\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL
+        Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.456</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['5215']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:42:57 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:01:26 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '5220'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/namecheap/IntegrationTests/test_provider_when_calling_list_records_with_no_arguments_should_list_all.yaml
+++ b/tests/fixtures/cassettes/namecheap/IntegrationTests/test_provider_when_calling_list_records_with_no_arguments_should_list_all.yaml
@@ -2,135 +2,163 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise.com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=unittest2.dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
-        \ Status=\"Ok\" ID=\"277432\" DomainName=\"example-aptise.com\" OwnerName=\"\
-        jvsandbox\" IsOwner=\"true\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
-        \n        <CreatedDate>03/25/2018</CreatedDate>\r\n        <ExpiredDate>03/25/2019</ExpiredDate>\r\
-        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
-        \ />\r\n      <Whoisguard Enabled=\"NotAlloted\">\r\n        <ID>0</ID>\r\n\
-        \      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
-        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
-        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
-        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
-        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"24\" EmailType=\"\
-        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
-        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
-        \n      <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.181</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult
+        Status=\"Ok\" ID=\"589667\" DomainName=\"unittest2.dev\" OwnerName=\"phassberg\"
+        IsOwner=\"true\" IsPremium=\"false\">\r\n      <DomainDetails>\r\n        <CreatedDate>05/20/2020</CreatedDate>\r\n
+        \       <ExpiredDate>05/20/2021</ExpiredDate>\r\n        <NumYears>0</NumYears>\r\n
+        \     </DomainDetails>\r\n      <LockDetails />\r\n      <Whoisguard Enabled=\"True\">\r\n
+        \       <ID>481121</ID>\r\n        <ExpiredDate>05/20/2021</ExpiredDate>\r\n
+        \       <EmailDetails WhoisGuardEmail=\"824017ccbed343119b3459c7d3304ba5.protect@whoisguard.com\"
+        ForwardedTo=\"dr.doddo@gmail.com\" LastAutoEmailChangeDate=\"05/20/2020\"
+        AutoEmailChangeFrequencyDays=\"3\" />\r\n      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n
+        \       <UseAutoRenew>false</UseAutoRenew>\r\n        <SubscriptionId>-1</SubscriptionId>\r\n
+        \       <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n
+        \       <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n
+        \     <DnsDetails ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"24\"
+        EmailType=\"FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\n
+        \       <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\n
+        \     <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.181</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['1493']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:42:57 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:01:27 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '1740'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest2&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
-        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524842\" Name=\"_acme-challenge.listrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524843\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524833\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524158\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524214\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
-        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
-        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>1.192</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest2.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n      <host
+        HostId=\"746360\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746361\" Name=\"docs\" Type=\"CNAME\" Address=\"docs.example.com.\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746355\" Name=\"www\" Type=\"CNAME\"
+        Address=\"parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\"
+        FriendlyName=\"CNAME Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n
+        \     <host HostId=\"746365\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746366\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746373\" Name=\"_acme-challenge.deleterecordinset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746362\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746363\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746376\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746377\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746367\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746364\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746383\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746384\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746381\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746385\" Name=\"orig.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746387\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746378\" Name=\"random.fqdntest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746379\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746380\" Name=\"random.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746382\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746386\" Name=\"updated.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746388\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746354\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest2.dev/\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL
+        Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.31</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['5215']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:42:59 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:01:28 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '5219'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/namecheap/IntegrationTests/test_provider_when_calling_update_record_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/namecheap/IntegrationTests/test_provider_when_calling_update_record_should_modify_record.yaml
@@ -2,477 +2,567 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise.com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=unittest2.dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
-        \ Status=\"Ok\" ID=\"277432\" DomainName=\"example-aptise.com\" OwnerName=\"\
-        jvsandbox\" IsOwner=\"true\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
-        \n        <CreatedDate>03/25/2018</CreatedDate>\r\n        <ExpiredDate>03/25/2019</ExpiredDate>\r\
-        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
-        \ />\r\n      <Whoisguard Enabled=\"NotAlloted\">\r\n        <ID>0</ID>\r\n\
-        \      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
-        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
-        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
-        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
-        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"24\" EmailType=\"\
-        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
-        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
-        \n      <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.104</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult
+        Status=\"Ok\" ID=\"589667\" DomainName=\"unittest2.dev\" OwnerName=\"phassberg\"
+        IsOwner=\"true\" IsPremium=\"false\">\r\n      <DomainDetails>\r\n        <CreatedDate>05/20/2020</CreatedDate>\r\n
+        \       <ExpiredDate>05/20/2021</ExpiredDate>\r\n        <NumYears>0</NumYears>\r\n
+        \     </DomainDetails>\r\n      <LockDetails />\r\n      <Whoisguard Enabled=\"True\">\r\n
+        \       <ID>481121</ID>\r\n        <ExpiredDate>05/20/2021</ExpiredDate>\r\n
+        \       <EmailDetails WhoisGuardEmail=\"824017ccbed343119b3459c7d3304ba5.protect@whoisguard.com\"
+        ForwardedTo=\"dr.doddo@gmail.com\" LastAutoEmailChangeDate=\"05/20/2020\"
+        AutoEmailChangeFrequencyDays=\"3\" />\r\n      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n
+        \       <UseAutoRenew>false</UseAutoRenew>\r\n        <SubscriptionId>-1</SubscriptionId>\r\n
+        \       <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n
+        \       <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n
+        \     <DnsDetails ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"24\"
+        EmailType=\"FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\n
+        \       <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\n
+        \     <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.015</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['1493']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:42:59 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:01:30 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '1740'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest2&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
-        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524842\" Name=\"_acme-challenge.listrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524843\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524833\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524158\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524214\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
-        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
-        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>1.957</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest2.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n      <host
+        HostId=\"746360\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746361\" Name=\"docs\" Type=\"CNAME\" Address=\"docs.example.com.\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746355\" Name=\"www\" Type=\"CNAME\"
+        Address=\"parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\"
+        FriendlyName=\"CNAME Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n
+        \     <host HostId=\"746365\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746366\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746373\" Name=\"_acme-challenge.deleterecordinset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746362\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746363\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746376\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746377\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746367\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746364\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746383\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746384\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746381\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746385\" Name=\"orig.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746387\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746378\" Name=\"random.fqdntest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746379\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746380\" Name=\"random.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746382\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746386\" Name=\"updated.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746388\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746354\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest2.dev/\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL
+        Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.43</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['5215']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:43:03 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:01:31 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '5219'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'RecordType21=TXT&HostId19=524164&RecordType20=TXT&RecordType23=TXT&MXPref24=10&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&IsDDNSEnabled23=false&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524157&HostId9=524842&IsDDNSEnabled24=false&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524831&HostId5=524832&HostId6=524839&HostId7=524156&IsDDNSEnabled22=false&MXPref23=10&HostId24=524160&HostId23=524173&HostId22=524171&HostId21=524167&HostId20=524165&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=CName+Record&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524158&HostId13=524168&HostId10=524843&HostId11=524833&HostId16=524170&HostId17=524172&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken1&FriendlyName24=URL+Record&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=&FriendlyName23=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&AssociatedAppTitle23=&HostName12=_acme-challenge.test&HostName13=orig.nameonly.test&HostName10=_acme-challenge.listrecordset&HostName11=_acme-challenge.noop&HostName16=orig.testfqdn&HostName17=orig.testfull&HostName14=orig.nameonly.test&Address1=127.0.0.1&HostName18=random.fqdntest&HostName19=random.fulltest&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=60&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=60&TTL14=1800&RecordType24=URL&TTL24=1800&TTL23=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&HostName24=yyy&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&AssociatedAppTitle22=&AssociatedAppTitle24=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&RecordType25=TXT&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.listrecordset&Address10=challengetoken2&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=updated&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName23=updated.testfull&HostName22=updated.testfqdn&HostName21=updated.test&HostName20=random.test&TTL10=1800&HostName25=orig.test&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&IsActive23=true&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&IsActive24=true&SLD=example-aptise&MXPref4=10&Address25=challengetoken&Address24=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&Address23=challengetoken&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524214&AssociatedAppTitle19=&HostId15=524166&HostId18=524163'
+    body: HostId1=746360&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746361&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746355&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746365&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746366&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746373&Address6=challengetoken2&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.deleterecordinset&RecordType6=TXT&HostId7=746362&Address7=challengetoken&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.fqdn&RecordType7=TXT&HostId8=746363&Address8=challengetoken&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.full&RecordType8=TXT&HostId9=746376&Address9=challengetoken1&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.listrecordset&RecordType9=TXT&HostId10=746377&Address10=challengetoken2&MXPref10=10&TTL10=3600&AssociatedAppTitle10=&FriendlyName10=&IsActive10=true&IsDDNSEnabled10=false&HostName10=_acme-challenge.listrecordset&RecordType10=TXT&HostId11=746367&Address11=challengetoken&MXPref11=10&TTL11=3600&AssociatedAppTitle11=&FriendlyName11=&IsActive11=true&IsDDNSEnabled11=false&HostName11=_acme-challenge.noop&RecordType11=TXT&HostId12=746364&Address12=challengetoken&MXPref12=10&TTL12=3600&AssociatedAppTitle12=&FriendlyName12=&IsActive12=true&IsDDNSEnabled12=false&HostName12=_acme-challenge.test&RecordType12=TXT&HostId13=746383&Address13=challengetoken&MXPref13=10&TTL13=3600&AssociatedAppTitle13=&FriendlyName13=&IsActive13=true&IsDDNSEnabled13=false&HostName13=orig.nameonly.test&RecordType13=TXT&HostId14=746384&Address14=updated&MXPref14=10&TTL14=3600&AssociatedAppTitle14=&FriendlyName14=&IsActive14=true&IsDDNSEnabled14=false&HostName14=orig.nameonly.test&RecordType14=TXT&HostId15=746381&Address15=challengetoken&MXPref15=10&TTL15=3600&AssociatedAppTitle15=&FriendlyName15=&IsActive15=true&IsDDNSEnabled15=false&HostName15=orig.test&RecordType15=TXT&HostId16=746385&Address16=challengetoken&MXPref16=10&TTL16=3600&AssociatedAppTitle16=&FriendlyName16=&IsActive16=true&IsDDNSEnabled16=false&HostName16=orig.testfqdn&RecordType16=TXT&HostId17=746387&Address17=challengetoken&MXPref17=10&TTL17=3600&AssociatedAppTitle17=&FriendlyName17=&IsActive17=true&IsDDNSEnabled17=false&HostName17=orig.testfull&RecordType17=TXT&HostId18=746378&Address18=challengetoken&MXPref18=10&TTL18=3600&AssociatedAppTitle18=&FriendlyName18=&IsActive18=true&IsDDNSEnabled18=false&HostName18=random.fqdntest&RecordType18=TXT&HostId19=746379&Address19=challengetoken&MXPref19=10&TTL19=3600&AssociatedAppTitle19=&FriendlyName19=&IsActive19=true&IsDDNSEnabled19=false&HostName19=random.fulltest&RecordType19=TXT&HostId20=746380&Address20=challengetoken&MXPref20=10&TTL20=3600&AssociatedAppTitle20=&FriendlyName20=&IsActive20=true&IsDDNSEnabled20=false&HostName20=random.test&RecordType20=TXT&HostId21=746382&Address21=challengetoken&MXPref21=10&TTL21=3600&AssociatedAppTitle21=&FriendlyName21=&IsActive21=true&IsDDNSEnabled21=false&HostName21=updated.test&RecordType21=TXT&HostId22=746386&Address22=challengetoken&MXPref22=10&TTL22=3600&AssociatedAppTitle22=&FriendlyName22=&IsActive22=true&IsDDNSEnabled22=false&HostName22=updated.testfqdn&RecordType22=TXT&HostId23=746388&Address23=challengetoken&MXPref23=10&TTL23=3600&AssociatedAppTitle23=&FriendlyName23=&IsActive23=true&IsDDNSEnabled23=false&HostName23=updated.testfull&RecordType23=TXT&HostId24=746354&Address24=http%3A%2F%2Fwww.unittest2.dev%2F&MXPref24=10&TTL24=1800&AssociatedAppTitle24=URL+Forwarding&FriendlyName24=URL+Record&IsActive24=true&IsDDNSEnabled24=false&HostName24=%40&RecordType24=URL&Address25=challengetoken&TTL25=3600&HostName25=orig.test&RecordType25=TXT&SLD=unittest2&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['4525']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '4534'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>1.081</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest2.dev\" IsSuccess=\"true\">\r\n      <Warnings />\r\n    </DomainDNSSetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.773</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['559']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:43:05 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:01:32 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '557'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest2&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
-        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524842\" Name=\"_acme-challenge.listrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524843\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524833\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524158\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524214\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
-        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
-        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.977</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest2.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n      <host
+        HostId=\"746360\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746361\" Name=\"docs\" Type=\"CNAME\" Address=\"docs.example.com.\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746355\" Name=\"www\" Type=\"CNAME\"
+        Address=\"parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\"
+        FriendlyName=\"CNAME Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n
+        \     <host HostId=\"746365\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746366\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746373\" Name=\"_acme-challenge.deleterecordinset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746362\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746363\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746376\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746377\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746367\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746364\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746383\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746384\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746381\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746385\" Name=\"orig.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746387\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746378\" Name=\"random.fqdntest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746379\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746380\" Name=\"random.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746382\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746386\" Name=\"updated.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746388\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746354\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest2.dev/\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL
+        Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.595</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['5215']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:43:08 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:01:33 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '5220'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest2&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
-        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524842\" Name=\"_acme-challenge.listrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524843\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524833\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524158\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524214\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
-        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
-        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>1.004</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest2.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n      <host
+        HostId=\"746360\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746361\" Name=\"docs\" Type=\"CNAME\" Address=\"docs.example.com.\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746355\" Name=\"www\" Type=\"CNAME\"
+        Address=\"parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\"
+        FriendlyName=\"CNAME Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n
+        \     <host HostId=\"746365\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746366\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746373\" Name=\"_acme-challenge.deleterecordinset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746362\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746363\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746376\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746377\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746367\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746364\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746383\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746384\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746381\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746385\" Name=\"orig.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746387\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746378\" Name=\"random.fqdntest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746379\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746380\" Name=\"random.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746382\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746386\" Name=\"updated.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746388\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746354\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest2.dev/\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL
+        Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.304</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['5215']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:43:09 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:01:36 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '5220'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest2&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
-        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524842\" Name=\"_acme-challenge.listrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524843\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524833\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524158\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524214\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
-        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
-        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.752</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest2.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n      <host
+        HostId=\"746360\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746361\" Name=\"docs\" Type=\"CNAME\" Address=\"docs.example.com.\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746355\" Name=\"www\" Type=\"CNAME\"
+        Address=\"parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\"
+        FriendlyName=\"CNAME Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n
+        \     <host HostId=\"746365\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746366\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746373\" Name=\"_acme-challenge.deleterecordinset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746362\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746363\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746376\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746377\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746367\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746364\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746383\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746384\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746381\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746385\" Name=\"orig.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746387\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746378\" Name=\"random.fqdntest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746379\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746380\" Name=\"random.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746382\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746386\" Name=\"updated.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746388\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746354\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest2.dev/\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL
+        Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.303</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['5215']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:43:11 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:01:36 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '5220'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'RecordType21=TXT&HostId19=524164&RecordType20=TXT&RecordType23=TXT&MXPref24=10&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&IsDDNSEnabled23=false&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524157&HostId9=524842&IsDDNSEnabled24=false&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524831&HostId5=524832&HostId6=524839&HostId7=524156&IsDDNSEnabled22=false&MXPref23=10&HostId24=524160&HostId23=524173&HostId22=524171&HostId21=524167&HostId20=524165&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=CName+Record&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524158&HostId13=524168&HostId10=524843&HostId11=524833&HostId16=524170&HostId17=524172&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken1&FriendlyName24=URL+Record&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=&FriendlyName23=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&AssociatedAppTitle23=&HostName12=_acme-challenge.test&HostName13=orig.nameonly.test&HostName10=_acme-challenge.listrecordset&HostName11=_acme-challenge.noop&HostName16=orig.testfqdn&HostName17=orig.testfull&HostName14=orig.nameonly.test&Address1=127.0.0.1&HostName18=random.fqdntest&HostName19=random.fulltest&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=60&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=60&TTL14=1800&RecordType24=URL&TTL24=1800&TTL23=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&HostName24=yyy&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&AssociatedAppTitle22=&AssociatedAppTitle24=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&RecordType25=TXT&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.listrecordset&Address10=challengetoken2&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=updated&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName23=updated.testfull&HostName22=updated.testfqdn&HostName21=updated.test&HostName20=random.test&TTL10=1800&HostName25=updated.test&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&IsActive23=true&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&IsActive24=true&SLD=example-aptise&MXPref4=10&Address25=challengetoken&Address24=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&Address23=challengetoken&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524214&AssociatedAppTitle19=&HostId15=524166&HostId18=524163'
+    body: HostId1=746360&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746361&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746355&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746365&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746366&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746373&Address6=challengetoken2&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.deleterecordinset&RecordType6=TXT&HostId7=746362&Address7=challengetoken&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.fqdn&RecordType7=TXT&HostId8=746363&Address8=challengetoken&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.full&RecordType8=TXT&HostId9=746376&Address9=challengetoken1&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.listrecordset&RecordType9=TXT&HostId10=746377&Address10=challengetoken2&MXPref10=10&TTL10=3600&AssociatedAppTitle10=&FriendlyName10=&IsActive10=true&IsDDNSEnabled10=false&HostName10=_acme-challenge.listrecordset&RecordType10=TXT&HostId11=746367&Address11=challengetoken&MXPref11=10&TTL11=3600&AssociatedAppTitle11=&FriendlyName11=&IsActive11=true&IsDDNSEnabled11=false&HostName11=_acme-challenge.noop&RecordType11=TXT&HostId12=746364&Address12=challengetoken&MXPref12=10&TTL12=3600&AssociatedAppTitle12=&FriendlyName12=&IsActive12=true&IsDDNSEnabled12=false&HostName12=_acme-challenge.test&RecordType12=TXT&HostId13=746383&Address13=challengetoken&MXPref13=10&TTL13=3600&AssociatedAppTitle13=&FriendlyName13=&IsActive13=true&IsDDNSEnabled13=false&HostName13=orig.nameonly.test&RecordType13=TXT&HostId14=746384&Address14=updated&MXPref14=10&TTL14=3600&AssociatedAppTitle14=&FriendlyName14=&IsActive14=true&IsDDNSEnabled14=false&HostName14=orig.nameonly.test&RecordType14=TXT&HostId15=746381&Address15=challengetoken&MXPref15=10&TTL15=3600&AssociatedAppTitle15=&FriendlyName15=&IsActive15=true&IsDDNSEnabled15=false&HostName15=orig.test&RecordType15=TXT&HostId16=746385&Address16=challengetoken&MXPref16=10&TTL16=3600&AssociatedAppTitle16=&FriendlyName16=&IsActive16=true&IsDDNSEnabled16=false&HostName16=orig.testfqdn&RecordType16=TXT&HostId17=746387&Address17=challengetoken&MXPref17=10&TTL17=3600&AssociatedAppTitle17=&FriendlyName17=&IsActive17=true&IsDDNSEnabled17=false&HostName17=orig.testfull&RecordType17=TXT&HostId18=746378&Address18=challengetoken&MXPref18=10&TTL18=3600&AssociatedAppTitle18=&FriendlyName18=&IsActive18=true&IsDDNSEnabled18=false&HostName18=random.fqdntest&RecordType18=TXT&HostId19=746379&Address19=challengetoken&MXPref19=10&TTL19=3600&AssociatedAppTitle19=&FriendlyName19=&IsActive19=true&IsDDNSEnabled19=false&HostName19=random.fulltest&RecordType19=TXT&HostId20=746380&Address20=challengetoken&MXPref20=10&TTL20=3600&AssociatedAppTitle20=&FriendlyName20=&IsActive20=true&IsDDNSEnabled20=false&HostName20=random.test&RecordType20=TXT&HostId21=746382&Address21=challengetoken&MXPref21=10&TTL21=3600&AssociatedAppTitle21=&FriendlyName21=&IsActive21=true&IsDDNSEnabled21=false&HostName21=updated.test&RecordType21=TXT&HostId22=746386&Address22=challengetoken&MXPref22=10&TTL22=3600&AssociatedAppTitle22=&FriendlyName22=&IsActive22=true&IsDDNSEnabled22=false&HostName22=updated.testfqdn&RecordType22=TXT&HostId23=746388&Address23=challengetoken&MXPref23=10&TTL23=3600&AssociatedAppTitle23=&FriendlyName23=&IsActive23=true&IsDDNSEnabled23=false&HostName23=updated.testfull&RecordType23=TXT&HostId24=746354&Address24=http%3A%2F%2Fwww.unittest2.dev%2F&MXPref24=10&TTL24=1800&AssociatedAppTitle24=URL+Forwarding&FriendlyName24=URL+Record&IsActive24=true&IsDDNSEnabled24=false&HostName24=%40&RecordType24=URL&Address25=challengetoken&TTL25=3600&HostName25=updated.test&RecordType25=TXT&SLD=unittest2&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['4528']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '4537'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>1.019</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest2.dev\" IsSuccess=\"true\">\r\n      <Warnings />\r\n    </DomainDNSSetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.643</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['559']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:43:12 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:01:38 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '557'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/namecheap/IntegrationTests/test_provider_when_calling_update_record_should_modify_record_name_specified.yaml
+++ b/tests/fixtures/cassettes/namecheap/IntegrationTests/test_provider_when_calling_update_record_should_modify_record_name_specified.yaml
@@ -2,504 +2,611 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise.com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=unittest2.dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
-        \ Status=\"Ok\" ID=\"277432\" DomainName=\"example-aptise.com\" OwnerName=\"\
-        jvsandbox\" IsOwner=\"true\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
-        \n        <CreatedDate>03/25/2018</CreatedDate>\r\n        <ExpiredDate>03/25/2019</ExpiredDate>\r\
-        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
-        \ />\r\n      <Whoisguard Enabled=\"NotAlloted\">\r\n        <ID>0</ID>\r\n\
-        \      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
-        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
-        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
-        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
-        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"24\" EmailType=\"\
-        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
-        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
-        \n      <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.043</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult
+        Status=\"Ok\" ID=\"589667\" DomainName=\"unittest2.dev\" OwnerName=\"phassberg\"
+        IsOwner=\"true\" IsPremium=\"false\">\r\n      <DomainDetails>\r\n        <CreatedDate>05/20/2020</CreatedDate>\r\n
+        \       <ExpiredDate>05/20/2021</ExpiredDate>\r\n        <NumYears>0</NumYears>\r\n
+        \     </DomainDetails>\r\n      <LockDetails />\r\n      <Whoisguard Enabled=\"True\">\r\n
+        \       <ID>481121</ID>\r\n        <ExpiredDate>05/20/2021</ExpiredDate>\r\n
+        \       <EmailDetails WhoisGuardEmail=\"824017ccbed343119b3459c7d3304ba5.protect@whoisguard.com\"
+        ForwardedTo=\"dr.doddo@gmail.com\" LastAutoEmailChangeDate=\"05/20/2020\"
+        AutoEmailChangeFrequencyDays=\"3\" />\r\n      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n
+        \       <UseAutoRenew>false</UseAutoRenew>\r\n        <SubscriptionId>-1</SubscriptionId>\r\n
+        \       <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n
+        \       <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n
+        \     <DnsDetails ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"24\"
+        EmailType=\"FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\n
+        \       <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\n
+        \     <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.018</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['1493']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:43:12 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:01:38 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '1740'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest2&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
-        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524842\" Name=\"_acme-challenge.listrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524843\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524833\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524158\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524214\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
-        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
-        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.679</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest2.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n      <host
+        HostId=\"746360\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746361\" Name=\"docs\" Type=\"CNAME\" Address=\"docs.example.com.\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746355\" Name=\"www\" Type=\"CNAME\"
+        Address=\"parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\"
+        FriendlyName=\"CNAME Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n
+        \     <host HostId=\"746365\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746366\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746373\" Name=\"_acme-challenge.deleterecordinset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746362\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746363\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746376\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746377\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746367\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746364\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746383\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746384\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746381\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746385\" Name=\"orig.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746387\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746378\" Name=\"random.fqdntest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746379\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746380\" Name=\"random.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746382\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746386\" Name=\"updated.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746388\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746354\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest2.dev/\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL
+        Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.579</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['5215']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:43:14 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:01:41 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '5220'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'RecordType21=TXT&HostId19=524164&RecordType20=TXT&RecordType23=TXT&MXPref24=10&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&IsDDNSEnabled23=false&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524157&HostId9=524842&IsDDNSEnabled24=false&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524831&HostId5=524832&HostId6=524839&HostId7=524156&IsDDNSEnabled22=false&MXPref23=10&HostId24=524160&HostId23=524173&HostId22=524171&HostId21=524167&HostId20=524165&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=CName+Record&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524158&HostId13=524168&HostId10=524843&HostId11=524833&HostId16=524170&HostId17=524172&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken1&FriendlyName24=URL+Record&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=&FriendlyName23=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&AssociatedAppTitle23=&HostName12=_acme-challenge.test&HostName13=orig.nameonly.test&HostName10=_acme-challenge.listrecordset&HostName11=_acme-challenge.noop&HostName16=orig.testfqdn&HostName17=orig.testfull&HostName14=orig.nameonly.test&Address1=127.0.0.1&HostName18=random.fqdntest&HostName19=random.fulltest&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=60&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=60&TTL14=1800&RecordType24=URL&TTL24=1800&TTL23=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&HostName24=yyy&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&AssociatedAppTitle22=&AssociatedAppTitle24=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&RecordType25=TXT&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.listrecordset&Address10=challengetoken2&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=updated&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName23=updated.testfull&HostName22=updated.testfqdn&HostName21=updated.test&HostName20=random.test&TTL10=1800&HostName25=orig.nameonly.test&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&IsActive23=true&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&IsActive24=true&SLD=example-aptise&MXPref4=10&Address25=challengetoken&Address24=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&Address23=challengetoken&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524214&AssociatedAppTitle19=&HostId15=524166&HostId18=524163'
+    body: HostId1=746360&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746361&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746355&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746365&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746366&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746373&Address6=challengetoken2&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.deleterecordinset&RecordType6=TXT&HostId7=746362&Address7=challengetoken&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.fqdn&RecordType7=TXT&HostId8=746363&Address8=challengetoken&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.full&RecordType8=TXT&HostId9=746376&Address9=challengetoken1&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.listrecordset&RecordType9=TXT&HostId10=746377&Address10=challengetoken2&MXPref10=10&TTL10=3600&AssociatedAppTitle10=&FriendlyName10=&IsActive10=true&IsDDNSEnabled10=false&HostName10=_acme-challenge.listrecordset&RecordType10=TXT&HostId11=746367&Address11=challengetoken&MXPref11=10&TTL11=3600&AssociatedAppTitle11=&FriendlyName11=&IsActive11=true&IsDDNSEnabled11=false&HostName11=_acme-challenge.noop&RecordType11=TXT&HostId12=746364&Address12=challengetoken&MXPref12=10&TTL12=3600&AssociatedAppTitle12=&FriendlyName12=&IsActive12=true&IsDDNSEnabled12=false&HostName12=_acme-challenge.test&RecordType12=TXT&HostId13=746383&Address13=challengetoken&MXPref13=10&TTL13=3600&AssociatedAppTitle13=&FriendlyName13=&IsActive13=true&IsDDNSEnabled13=false&HostName13=orig.nameonly.test&RecordType13=TXT&HostId14=746384&Address14=updated&MXPref14=10&TTL14=3600&AssociatedAppTitle14=&FriendlyName14=&IsActive14=true&IsDDNSEnabled14=false&HostName14=orig.nameonly.test&RecordType14=TXT&HostId15=746381&Address15=challengetoken&MXPref15=10&TTL15=3600&AssociatedAppTitle15=&FriendlyName15=&IsActive15=true&IsDDNSEnabled15=false&HostName15=orig.test&RecordType15=TXT&HostId16=746385&Address16=challengetoken&MXPref16=10&TTL16=3600&AssociatedAppTitle16=&FriendlyName16=&IsActive16=true&IsDDNSEnabled16=false&HostName16=orig.testfqdn&RecordType16=TXT&HostId17=746387&Address17=challengetoken&MXPref17=10&TTL17=3600&AssociatedAppTitle17=&FriendlyName17=&IsActive17=true&IsDDNSEnabled17=false&HostName17=orig.testfull&RecordType17=TXT&HostId18=746378&Address18=challengetoken&MXPref18=10&TTL18=3600&AssociatedAppTitle18=&FriendlyName18=&IsActive18=true&IsDDNSEnabled18=false&HostName18=random.fqdntest&RecordType18=TXT&HostId19=746379&Address19=challengetoken&MXPref19=10&TTL19=3600&AssociatedAppTitle19=&FriendlyName19=&IsActive19=true&IsDDNSEnabled19=false&HostName19=random.fulltest&RecordType19=TXT&HostId20=746380&Address20=challengetoken&MXPref20=10&TTL20=3600&AssociatedAppTitle20=&FriendlyName20=&IsActive20=true&IsDDNSEnabled20=false&HostName20=random.test&RecordType20=TXT&HostId21=746382&Address21=challengetoken&MXPref21=10&TTL21=3600&AssociatedAppTitle21=&FriendlyName21=&IsActive21=true&IsDDNSEnabled21=false&HostName21=updated.test&RecordType21=TXT&HostId22=746386&Address22=challengetoken&MXPref22=10&TTL22=3600&AssociatedAppTitle22=&FriendlyName22=&IsActive22=true&IsDDNSEnabled22=false&HostName22=updated.testfqdn&RecordType22=TXT&HostId23=746388&Address23=challengetoken&MXPref23=10&TTL23=3600&AssociatedAppTitle23=&FriendlyName23=&IsActive23=true&IsDDNSEnabled23=false&HostName23=updated.testfull&RecordType23=TXT&HostId24=746354&Address24=http%3A%2F%2Fwww.unittest2.dev%2F&MXPref24=10&TTL24=1800&AssociatedAppTitle24=URL+Forwarding&FriendlyName24=URL+Record&IsActive24=true&IsDDNSEnabled24=false&HostName24=%40&RecordType24=URL&Address25=challengetoken&TTL25=3600&HostName25=orig.nameonly.test&RecordType25=TXT&SLD=unittest2&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['4534']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '4543'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.802</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest2.dev\" IsSuccess=\"true\">\r\n      <Warnings />\r\n    </DomainDNSSetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.921</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['559']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:43:15 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:01:42 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '557'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest2&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
-        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524842\" Name=\"_acme-challenge.listrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524843\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524833\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524158\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524214\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
-        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
-        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.742</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest2.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n      <host
+        HostId=\"746360\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746361\" Name=\"docs\" Type=\"CNAME\" Address=\"docs.example.com.\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746355\" Name=\"www\" Type=\"CNAME\"
+        Address=\"parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\"
+        FriendlyName=\"CNAME Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n
+        \     <host HostId=\"746365\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746366\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746373\" Name=\"_acme-challenge.deleterecordinset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746362\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746363\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746376\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746377\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746367\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746364\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746383\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746384\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746381\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746385\" Name=\"orig.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746387\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746378\" Name=\"random.fqdntest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746379\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746380\" Name=\"random.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746382\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746386\" Name=\"updated.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746388\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746354\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest2.dev/\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL
+        Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.419</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['5215']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:43:16 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:01:43 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '5220'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest2&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
-        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524842\" Name=\"_acme-challenge.listrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524843\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524833\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524158\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524214\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
-        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
-        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.943</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest2.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n      <host
+        HostId=\"746360\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746361\" Name=\"docs\" Type=\"CNAME\" Address=\"docs.example.com.\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746355\" Name=\"www\" Type=\"CNAME\"
+        Address=\"parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\"
+        FriendlyName=\"CNAME Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n
+        \     <host HostId=\"746365\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746366\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746373\" Name=\"_acme-challenge.deleterecordinset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746362\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746363\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746376\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746377\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746367\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746364\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746383\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746384\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746381\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746385\" Name=\"orig.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746387\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746378\" Name=\"random.fqdntest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746379\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746380\" Name=\"random.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746382\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746386\" Name=\"updated.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746388\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746354\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest2.dev/\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL
+        Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.342</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['5215']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:43:18 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:01:45 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '5220'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'RecordType21=TXT&HostId19=524165&RecordType20=TXT&RecordType23=URL&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&IsDDNSEnabled23=false&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524157&HostId9=524842&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524831&HostId5=524832&HostId6=524839&HostId7=524156&IsDDNSEnabled22=false&MXPref23=10&HostId23=524160&HostId22=524173&HostId21=524171&HostId20=524167&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=CName+Record&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524158&HostId13=524168&HostId10=524843&HostId11=524833&HostId16=524172&HostId17=524163&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken1&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=&FriendlyName23=URL+Record&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&AssociatedAppTitle23=&HostName12=_acme-challenge.test&HostName13=orig.nameonly.test&HostName10=_acme-challenge.listrecordset&HostName11=_acme-challenge.noop&HostName16=orig.testfull&HostName17=random.fqdntest&HostName14=orig.test&Address1=127.0.0.1&HostName18=random.fulltest&HostName19=random.test&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=60&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=60&TTL14=1800&TTL23=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&AssociatedAppTitle22=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.listrecordset&Address10=challengetoken2&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName23=yyy&HostName22=updated.testfull&HostName21=updated.testfqdn&HostName20=updated.test&TTL10=1800&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&IsActive23=true&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.testfqdn&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&SLD=example-aptise&MXPref4=10&Address23=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524166&AssociatedAppTitle19=&HostId15=524170&HostId18=524164'
+    body: HostId1=746360&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746361&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746355&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746365&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746366&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746373&Address6=challengetoken2&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.deleterecordinset&RecordType6=TXT&HostId7=746362&Address7=challengetoken&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.fqdn&RecordType7=TXT&HostId8=746363&Address8=challengetoken&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.full&RecordType8=TXT&HostId9=746376&Address9=challengetoken1&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.listrecordset&RecordType9=TXT&HostId10=746377&Address10=challengetoken2&MXPref10=10&TTL10=3600&AssociatedAppTitle10=&FriendlyName10=&IsActive10=true&IsDDNSEnabled10=false&HostName10=_acme-challenge.listrecordset&RecordType10=TXT&HostId11=746367&Address11=challengetoken&MXPref11=10&TTL11=3600&AssociatedAppTitle11=&FriendlyName11=&IsActive11=true&IsDDNSEnabled11=false&HostName11=_acme-challenge.noop&RecordType11=TXT&HostId12=746364&Address12=challengetoken&MXPref12=10&TTL12=3600&AssociatedAppTitle12=&FriendlyName12=&IsActive12=true&IsDDNSEnabled12=false&HostName12=_acme-challenge.test&RecordType12=TXT&HostId13=746383&Address13=challengetoken&MXPref13=10&TTL13=3600&AssociatedAppTitle13=&FriendlyName13=&IsActive13=true&IsDDNSEnabled13=false&HostName13=orig.nameonly.test&RecordType13=TXT&HostId14=746381&Address14=challengetoken&MXPref14=10&TTL14=3600&AssociatedAppTitle14=&FriendlyName14=&IsActive14=true&IsDDNSEnabled14=false&HostName14=orig.test&RecordType14=TXT&HostId15=746385&Address15=challengetoken&MXPref15=10&TTL15=3600&AssociatedAppTitle15=&FriendlyName15=&IsActive15=true&IsDDNSEnabled15=false&HostName15=orig.testfqdn&RecordType15=TXT&HostId16=746387&Address16=challengetoken&MXPref16=10&TTL16=3600&AssociatedAppTitle16=&FriendlyName16=&IsActive16=true&IsDDNSEnabled16=false&HostName16=orig.testfull&RecordType16=TXT&HostId17=746378&Address17=challengetoken&MXPref17=10&TTL17=3600&AssociatedAppTitle17=&FriendlyName17=&IsActive17=true&IsDDNSEnabled17=false&HostName17=random.fqdntest&RecordType17=TXT&HostId18=746379&Address18=challengetoken&MXPref18=10&TTL18=3600&AssociatedAppTitle18=&FriendlyName18=&IsActive18=true&IsDDNSEnabled18=false&HostName18=random.fulltest&RecordType18=TXT&HostId19=746380&Address19=challengetoken&MXPref19=10&TTL19=3600&AssociatedAppTitle19=&FriendlyName19=&IsActive19=true&IsDDNSEnabled19=false&HostName19=random.test&RecordType19=TXT&HostId20=746382&Address20=challengetoken&MXPref20=10&TTL20=3600&AssociatedAppTitle20=&FriendlyName20=&IsActive20=true&IsDDNSEnabled20=false&HostName20=updated.test&RecordType20=TXT&HostId21=746386&Address21=challengetoken&MXPref21=10&TTL21=3600&AssociatedAppTitle21=&FriendlyName21=&IsActive21=true&IsDDNSEnabled21=false&HostName21=updated.testfqdn&RecordType21=TXT&HostId22=746388&Address22=challengetoken&MXPref22=10&TTL22=3600&AssociatedAppTitle22=&FriendlyName22=&IsActive22=true&IsDDNSEnabled22=false&HostName22=updated.testfull&RecordType22=TXT&HostId23=746354&Address23=http%3A%2F%2Fwww.unittest2.dev%2F&MXPref23=10&TTL23=1800&AssociatedAppTitle23=URL+Forwarding&FriendlyName23=URL+Record&IsActive23=true&IsDDNSEnabled23=false&HostName23=%40&RecordType23=URL&SLD=unittest2&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['4282']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '4280'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.996</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest2.dev\" IsSuccess=\"true\">\r\n      <Warnings />\r\n    </DomainDNSSetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.721</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['559']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:43:19 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:01:46 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '557'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest2&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
-        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524842\" Name=\"_acme-challenge.listrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524843\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524833\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524158\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524166\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"\
-        orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524163\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\"\
-        \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524165\" Name=\"random.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524167\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524171\" Name=\"\
-        updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524160\" Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
-        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.794</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest2.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n      <host
+        HostId=\"746360\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746361\" Name=\"docs\" Type=\"CNAME\" Address=\"docs.example.com.\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746355\" Name=\"www\" Type=\"CNAME\"
+        Address=\"parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\"
+        FriendlyName=\"CNAME Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n
+        \     <host HostId=\"746365\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746366\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746373\" Name=\"_acme-challenge.deleterecordinset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746362\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746363\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746376\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746377\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746367\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746364\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746383\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746381\" Name=\"orig.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746385\" Name=\"orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746387\" Name=\"orig.testfull\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746378\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746379\" Name=\"random.fulltest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746380\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746382\" Name=\"updated.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746386\" Name=\"updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746388\" Name=\"updated.testfull\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746354\" Name=\"@\" Type=\"URL\" Address=\"http://www.unittest2.dev/\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL
+        Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.158</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['5029']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:43:21 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:01:47 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '5034'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'RecordType21=TXT&HostId19=524165&RecordType20=TXT&RecordType23=URL&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&IsDDNSEnabled23=false&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524157&HostId9=524842&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524831&HostId5=524832&HostId6=524839&HostId7=524156&IsDDNSEnabled22=false&MXPref23=10&HostId23=524160&HostId22=524173&HostId21=524171&HostId20=524167&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=CName+Record&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524158&HostId13=524168&HostId10=524843&HostId11=524833&HostId16=524172&HostId17=524163&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken1&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=&FriendlyName23=URL+Record&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&AssociatedAppTitle23=&HostName12=_acme-challenge.test&HostName13=orig.nameonly.test&HostName10=_acme-challenge.listrecordset&HostName11=_acme-challenge.noop&HostName16=orig.testfull&HostName17=random.fqdntest&HostName14=orig.test&Address1=127.0.0.1&HostName18=random.fulltest&HostName19=random.test&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=60&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=60&TTL14=1800&RecordType24=TXT&TTL23=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&HostName24=orig.nameonly.test&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&AssociatedAppTitle22=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.listrecordset&Address10=challengetoken2&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName23=yyy&HostName22=updated.testfull&HostName21=updated.testfqdn&HostName20=updated.test&TTL10=1800&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&IsActive23=true&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.testfqdn&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&SLD=example-aptise&MXPref4=10&Address24=updated&Address23=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524166&AssociatedAppTitle19=&HostId15=524170&HostId18=524164'
+    body: HostId1=746360&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746361&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746355&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746365&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746366&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746373&Address6=challengetoken2&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.deleterecordinset&RecordType6=TXT&HostId7=746362&Address7=challengetoken&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.fqdn&RecordType7=TXT&HostId8=746363&Address8=challengetoken&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.full&RecordType8=TXT&HostId9=746376&Address9=challengetoken1&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.listrecordset&RecordType9=TXT&HostId10=746377&Address10=challengetoken2&MXPref10=10&TTL10=3600&AssociatedAppTitle10=&FriendlyName10=&IsActive10=true&IsDDNSEnabled10=false&HostName10=_acme-challenge.listrecordset&RecordType10=TXT&HostId11=746367&Address11=challengetoken&MXPref11=10&TTL11=3600&AssociatedAppTitle11=&FriendlyName11=&IsActive11=true&IsDDNSEnabled11=false&HostName11=_acme-challenge.noop&RecordType11=TXT&HostId12=746364&Address12=challengetoken&MXPref12=10&TTL12=3600&AssociatedAppTitle12=&FriendlyName12=&IsActive12=true&IsDDNSEnabled12=false&HostName12=_acme-challenge.test&RecordType12=TXT&HostId13=746383&Address13=challengetoken&MXPref13=10&TTL13=3600&AssociatedAppTitle13=&FriendlyName13=&IsActive13=true&IsDDNSEnabled13=false&HostName13=orig.nameonly.test&RecordType13=TXT&HostId14=746381&Address14=challengetoken&MXPref14=10&TTL14=3600&AssociatedAppTitle14=&FriendlyName14=&IsActive14=true&IsDDNSEnabled14=false&HostName14=orig.test&RecordType14=TXT&HostId15=746385&Address15=challengetoken&MXPref15=10&TTL15=3600&AssociatedAppTitle15=&FriendlyName15=&IsActive15=true&IsDDNSEnabled15=false&HostName15=orig.testfqdn&RecordType15=TXT&HostId16=746387&Address16=challengetoken&MXPref16=10&TTL16=3600&AssociatedAppTitle16=&FriendlyName16=&IsActive16=true&IsDDNSEnabled16=false&HostName16=orig.testfull&RecordType16=TXT&HostId17=746378&Address17=challengetoken&MXPref17=10&TTL17=3600&AssociatedAppTitle17=&FriendlyName17=&IsActive17=true&IsDDNSEnabled17=false&HostName17=random.fqdntest&RecordType17=TXT&HostId18=746379&Address18=challengetoken&MXPref18=10&TTL18=3600&AssociatedAppTitle18=&FriendlyName18=&IsActive18=true&IsDDNSEnabled18=false&HostName18=random.fulltest&RecordType18=TXT&HostId19=746380&Address19=challengetoken&MXPref19=10&TTL19=3600&AssociatedAppTitle19=&FriendlyName19=&IsActive19=true&IsDDNSEnabled19=false&HostName19=random.test&RecordType19=TXT&HostId20=746382&Address20=challengetoken&MXPref20=10&TTL20=3600&AssociatedAppTitle20=&FriendlyName20=&IsActive20=true&IsDDNSEnabled20=false&HostName20=updated.test&RecordType20=TXT&HostId21=746386&Address21=challengetoken&MXPref21=10&TTL21=3600&AssociatedAppTitle21=&FriendlyName21=&IsActive21=true&IsDDNSEnabled21=false&HostName21=updated.testfqdn&RecordType21=TXT&HostId22=746388&Address22=challengetoken&MXPref22=10&TTL22=3600&AssociatedAppTitle22=&FriendlyName22=&IsActive22=true&IsDDNSEnabled22=false&HostName22=updated.testfull&RecordType22=TXT&HostId23=746354&Address23=http%3A%2F%2Fwww.unittest2.dev%2F&MXPref23=10&TTL23=1800&AssociatedAppTitle23=URL+Forwarding&FriendlyName23=URL+Record&IsActive23=true&IsDDNSEnabled23=false&HostName23=%40&RecordType23=URL&Address24=updated&TTL24=3600&HostName24=orig.nameonly.test&RecordType24=TXT&SLD=unittest2&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['4347']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '4356'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.748</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest2.dev\" IsSuccess=\"true\">\r\n      <Warnings />\r\n    </DomainDNSSetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.966</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['559']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:43:22 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:01:48 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '557'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/namecheap/IntegrationTests/test_provider_when_calling_update_record_with_fqdn_name_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/namecheap/IntegrationTests/test_provider_when_calling_update_record_with_fqdn_name_should_modify_record.yaml
@@ -2,477 +2,567 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise.com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=unittest2.dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
-        \ Status=\"Ok\" ID=\"277432\" DomainName=\"example-aptise.com\" OwnerName=\"\
-        jvsandbox\" IsOwner=\"true\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
-        \n        <CreatedDate>03/25/2018</CreatedDate>\r\n        <ExpiredDate>03/25/2019</ExpiredDate>\r\
-        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
-        \ />\r\n      <Whoisguard Enabled=\"NotAlloted\">\r\n        <ID>0</ID>\r\n\
-        \      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
-        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
-        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
-        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
-        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"24\" EmailType=\"\
-        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
-        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
-        \n      <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.034</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult
+        Status=\"Ok\" ID=\"589667\" DomainName=\"unittest2.dev\" OwnerName=\"phassberg\"
+        IsOwner=\"true\" IsPremium=\"false\">\r\n      <DomainDetails>\r\n        <CreatedDate>05/20/2020</CreatedDate>\r\n
+        \       <ExpiredDate>05/20/2021</ExpiredDate>\r\n        <NumYears>0</NumYears>\r\n
+        \     </DomainDetails>\r\n      <LockDetails />\r\n      <Whoisguard Enabled=\"True\">\r\n
+        \       <ID>481121</ID>\r\n        <ExpiredDate>05/20/2021</ExpiredDate>\r\n
+        \       <EmailDetails WhoisGuardEmail=\"824017ccbed343119b3459c7d3304ba5.protect@whoisguard.com\"
+        ForwardedTo=\"dr.doddo@gmail.com\" LastAutoEmailChangeDate=\"05/20/2020\"
+        AutoEmailChangeFrequencyDays=\"3\" />\r\n      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n
+        \       <UseAutoRenew>false</UseAutoRenew>\r\n        <SubscriptionId>-1</SubscriptionId>\r\n
+        \       <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n
+        \       <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n
+        \     <DnsDetails ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"24\"
+        EmailType=\"FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\n
+        \       <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\n
+        \     <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.186</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['1493']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:43:23 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:01:50 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '1740'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest2&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
-        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524842\" Name=\"_acme-challenge.listrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524843\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524833\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524158\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524844\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
-        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
-        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.732</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest2.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n      <host
+        HostId=\"746360\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746361\" Name=\"docs\" Type=\"CNAME\" Address=\"docs.example.com.\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746355\" Name=\"www\" Type=\"CNAME\"
+        Address=\"parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\"
+        FriendlyName=\"CNAME Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n
+        \     <host HostId=\"746365\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746366\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746373\" Name=\"_acme-challenge.deleterecordinset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746362\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746363\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746376\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746377\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746367\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746364\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746383\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746389\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746381\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746385\" Name=\"orig.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746387\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746378\" Name=\"random.fqdntest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746379\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746380\" Name=\"random.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746382\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746386\" Name=\"updated.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746388\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746354\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest2.dev/\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL
+        Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.413</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['5215']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:43:24 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:01:51 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '5220'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'RecordType21=TXT&HostId19=524164&RecordType20=TXT&RecordType23=TXT&MXPref24=10&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&IsDDNSEnabled23=false&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524157&HostId9=524842&IsDDNSEnabled24=false&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524831&HostId5=524832&HostId6=524839&HostId7=524156&IsDDNSEnabled22=false&MXPref23=10&HostId24=524160&HostId23=524173&HostId22=524171&HostId21=524167&HostId20=524165&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=CName+Record&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524158&HostId13=524168&HostId10=524843&HostId11=524833&HostId16=524170&HostId17=524172&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken1&FriendlyName24=URL+Record&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=&FriendlyName23=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&AssociatedAppTitle23=&HostName12=_acme-challenge.test&HostName13=orig.nameonly.test&HostName10=_acme-challenge.listrecordset&HostName11=_acme-challenge.noop&HostName16=orig.testfqdn&HostName17=orig.testfull&HostName14=orig.nameonly.test&Address1=127.0.0.1&HostName18=random.fqdntest&HostName19=random.fulltest&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=60&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=60&TTL14=1800&RecordType24=URL&TTL24=1800&TTL23=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&HostName24=yyy&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&AssociatedAppTitle22=&AssociatedAppTitle24=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&RecordType25=TXT&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.listrecordset&Address10=challengetoken2&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=updated&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName23=updated.testfull&HostName22=updated.testfqdn&HostName21=updated.test&HostName20=random.test&TTL10=1800&HostName25=orig.testfqdn&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&IsActive23=true&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&IsActive24=true&SLD=example-aptise&MXPref4=10&Address25=challengetoken&Address24=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&Address23=challengetoken&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524844&AssociatedAppTitle19=&HostId15=524166&HostId18=524163'
+    body: HostId1=746360&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746361&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746355&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746365&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746366&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746373&Address6=challengetoken2&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.deleterecordinset&RecordType6=TXT&HostId7=746362&Address7=challengetoken&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.fqdn&RecordType7=TXT&HostId8=746363&Address8=challengetoken&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.full&RecordType8=TXT&HostId9=746376&Address9=challengetoken1&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.listrecordset&RecordType9=TXT&HostId10=746377&Address10=challengetoken2&MXPref10=10&TTL10=3600&AssociatedAppTitle10=&FriendlyName10=&IsActive10=true&IsDDNSEnabled10=false&HostName10=_acme-challenge.listrecordset&RecordType10=TXT&HostId11=746367&Address11=challengetoken&MXPref11=10&TTL11=3600&AssociatedAppTitle11=&FriendlyName11=&IsActive11=true&IsDDNSEnabled11=false&HostName11=_acme-challenge.noop&RecordType11=TXT&HostId12=746364&Address12=challengetoken&MXPref12=10&TTL12=3600&AssociatedAppTitle12=&FriendlyName12=&IsActive12=true&IsDDNSEnabled12=false&HostName12=_acme-challenge.test&RecordType12=TXT&HostId13=746383&Address13=challengetoken&MXPref13=10&TTL13=3600&AssociatedAppTitle13=&FriendlyName13=&IsActive13=true&IsDDNSEnabled13=false&HostName13=orig.nameonly.test&RecordType13=TXT&HostId14=746389&Address14=updated&MXPref14=10&TTL14=3600&AssociatedAppTitle14=&FriendlyName14=&IsActive14=true&IsDDNSEnabled14=false&HostName14=orig.nameonly.test&RecordType14=TXT&HostId15=746381&Address15=challengetoken&MXPref15=10&TTL15=3600&AssociatedAppTitle15=&FriendlyName15=&IsActive15=true&IsDDNSEnabled15=false&HostName15=orig.test&RecordType15=TXT&HostId16=746385&Address16=challengetoken&MXPref16=10&TTL16=3600&AssociatedAppTitle16=&FriendlyName16=&IsActive16=true&IsDDNSEnabled16=false&HostName16=orig.testfqdn&RecordType16=TXT&HostId17=746387&Address17=challengetoken&MXPref17=10&TTL17=3600&AssociatedAppTitle17=&FriendlyName17=&IsActive17=true&IsDDNSEnabled17=false&HostName17=orig.testfull&RecordType17=TXT&HostId18=746378&Address18=challengetoken&MXPref18=10&TTL18=3600&AssociatedAppTitle18=&FriendlyName18=&IsActive18=true&IsDDNSEnabled18=false&HostName18=random.fqdntest&RecordType18=TXT&HostId19=746379&Address19=challengetoken&MXPref19=10&TTL19=3600&AssociatedAppTitle19=&FriendlyName19=&IsActive19=true&IsDDNSEnabled19=false&HostName19=random.fulltest&RecordType19=TXT&HostId20=746380&Address20=challengetoken&MXPref20=10&TTL20=3600&AssociatedAppTitle20=&FriendlyName20=&IsActive20=true&IsDDNSEnabled20=false&HostName20=random.test&RecordType20=TXT&HostId21=746382&Address21=challengetoken&MXPref21=10&TTL21=3600&AssociatedAppTitle21=&FriendlyName21=&IsActive21=true&IsDDNSEnabled21=false&HostName21=updated.test&RecordType21=TXT&HostId22=746386&Address22=challengetoken&MXPref22=10&TTL22=3600&AssociatedAppTitle22=&FriendlyName22=&IsActive22=true&IsDDNSEnabled22=false&HostName22=updated.testfqdn&RecordType22=TXT&HostId23=746388&Address23=challengetoken&MXPref23=10&TTL23=3600&AssociatedAppTitle23=&FriendlyName23=&IsActive23=true&IsDDNSEnabled23=false&HostName23=updated.testfull&RecordType23=TXT&HostId24=746354&Address24=http%3A%2F%2Fwww.unittest2.dev%2F&MXPref24=10&TTL24=1800&AssociatedAppTitle24=URL+Forwarding&FriendlyName24=URL+Record&IsActive24=true&IsDDNSEnabled24=false&HostName24=%40&RecordType24=URL&Address25=challengetoken&TTL25=3600&HostName25=orig.testfqdn&RecordType25=TXT&SLD=unittest2&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['4529']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '4538'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.838</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest2.dev\" IsSuccess=\"true\">\r\n      <Warnings />\r\n    </DomainDNSSetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.459</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['559']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:43:26 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:01:52 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '557'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest2&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
-        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524842\" Name=\"_acme-challenge.listrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524843\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524833\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524158\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524844\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
-        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
-        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.694</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest2.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n      <host
+        HostId=\"746360\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746361\" Name=\"docs\" Type=\"CNAME\" Address=\"docs.example.com.\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746355\" Name=\"www\" Type=\"CNAME\"
+        Address=\"parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\"
+        FriendlyName=\"CNAME Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n
+        \     <host HostId=\"746365\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746366\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746373\" Name=\"_acme-challenge.deleterecordinset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746362\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746363\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746376\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746377\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746367\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746364\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746383\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746389\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746381\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746385\" Name=\"orig.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746387\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746378\" Name=\"random.fqdntest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746379\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746380\" Name=\"random.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746382\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746386\" Name=\"updated.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746388\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746354\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest2.dev/\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL
+        Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.38</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['5215']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:43:27 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:01:54 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '5219'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest2&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
-        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524842\" Name=\"_acme-challenge.listrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524843\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524833\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524158\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524844\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
-        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
-        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.599</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest2.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n      <host
+        HostId=\"746360\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746361\" Name=\"docs\" Type=\"CNAME\" Address=\"docs.example.com.\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746355\" Name=\"www\" Type=\"CNAME\"
+        Address=\"parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\"
+        FriendlyName=\"CNAME Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n
+        \     <host HostId=\"746365\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746366\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746373\" Name=\"_acme-challenge.deleterecordinset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746362\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746363\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746376\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746377\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746367\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746364\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746383\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746389\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746381\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746385\" Name=\"orig.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746387\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746378\" Name=\"random.fqdntest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746379\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746380\" Name=\"random.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746382\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746386\" Name=\"updated.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746388\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746354\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest2.dev/\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL
+        Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.336</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['5215']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:43:27 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:01:55 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '5220'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest2&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
-        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524842\" Name=\"_acme-challenge.listrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524843\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524833\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524158\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524844\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
-        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
-        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.777</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest2.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n      <host
+        HostId=\"746360\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746361\" Name=\"docs\" Type=\"CNAME\" Address=\"docs.example.com.\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746355\" Name=\"www\" Type=\"CNAME\"
+        Address=\"parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\"
+        FriendlyName=\"CNAME Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n
+        \     <host HostId=\"746365\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746366\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746373\" Name=\"_acme-challenge.deleterecordinset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746362\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746363\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746376\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746377\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746367\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746364\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746383\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746389\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746381\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746385\" Name=\"orig.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746387\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746378\" Name=\"random.fqdntest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746379\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746380\" Name=\"random.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746382\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746386\" Name=\"updated.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746388\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746354\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest2.dev/\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL
+        Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.479</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['5215']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:43:29 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:01:56 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '5220'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'RecordType21=TXT&HostId19=524164&RecordType20=TXT&RecordType23=TXT&MXPref24=10&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&IsDDNSEnabled23=false&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524157&HostId9=524842&IsDDNSEnabled24=false&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524831&HostId5=524832&HostId6=524839&HostId7=524156&IsDDNSEnabled22=false&MXPref23=10&HostId24=524160&HostId23=524173&HostId22=524171&HostId21=524167&HostId20=524165&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=CName+Record&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524158&HostId13=524168&HostId10=524843&HostId11=524833&HostId16=524170&HostId17=524172&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken1&FriendlyName24=URL+Record&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=&FriendlyName23=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&AssociatedAppTitle23=&HostName12=_acme-challenge.test&HostName13=orig.nameonly.test&HostName10=_acme-challenge.listrecordset&HostName11=_acme-challenge.noop&HostName16=orig.testfqdn&HostName17=orig.testfull&HostName14=orig.nameonly.test&Address1=127.0.0.1&HostName18=random.fqdntest&HostName19=random.fulltest&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=60&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=60&TTL14=1800&RecordType24=URL&TTL24=1800&TTL23=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&HostName24=yyy&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&AssociatedAppTitle22=&AssociatedAppTitle24=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&RecordType25=TXT&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.listrecordset&Address10=challengetoken2&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=updated&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName23=updated.testfull&HostName22=updated.testfqdn&HostName21=updated.test&HostName20=random.test&TTL10=1800&HostName25=updated.testfqdn&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&IsActive23=true&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&IsActive24=true&SLD=example-aptise&MXPref4=10&Address25=challengetoken&Address24=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&Address23=challengetoken&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524844&AssociatedAppTitle19=&HostId15=524166&HostId18=524163'
+    body: HostId1=746360&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746361&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746355&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746365&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746366&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746373&Address6=challengetoken2&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.deleterecordinset&RecordType6=TXT&HostId7=746362&Address7=challengetoken&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.fqdn&RecordType7=TXT&HostId8=746363&Address8=challengetoken&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.full&RecordType8=TXT&HostId9=746376&Address9=challengetoken1&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.listrecordset&RecordType9=TXT&HostId10=746377&Address10=challengetoken2&MXPref10=10&TTL10=3600&AssociatedAppTitle10=&FriendlyName10=&IsActive10=true&IsDDNSEnabled10=false&HostName10=_acme-challenge.listrecordset&RecordType10=TXT&HostId11=746367&Address11=challengetoken&MXPref11=10&TTL11=3600&AssociatedAppTitle11=&FriendlyName11=&IsActive11=true&IsDDNSEnabled11=false&HostName11=_acme-challenge.noop&RecordType11=TXT&HostId12=746364&Address12=challengetoken&MXPref12=10&TTL12=3600&AssociatedAppTitle12=&FriendlyName12=&IsActive12=true&IsDDNSEnabled12=false&HostName12=_acme-challenge.test&RecordType12=TXT&HostId13=746383&Address13=challengetoken&MXPref13=10&TTL13=3600&AssociatedAppTitle13=&FriendlyName13=&IsActive13=true&IsDDNSEnabled13=false&HostName13=orig.nameonly.test&RecordType13=TXT&HostId14=746389&Address14=updated&MXPref14=10&TTL14=3600&AssociatedAppTitle14=&FriendlyName14=&IsActive14=true&IsDDNSEnabled14=false&HostName14=orig.nameonly.test&RecordType14=TXT&HostId15=746381&Address15=challengetoken&MXPref15=10&TTL15=3600&AssociatedAppTitle15=&FriendlyName15=&IsActive15=true&IsDDNSEnabled15=false&HostName15=orig.test&RecordType15=TXT&HostId16=746385&Address16=challengetoken&MXPref16=10&TTL16=3600&AssociatedAppTitle16=&FriendlyName16=&IsActive16=true&IsDDNSEnabled16=false&HostName16=orig.testfqdn&RecordType16=TXT&HostId17=746387&Address17=challengetoken&MXPref17=10&TTL17=3600&AssociatedAppTitle17=&FriendlyName17=&IsActive17=true&IsDDNSEnabled17=false&HostName17=orig.testfull&RecordType17=TXT&HostId18=746378&Address18=challengetoken&MXPref18=10&TTL18=3600&AssociatedAppTitle18=&FriendlyName18=&IsActive18=true&IsDDNSEnabled18=false&HostName18=random.fqdntest&RecordType18=TXT&HostId19=746379&Address19=challengetoken&MXPref19=10&TTL19=3600&AssociatedAppTitle19=&FriendlyName19=&IsActive19=true&IsDDNSEnabled19=false&HostName19=random.fulltest&RecordType19=TXT&HostId20=746380&Address20=challengetoken&MXPref20=10&TTL20=3600&AssociatedAppTitle20=&FriendlyName20=&IsActive20=true&IsDDNSEnabled20=false&HostName20=random.test&RecordType20=TXT&HostId21=746382&Address21=challengetoken&MXPref21=10&TTL21=3600&AssociatedAppTitle21=&FriendlyName21=&IsActive21=true&IsDDNSEnabled21=false&HostName21=updated.test&RecordType21=TXT&HostId22=746386&Address22=challengetoken&MXPref22=10&TTL22=3600&AssociatedAppTitle22=&FriendlyName22=&IsActive22=true&IsDDNSEnabled22=false&HostName22=updated.testfqdn&RecordType22=TXT&HostId23=746388&Address23=challengetoken&MXPref23=10&TTL23=3600&AssociatedAppTitle23=&FriendlyName23=&IsActive23=true&IsDDNSEnabled23=false&HostName23=updated.testfull&RecordType23=TXT&HostId24=746354&Address24=http%3A%2F%2Fwww.unittest2.dev%2F&MXPref24=10&TTL24=1800&AssociatedAppTitle24=URL+Forwarding&FriendlyName24=URL+Record&IsActive24=true&IsDDNSEnabled24=false&HostName24=%40&RecordType24=URL&Address25=challengetoken&TTL25=3600&HostName25=updated.testfqdn&RecordType25=TXT&SLD=unittest2&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['4532']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '4541'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>1.064</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest2.dev\" IsSuccess=\"true\">\r\n      <Warnings />\r\n    </DomainDNSSetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.734</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['559']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:43:30 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:01:58 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '557'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/namecheap/IntegrationTests/test_provider_when_calling_update_record_with_full_name_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/namecheap/IntegrationTests/test_provider_when_calling_update_record_with_full_name_should_modify_record.yaml
@@ -2,477 +2,567 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise.com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=unittest2.dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
-        \ Status=\"Ok\" ID=\"277432\" DomainName=\"example-aptise.com\" OwnerName=\"\
-        jvsandbox\" IsOwner=\"true\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
-        \n        <CreatedDate>03/25/2018</CreatedDate>\r\n        <ExpiredDate>03/25/2019</ExpiredDate>\r\
-        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
-        \ />\r\n      <Whoisguard Enabled=\"NotAlloted\">\r\n        <ID>0</ID>\r\n\
-        \      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
-        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
-        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
-        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
-        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"24\" EmailType=\"\
-        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
-        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
-        \n      <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.112</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult
+        Status=\"Ok\" ID=\"589667\" DomainName=\"unittest2.dev\" OwnerName=\"phassberg\"
+        IsOwner=\"true\" IsPremium=\"false\">\r\n      <DomainDetails>\r\n        <CreatedDate>05/20/2020</CreatedDate>\r\n
+        \       <ExpiredDate>05/20/2021</ExpiredDate>\r\n        <NumYears>0</NumYears>\r\n
+        \     </DomainDetails>\r\n      <LockDetails />\r\n      <Whoisguard Enabled=\"True\">\r\n
+        \       <ID>481121</ID>\r\n        <ExpiredDate>05/20/2021</ExpiredDate>\r\n
+        \       <EmailDetails WhoisGuardEmail=\"824017ccbed343119b3459c7d3304ba5.protect@whoisguard.com\"
+        ForwardedTo=\"dr.doddo@gmail.com\" LastAutoEmailChangeDate=\"05/20/2020\"
+        AutoEmailChangeFrequencyDays=\"3\" />\r\n      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n
+        \       <UseAutoRenew>false</UseAutoRenew>\r\n        <SubscriptionId>-1</SubscriptionId>\r\n
+        \       <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n
+        \       <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n
+        \     <DnsDetails ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"24\"
+        EmailType=\"FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\n
+        \       <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\n
+        \     <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.183</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['1493']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:43:31 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:02:00 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '1740'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest2&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
-        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524842\" Name=\"_acme-challenge.listrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524843\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524833\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524158\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524844\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
-        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
-        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.829</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest2.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n      <host
+        HostId=\"746360\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746361\" Name=\"docs\" Type=\"CNAME\" Address=\"docs.example.com.\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746355\" Name=\"www\" Type=\"CNAME\"
+        Address=\"parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\"
+        FriendlyName=\"CNAME Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n
+        \     <host HostId=\"746365\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746366\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746373\" Name=\"_acme-challenge.deleterecordinset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746362\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746363\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746376\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746377\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746367\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746364\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746383\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746389\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746381\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746385\" Name=\"orig.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746387\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746378\" Name=\"random.fqdntest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746379\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746380\" Name=\"random.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746382\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746386\" Name=\"updated.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746388\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746354\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest2.dev/\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL
+        Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.316</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['5215']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:43:33 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:02:00 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '5220'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'RecordType21=TXT&HostId19=524164&RecordType20=TXT&RecordType23=TXT&MXPref24=10&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&IsDDNSEnabled23=false&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524157&HostId9=524842&IsDDNSEnabled24=false&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524831&HostId5=524832&HostId6=524839&HostId7=524156&IsDDNSEnabled22=false&MXPref23=10&HostId24=524160&HostId23=524173&HostId22=524171&HostId21=524167&HostId20=524165&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=CName+Record&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524158&HostId13=524168&HostId10=524843&HostId11=524833&HostId16=524170&HostId17=524172&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken1&FriendlyName24=URL+Record&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=&FriendlyName23=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&AssociatedAppTitle23=&HostName12=_acme-challenge.test&HostName13=orig.nameonly.test&HostName10=_acme-challenge.listrecordset&HostName11=_acme-challenge.noop&HostName16=orig.testfqdn&HostName17=orig.testfull&HostName14=orig.nameonly.test&Address1=127.0.0.1&HostName18=random.fqdntest&HostName19=random.fulltest&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=60&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=60&TTL14=1800&RecordType24=URL&TTL24=1800&TTL23=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&HostName24=yyy&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&AssociatedAppTitle22=&AssociatedAppTitle24=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&RecordType25=TXT&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.listrecordset&Address10=challengetoken2&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=updated&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName23=updated.testfull&HostName22=updated.testfqdn&HostName21=updated.test&HostName20=random.test&TTL10=1800&HostName25=orig.testfull&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&IsActive23=true&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&IsActive24=true&SLD=example-aptise&MXPref4=10&Address25=challengetoken&Address24=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&Address23=challengetoken&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524844&AssociatedAppTitle19=&HostId15=524166&HostId18=524163'
+    body: HostId1=746360&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746361&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746355&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746365&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746366&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746373&Address6=challengetoken2&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.deleterecordinset&RecordType6=TXT&HostId7=746362&Address7=challengetoken&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.fqdn&RecordType7=TXT&HostId8=746363&Address8=challengetoken&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.full&RecordType8=TXT&HostId9=746376&Address9=challengetoken1&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.listrecordset&RecordType9=TXT&HostId10=746377&Address10=challengetoken2&MXPref10=10&TTL10=3600&AssociatedAppTitle10=&FriendlyName10=&IsActive10=true&IsDDNSEnabled10=false&HostName10=_acme-challenge.listrecordset&RecordType10=TXT&HostId11=746367&Address11=challengetoken&MXPref11=10&TTL11=3600&AssociatedAppTitle11=&FriendlyName11=&IsActive11=true&IsDDNSEnabled11=false&HostName11=_acme-challenge.noop&RecordType11=TXT&HostId12=746364&Address12=challengetoken&MXPref12=10&TTL12=3600&AssociatedAppTitle12=&FriendlyName12=&IsActive12=true&IsDDNSEnabled12=false&HostName12=_acme-challenge.test&RecordType12=TXT&HostId13=746383&Address13=challengetoken&MXPref13=10&TTL13=3600&AssociatedAppTitle13=&FriendlyName13=&IsActive13=true&IsDDNSEnabled13=false&HostName13=orig.nameonly.test&RecordType13=TXT&HostId14=746389&Address14=updated&MXPref14=10&TTL14=3600&AssociatedAppTitle14=&FriendlyName14=&IsActive14=true&IsDDNSEnabled14=false&HostName14=orig.nameonly.test&RecordType14=TXT&HostId15=746381&Address15=challengetoken&MXPref15=10&TTL15=3600&AssociatedAppTitle15=&FriendlyName15=&IsActive15=true&IsDDNSEnabled15=false&HostName15=orig.test&RecordType15=TXT&HostId16=746385&Address16=challengetoken&MXPref16=10&TTL16=3600&AssociatedAppTitle16=&FriendlyName16=&IsActive16=true&IsDDNSEnabled16=false&HostName16=orig.testfqdn&RecordType16=TXT&HostId17=746387&Address17=challengetoken&MXPref17=10&TTL17=3600&AssociatedAppTitle17=&FriendlyName17=&IsActive17=true&IsDDNSEnabled17=false&HostName17=orig.testfull&RecordType17=TXT&HostId18=746378&Address18=challengetoken&MXPref18=10&TTL18=3600&AssociatedAppTitle18=&FriendlyName18=&IsActive18=true&IsDDNSEnabled18=false&HostName18=random.fqdntest&RecordType18=TXT&HostId19=746379&Address19=challengetoken&MXPref19=10&TTL19=3600&AssociatedAppTitle19=&FriendlyName19=&IsActive19=true&IsDDNSEnabled19=false&HostName19=random.fulltest&RecordType19=TXT&HostId20=746380&Address20=challengetoken&MXPref20=10&TTL20=3600&AssociatedAppTitle20=&FriendlyName20=&IsActive20=true&IsDDNSEnabled20=false&HostName20=random.test&RecordType20=TXT&HostId21=746382&Address21=challengetoken&MXPref21=10&TTL21=3600&AssociatedAppTitle21=&FriendlyName21=&IsActive21=true&IsDDNSEnabled21=false&HostName21=updated.test&RecordType21=TXT&HostId22=746386&Address22=challengetoken&MXPref22=10&TTL22=3600&AssociatedAppTitle22=&FriendlyName22=&IsActive22=true&IsDDNSEnabled22=false&HostName22=updated.testfqdn&RecordType22=TXT&HostId23=746388&Address23=challengetoken&MXPref23=10&TTL23=3600&AssociatedAppTitle23=&FriendlyName23=&IsActive23=true&IsDDNSEnabled23=false&HostName23=updated.testfull&RecordType23=TXT&HostId24=746354&Address24=http%3A%2F%2Fwww.unittest2.dev%2F&MXPref24=10&TTL24=1800&AssociatedAppTitle24=URL+Forwarding&FriendlyName24=URL+Record&IsActive24=true&IsDDNSEnabled24=false&HostName24=%40&RecordType24=URL&Address25=challengetoken&TTL25=3600&HostName25=orig.testfull&RecordType25=TXT&SLD=unittest2&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['4529']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '4538'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.755</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest2.dev\" IsSuccess=\"true\">\r\n      <Warnings />\r\n    </DomainDNSSetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.443</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['559']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:43:34 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:02:01 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '557'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest2&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
-        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524842\" Name=\"_acme-challenge.listrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524843\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524833\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524158\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524844\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
-        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
-        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.601</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest2.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n      <host
+        HostId=\"746360\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746361\" Name=\"docs\" Type=\"CNAME\" Address=\"docs.example.com.\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746355\" Name=\"www\" Type=\"CNAME\"
+        Address=\"parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\"
+        FriendlyName=\"CNAME Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n
+        \     <host HostId=\"746365\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746366\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746373\" Name=\"_acme-challenge.deleterecordinset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746362\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746363\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746376\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746377\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746367\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746364\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746383\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746389\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746381\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746385\" Name=\"orig.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746387\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746378\" Name=\"random.fqdntest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746379\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746380\" Name=\"random.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746382\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746386\" Name=\"updated.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746388\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746354\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest2.dev/\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL
+        Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.381</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['5215']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:43:34 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:02:02 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '5220'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest2&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
-        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524842\" Name=\"_acme-challenge.listrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524843\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524833\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524158\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524844\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
-        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
-        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.737</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest2.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n      <host
+        HostId=\"746360\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746361\" Name=\"docs\" Type=\"CNAME\" Address=\"docs.example.com.\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746355\" Name=\"www\" Type=\"CNAME\"
+        Address=\"parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\"
+        FriendlyName=\"CNAME Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n
+        \     <host HostId=\"746365\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746366\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746373\" Name=\"_acme-challenge.deleterecordinset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746362\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746363\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746376\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746377\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746367\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746364\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746383\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746389\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746381\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746385\" Name=\"orig.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746387\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746378\" Name=\"random.fqdntest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746379\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746380\" Name=\"random.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746382\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746386\" Name=\"updated.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746388\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746354\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest2.dev/\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL
+        Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.439</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['5215']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:43:38 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:02:04 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '5220'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest2&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
-        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524842\" Name=\"_acme-challenge.listrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524843\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524833\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524158\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524844\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
-        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
-        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>1.09</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest2.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n      <host
+        HostId=\"746360\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746361\" Name=\"docs\" Type=\"CNAME\" Address=\"docs.example.com.\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746355\" Name=\"www\" Type=\"CNAME\"
+        Address=\"parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\"
+        FriendlyName=\"CNAME Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n
+        \     <host HostId=\"746365\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746366\" Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746373\" Name=\"_acme-challenge.deleterecordinset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746362\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746363\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746376\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746377\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746367\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746364\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746383\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746389\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746381\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746385\" Name=\"orig.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746387\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746378\" Name=\"random.fqdntest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746379\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746380\" Name=\"random.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746382\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746386\" Name=\"updated.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746388\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746354\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest2.dev/\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL
+        Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.134</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['5214']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:43:39 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:02:05 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '5220'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'RecordType21=TXT&HostId19=524164&RecordType20=TXT&RecordType23=TXT&MXPref24=10&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&IsDDNSEnabled23=false&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524157&HostId9=524842&IsDDNSEnabled24=false&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524831&HostId5=524832&HostId6=524839&HostId7=524156&IsDDNSEnabled22=false&MXPref23=10&HostId24=524160&HostId23=524173&HostId22=524171&HostId21=524167&HostId20=524165&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=CName+Record&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524158&HostId13=524168&HostId10=524843&HostId11=524833&HostId16=524170&HostId17=524172&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken1&FriendlyName24=URL+Record&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=&FriendlyName23=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&AssociatedAppTitle23=&HostName12=_acme-challenge.test&HostName13=orig.nameonly.test&HostName10=_acme-challenge.listrecordset&HostName11=_acme-challenge.noop&HostName16=orig.testfqdn&HostName17=orig.testfull&HostName14=orig.nameonly.test&Address1=127.0.0.1&HostName18=random.fqdntest&HostName19=random.fulltest&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=60&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=60&TTL14=1800&RecordType24=URL&TTL24=1800&TTL23=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&HostName24=yyy&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&AssociatedAppTitle22=&AssociatedAppTitle24=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&RecordType25=TXT&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.listrecordset&Address10=challengetoken2&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=updated&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName23=updated.testfull&HostName22=updated.testfqdn&HostName21=updated.test&HostName20=random.test&TTL10=1800&HostName25=updated.testfull&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&IsActive23=true&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&IsActive24=true&SLD=example-aptise&MXPref4=10&Address25=challengetoken&Address24=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&Address23=challengetoken&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524844&AssociatedAppTitle19=&HostId15=524166&HostId18=524163'
+    body: HostId1=746360&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746361&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746355&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746365&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746366&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746373&Address6=challengetoken2&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.deleterecordinset&RecordType6=TXT&HostId7=746362&Address7=challengetoken&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.fqdn&RecordType7=TXT&HostId8=746363&Address8=challengetoken&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.full&RecordType8=TXT&HostId9=746376&Address9=challengetoken1&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.listrecordset&RecordType9=TXT&HostId10=746377&Address10=challengetoken2&MXPref10=10&TTL10=3600&AssociatedAppTitle10=&FriendlyName10=&IsActive10=true&IsDDNSEnabled10=false&HostName10=_acme-challenge.listrecordset&RecordType10=TXT&HostId11=746367&Address11=challengetoken&MXPref11=10&TTL11=3600&AssociatedAppTitle11=&FriendlyName11=&IsActive11=true&IsDDNSEnabled11=false&HostName11=_acme-challenge.noop&RecordType11=TXT&HostId12=746364&Address12=challengetoken&MXPref12=10&TTL12=3600&AssociatedAppTitle12=&FriendlyName12=&IsActive12=true&IsDDNSEnabled12=false&HostName12=_acme-challenge.test&RecordType12=TXT&HostId13=746383&Address13=challengetoken&MXPref13=10&TTL13=3600&AssociatedAppTitle13=&FriendlyName13=&IsActive13=true&IsDDNSEnabled13=false&HostName13=orig.nameonly.test&RecordType13=TXT&HostId14=746389&Address14=updated&MXPref14=10&TTL14=3600&AssociatedAppTitle14=&FriendlyName14=&IsActive14=true&IsDDNSEnabled14=false&HostName14=orig.nameonly.test&RecordType14=TXT&HostId15=746381&Address15=challengetoken&MXPref15=10&TTL15=3600&AssociatedAppTitle15=&FriendlyName15=&IsActive15=true&IsDDNSEnabled15=false&HostName15=orig.test&RecordType15=TXT&HostId16=746385&Address16=challengetoken&MXPref16=10&TTL16=3600&AssociatedAppTitle16=&FriendlyName16=&IsActive16=true&IsDDNSEnabled16=false&HostName16=orig.testfqdn&RecordType16=TXT&HostId17=746387&Address17=challengetoken&MXPref17=10&TTL17=3600&AssociatedAppTitle17=&FriendlyName17=&IsActive17=true&IsDDNSEnabled17=false&HostName17=orig.testfull&RecordType17=TXT&HostId18=746378&Address18=challengetoken&MXPref18=10&TTL18=3600&AssociatedAppTitle18=&FriendlyName18=&IsActive18=true&IsDDNSEnabled18=false&HostName18=random.fqdntest&RecordType18=TXT&HostId19=746379&Address19=challengetoken&MXPref19=10&TTL19=3600&AssociatedAppTitle19=&FriendlyName19=&IsActive19=true&IsDDNSEnabled19=false&HostName19=random.fulltest&RecordType19=TXT&HostId20=746380&Address20=challengetoken&MXPref20=10&TTL20=3600&AssociatedAppTitle20=&FriendlyName20=&IsActive20=true&IsDDNSEnabled20=false&HostName20=random.test&RecordType20=TXT&HostId21=746382&Address21=challengetoken&MXPref21=10&TTL21=3600&AssociatedAppTitle21=&FriendlyName21=&IsActive21=true&IsDDNSEnabled21=false&HostName21=updated.test&RecordType21=TXT&HostId22=746386&Address22=challengetoken&MXPref22=10&TTL22=3600&AssociatedAppTitle22=&FriendlyName22=&IsActive22=true&IsDDNSEnabled22=false&HostName22=updated.testfqdn&RecordType22=TXT&HostId23=746388&Address23=challengetoken&MXPref23=10&TTL23=3600&AssociatedAppTitle23=&FriendlyName23=&IsActive23=true&IsDDNSEnabled23=false&HostName23=updated.testfull&RecordType23=TXT&HostId24=746354&Address24=http%3A%2F%2Fwww.unittest2.dev%2F&MXPref24=10&TTL24=1800&AssociatedAppTitle24=URL+Forwarding&FriendlyName24=URL+Record&IsActive24=true&IsDDNSEnabled24=false&HostName24=%40&RecordType24=URL&Address25=challengetoken&TTL25=3600&HostName25=updated.testfull&RecordType25=TXT&SLD=unittest2&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['4532']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '4541'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.802</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest2.dev\" IsSuccess=\"true\">\r\n      <Warnings />\r\n    </DomainDNSSetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.801</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['559']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:43:40 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:02:07 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '557'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_provider_authenticate.yaml
+++ b/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_provider_authenticate.yaml
@@ -2,48 +2,65 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise-2.com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=unittest-seconddomain.dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
-        \ Status=\"Ok\" ID=\"277442\" DomainName=\"example-aptise-2.com\" OwnerName=\"\
-        jvsandbox2\" IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
-        \n        <CreatedDate>03/26/2018</CreatedDate>\r\n        <ExpiredDate>03/26/2019</ExpiredDate>\r\
-        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
-        \ />\r\n      <Whoisguard Enabled=\"True\">\r\n        <ID>233216</ID>\r\n\
-        \        <ExpiredDate>03/25/2019</ExpiredDate>\r\n        <EmailDetails WhoisGuardEmail=\"\
-        bdf487b65d844ddfafe33163f0e709f0.protect@whoisguard.com\" ForwardedTo=\"namecheap.sandbox.2@2xlp.com\"\
-        \ LastAutoEmailChangeDate=\"\" AutoEmailChangeFrequencyDays=\"0\" />\r\n \
-        \     </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
-        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
-        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
-        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
-        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"17\" EmailType=\"\
-        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
-        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
-        \n      <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\"\
-        >OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n        <Rights\
-        \ Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"nameserver\">OK</Rights>\r\
-        \n        <Rights Type=\"premiumDns\">OK</Rights>\r\n        <Rights Type=\"\
-        dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n    </DomainGetInfoResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.683</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult
+        Status=\"Ok\" ID=\"589668\" DomainName=\"unittest-seconddomain.dev\" OwnerName=\"phassberg2\"
+        IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\n        <CreatedDate>05/20/2020</CreatedDate>\r\n
+        \       <ExpiredDate>05/20/2021</ExpiredDate>\r\n        <NumYears>0</NumYears>\r\n
+        \     </DomainDetails>\r\n      <LockDetails />\r\n      <Whoisguard Enabled=\"True\">\r\n
+        \       <ID>481122</ID>\r\n        <ExpiredDate>05/20/2021</ExpiredDate>\r\n
+        \       <EmailDetails WhoisGuardEmail=\"af9bb0ea7b894617af45bb0fa4809b21.protect@whoisguard.com\"
+        ForwardedTo=\"drdoddo@gmail.com\" LastAutoEmailChangeDate=\"05/20/2020\" AutoEmailChangeFrequencyDays=\"3\"
+        />\r\n      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\n
+        \       <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\n
+        \       <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n        <IsActive>false</IsActive>\r\n
+        \     </PremiumDnsSubscription>\r\n      <DnsDetails ProviderType=\"FREE\"
+        IsUsingOurDNS=\"true\" HostCount=\"2\" EmailType=\"FWD\" DynamicDNSStatus=\"false\"
+        IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\n
+        \       <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\n
+        \     <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\">OK</Rights>\r\n
+        \       <Rights Type=\"eforward\">OK</Rights>\r\n        <Rights Type=\"rlock\">OK</Rights>\r\n
+        \       <Rights Type=\"parkpage\">OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n
+        \       <Rights Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"extend\">OK</Rights>\r\n
+        \       <Rights Type=\"nameserver\">OK</Rights>\r\n        <Rights Type=\"autorenew\">OK</Rights>\r\n
+        \       <Rights Type=\"whoisguard\">OK</Rights>\r\n        <Rights Type=\"premiumDns\">OK</Rights>\r\n
+        \       <Rights Type=\"dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n
+        \   </DomainGetInfoResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.434</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['2034']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:43:42 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:02:09 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '2308'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_provider_authenticate_with_unmanaged_domain_should_fail.yaml
+++ b/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_provider_authenticate_with_unmanaged_domain_should_fail.yaml
@@ -2,38 +2,53 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=thisisadomainidonotown.com
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"ERROR\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors>\r\n    <Error Number=\"2030166\">Domain is invalid</Error>\r\
-        \n  </Errors>\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
-        \ ID=\"0\" IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
-        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
-        \ />\r\n      <Whoisguard>\r\n        <ID>0</ID>\r\n      </Whoisguard>\r\n\
-        \      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
-        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
-        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
-        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
-        \ IsUsingOurDNS=\"false\" HostCount=\"0\" DynamicDNSStatus=\"false\" IsFailover=\"\
-        false\" />\r\n      <Modificationrights />\r\n    </DomainGetInfoResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.359</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"ERROR\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors>\r\n    <Error
+        Number=\"2030166\">Domain is invalid</Error>\r\n  </Errors>\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult
+        ID=\"0\" IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\n
+        \       <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails
+        />\r\n      <Whoisguard>\r\n        <ID>0</ID>\r\n      </Whoisguard>\r\n
+        \     <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\n
+        \       <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\n
+        \       <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n        <IsActive>false</IsActive>\r\n
+        \     </PremiumDnsSubscription>\r\n      <DnsDetails IsUsingOurDNS=\"false\"
+        HostCount=\"0\" DynamicDNSStatus=\"false\" IsFailover=\"false\" />\r\n      <Modificationrights
+        />\r\n    </DomainGetInfoResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.168</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['1189']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:43:42 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:02:09 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '1192'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_provider_when_calling_create_record_for_A_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_provider_when_calling_create_record_for_A_with_valid_name_and_content.yaml
@@ -2,151 +2,161 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise-2.com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=unittest-seconddomain.dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
-        \ Status=\"Ok\" ID=\"277442\" DomainName=\"example-aptise-2.com\" OwnerName=\"\
-        jvsandbox2\" IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
-        \n        <CreatedDate>03/26/2018</CreatedDate>\r\n        <ExpiredDate>03/26/2019</ExpiredDate>\r\
-        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
-        \ />\r\n      <Whoisguard Enabled=\"True\">\r\n        <ID>233216</ID>\r\n\
-        \        <ExpiredDate>03/25/2019</ExpiredDate>\r\n        <EmailDetails WhoisGuardEmail=\"\
-        bdf487b65d844ddfafe33163f0e709f0.protect@whoisguard.com\" ForwardedTo=\"namecheap.sandbox.2@2xlp.com\"\
-        \ LastAutoEmailChangeDate=\"\" AutoEmailChangeFrequencyDays=\"0\" />\r\n \
-        \     </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
-        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
-        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
-        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
-        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"17\" EmailType=\"\
-        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
-        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
-        \n      <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\"\
-        >OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n        <Rights\
-        \ Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"nameserver\">OK</Rights>\r\
-        \n        <Rights Type=\"premiumDns\">OK</Rights>\r\n        <Rights Type=\"\
-        dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n    </DomainGetInfoResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.214</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult
+        Status=\"Ok\" ID=\"589668\" DomainName=\"unittest-seconddomain.dev\" OwnerName=\"phassberg2\"
+        IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\n        <CreatedDate>05/20/2020</CreatedDate>\r\n
+        \       <ExpiredDate>05/20/2021</ExpiredDate>\r\n        <NumYears>0</NumYears>\r\n
+        \     </DomainDetails>\r\n      <LockDetails />\r\n      <Whoisguard Enabled=\"True\">\r\n
+        \       <ID>481122</ID>\r\n        <ExpiredDate>05/20/2021</ExpiredDate>\r\n
+        \       <EmailDetails WhoisGuardEmail=\"af9bb0ea7b894617af45bb0fa4809b21.protect@whoisguard.com\"
+        ForwardedTo=\"drdoddo@gmail.com\" LastAutoEmailChangeDate=\"05/20/2020\" AutoEmailChangeFrequencyDays=\"3\"
+        />\r\n      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\n
+        \       <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\n
+        \       <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n        <IsActive>false</IsActive>\r\n
+        \     </PremiumDnsSubscription>\r\n      <DnsDetails ProviderType=\"FREE\"
+        IsUsingOurDNS=\"true\" HostCount=\"2\" EmailType=\"FWD\" DynamicDNSStatus=\"false\"
+        IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\n
+        \       <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\n
+        \     <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\">OK</Rights>\r\n
+        \       <Rights Type=\"eforward\">OK</Rights>\r\n        <Rights Type=\"rlock\">OK</Rights>\r\n
+        \       <Rights Type=\"parkpage\">OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n
+        \       <Rights Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"extend\">OK</Rights>\r\n
+        \       <Rights Type=\"nameserver\">OK</Rights>\r\n        <Rights Type=\"autorenew\">OK</Rights>\r\n
+        \       <Rights Type=\"whoisguard\">OK</Rights>\r\n        <Rights Type=\"premiumDns\">OK</Rights>\r\n
+        \       <Rights Type=\"dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n
+        \   </DomainGetInfoResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.025</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['2034']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:43:44 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:02:10 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '2308'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest-seconddomain&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
-        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
-        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
-        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
-        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\"\
-        \ Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524195\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\"\
-        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524206\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524203\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"\
-        orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524200\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\"\
-        \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524202\" Name=\"random.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524204\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524208\" Name=\"\
-        updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.712</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest-seconddomain.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n
+        \     <host HostId=\"746357\" Name=\"www\" Type=\"CNAME\" Address=\"parkingpage.namecheap.com.\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"CNAME Record\"
+        IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746356\"
+        Name=\"@\" Type=\"URL\" Address=\"http://www.unittest-seconddomain.dev/\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL
+        Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.708</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['3752']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:43:45 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:02:11 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '996'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'IsActive10=true&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=A&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524206&HostId9=524203&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524193&HostId5=524194&HostId6=524195&HostId7=524205&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&FriendlyName3=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524200&HostId13=524201&HostId10=524207&HostId11=524209&HostId16=524208&HostId17=524210&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=updated&Address9=challengetoken&IsActive9=true&IsActive8=true&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&HostName12=random.fqdntest&HostName13=random.fulltest&HostName10=orig.testfqdn&HostName11=orig.testfull&HostName16=updated.testfqdn&HostName17=updated.testfull&HostName14=random.test&Address1=127.0.0.1&HostName18=localhost&MXPref5=10&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&Address12=challengetoken&Address18=127.0.0.1&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.fqdn&HostName5=_acme-challenge.full&HostName6=_acme-challenge.test&HostName7=orig.nameonly.test&HostName8=orig.nameonly.test&HostName9=orig.test&Address10=challengetoken&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken&TTL16=1800&FriendlyName16=&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=updated.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise-2&MXPref4=10&HostId14=524202&HostId15=524204'
+    body: HostId1=746357&Address1=parkingpage.namecheap.com.&MXPref1=10&TTL1=1800&AssociatedAppTitle1=&FriendlyName1=CNAME+Record&IsActive1=true&IsDDNSEnabled1=false&HostName1=www&RecordType1=CNAME&HostId2=746356&Address2=http%3A%2F%2Fwww.unittest-seconddomain.dev%2F&MXPref2=10&TTL2=1800&AssociatedAppTitle2=URL+Forwarding&FriendlyName2=URL+Record&IsActive2=true&IsDDNSEnabled2=false&HostName2=%40&RecordType2=URL&Address3=127.0.0.1&TTL3=3600&HostName3=localhost&RecordType3=A&SLD=unittest-seconddomain&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['3083']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '501'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>1.005</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest-seconddomain.dev\" IsSuccess=\"true\">\r\n      <Warnings
+        />\r\n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>1.072</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['561']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:43:47 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:02:13 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '569'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_provider_when_calling_create_record_for_CNAME_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_provider_when_calling_create_record_for_CNAME_with_valid_name_and_content.yaml
@@ -2,151 +2,163 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise-2.com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=unittest-seconddomain.dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
-        \ Status=\"Ok\" ID=\"277442\" DomainName=\"example-aptise-2.com\" OwnerName=\"\
-        jvsandbox2\" IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
-        \n        <CreatedDate>03/26/2018</CreatedDate>\r\n        <ExpiredDate>03/26/2019</ExpiredDate>\r\
-        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
-        \ />\r\n      <Whoisguard Enabled=\"True\">\r\n        <ID>233216</ID>\r\n\
-        \        <ExpiredDate>03/25/2019</ExpiredDate>\r\n        <EmailDetails WhoisGuardEmail=\"\
-        bdf487b65d844ddfafe33163f0e709f0.protect@whoisguard.com\" ForwardedTo=\"namecheap.sandbox.2@2xlp.com\"\
-        \ LastAutoEmailChangeDate=\"\" AutoEmailChangeFrequencyDays=\"0\" />\r\n \
-        \     </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
-        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
-        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
-        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
-        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"17\" EmailType=\"\
-        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
-        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
-        \n      <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\"\
-        >OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n        <Rights\
-        \ Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"nameserver\">OK</Rights>\r\
-        \n        <Rights Type=\"premiumDns\">OK</Rights>\r\n        <Rights Type=\"\
-        dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n    </DomainGetInfoResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.063</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult
+        Status=\"Ok\" ID=\"589668\" DomainName=\"unittest-seconddomain.dev\" OwnerName=\"phassberg2\"
+        IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\n        <CreatedDate>05/20/2020</CreatedDate>\r\n
+        \       <ExpiredDate>05/20/2021</ExpiredDate>\r\n        <NumYears>0</NumYears>\r\n
+        \     </DomainDetails>\r\n      <LockDetails />\r\n      <Whoisguard Enabled=\"True\">\r\n
+        \       <ID>481122</ID>\r\n        <ExpiredDate>05/20/2021</ExpiredDate>\r\n
+        \       <EmailDetails WhoisGuardEmail=\"af9bb0ea7b894617af45bb0fa4809b21.protect@whoisguard.com\"
+        ForwardedTo=\"drdoddo@gmail.com\" LastAutoEmailChangeDate=\"05/20/2020\" AutoEmailChangeFrequencyDays=\"3\"
+        />\r\n      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\n
+        \       <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\n
+        \       <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n        <IsActive>false</IsActive>\r\n
+        \     </PremiumDnsSubscription>\r\n      <DnsDetails ProviderType=\"FREE\"
+        IsUsingOurDNS=\"true\" HostCount=\"3\" EmailType=\"FWD\" DynamicDNSStatus=\"false\"
+        IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\n
+        \       <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\n
+        \     <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\">OK</Rights>\r\n
+        \       <Rights Type=\"eforward\">OK</Rights>\r\n        <Rights Type=\"rlock\">OK</Rights>\r\n
+        \       <Rights Type=\"parkpage\">OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n
+        \       <Rights Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"extend\">OK</Rights>\r\n
+        \       <Rights Type=\"nameserver\">OK</Rights>\r\n        <Rights Type=\"autorenew\">OK</Rights>\r\n
+        \       <Rights Type=\"whoisguard\">OK</Rights>\r\n        <Rights Type=\"premiumDns\">OK</Rights>\r\n
+        \       <Rights Type=\"dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n
+        \   </DomainGetInfoResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.189</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['2034']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:43:48 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:02:15 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '2308'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest-seconddomain&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
-        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
-        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
-        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
-        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\"\
-        \ Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524195\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\"\
-        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524206\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524203\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"\
-        orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524200\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\"\
-        \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524202\" Name=\"random.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524204\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524208\" Name=\"\
-        updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>1.109</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest-seconddomain.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n
+        \     <host HostId=\"746390\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746357\" Name=\"www\" Type=\"CNAME\"
+        Address=\"parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\"
+        FriendlyName=\"CNAME Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n
+        \     <host HostId=\"746356\" Name=\"@\" Type=\"URL\" Address=\"http://www.unittest-seconddomain.dev/\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL
+        Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.299</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['3752']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:43:50 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:02:16 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '1173'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'IsActive10=true&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=CNAME&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524206&HostId9=524203&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524193&HostId5=524194&HostId6=524195&HostId7=524205&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&FriendlyName3=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524200&HostId13=524201&HostId10=524207&HostId11=524209&HostId16=524208&HostId17=524210&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=updated&Address9=challengetoken&IsActive9=true&IsActive8=true&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&HostName12=random.fqdntest&HostName13=random.fulltest&HostName10=orig.testfqdn&HostName11=orig.testfull&HostName16=updated.testfqdn&HostName17=updated.testfull&HostName14=random.test&Address1=127.0.0.1&HostName18=docs&MXPref5=10&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&Address12=challengetoken&Address18=docs.example.com&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.fqdn&HostName5=_acme-challenge.full&HostName6=_acme-challenge.test&HostName7=orig.nameonly.test&HostName8=orig.nameonly.test&HostName9=orig.test&Address10=challengetoken&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken&TTL16=1800&FriendlyName16=&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=updated.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise-2&MXPref4=10&HostId14=524202&HostId15=524204'
+    body: HostId1=746390&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746357&Address2=parkingpage.namecheap.com.&MXPref2=10&TTL2=1800&AssociatedAppTitle2=&FriendlyName2=CNAME+Record&IsActive2=true&IsDDNSEnabled2=false&HostName2=www&RecordType2=CNAME&HostId3=746356&Address3=http%3A%2F%2Fwww.unittest-seconddomain.dev%2F&MXPref3=10&TTL3=1800&AssociatedAppTitle3=URL+Forwarding&FriendlyName3=URL+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=%40&RecordType3=URL&Address4=docs.example.com&TTL4=3600&HostName4=docs&RecordType4=CNAME&SLD=unittest-seconddomain&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['3089']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '668'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.769</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest-seconddomain.dev\" IsSuccess=\"true\">\r\n      <Warnings
+        />\r\n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.593</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['561']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:43:51 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:02:18 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '569'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_fqdn_name_and_content.yaml
+++ b/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_fqdn_name_and_content.yaml
@@ -2,151 +2,166 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise-2.com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=unittest-seconddomain.dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
-        \ Status=\"Ok\" ID=\"277442\" DomainName=\"example-aptise-2.com\" OwnerName=\"\
-        jvsandbox2\" IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
-        \n        <CreatedDate>03/26/2018</CreatedDate>\r\n        <ExpiredDate>03/26/2019</ExpiredDate>\r\
-        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
-        \ />\r\n      <Whoisguard Enabled=\"True\">\r\n        <ID>233216</ID>\r\n\
-        \        <ExpiredDate>03/25/2019</ExpiredDate>\r\n        <EmailDetails WhoisGuardEmail=\"\
-        bdf487b65d844ddfafe33163f0e709f0.protect@whoisguard.com\" ForwardedTo=\"namecheap.sandbox.2@2xlp.com\"\
-        \ LastAutoEmailChangeDate=\"\" AutoEmailChangeFrequencyDays=\"0\" />\r\n \
-        \     </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
-        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
-        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
-        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
-        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"17\" EmailType=\"\
-        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
-        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
-        \n      <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\"\
-        >OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n        <Rights\
-        \ Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"nameserver\">OK</Rights>\r\
-        \n        <Rights Type=\"premiumDns\">OK</Rights>\r\n        <Rights Type=\"\
-        dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n    </DomainGetInfoResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.032</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult
+        Status=\"Ok\" ID=\"589668\" DomainName=\"unittest-seconddomain.dev\" OwnerName=\"phassberg2\"
+        IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\n        <CreatedDate>05/20/2020</CreatedDate>\r\n
+        \       <ExpiredDate>05/20/2021</ExpiredDate>\r\n        <NumYears>0</NumYears>\r\n
+        \     </DomainDetails>\r\n      <LockDetails />\r\n      <Whoisguard Enabled=\"True\">\r\n
+        \       <ID>481122</ID>\r\n        <ExpiredDate>05/20/2021</ExpiredDate>\r\n
+        \       <EmailDetails WhoisGuardEmail=\"af9bb0ea7b894617af45bb0fa4809b21.protect@whoisguard.com\"
+        ForwardedTo=\"drdoddo@gmail.com\" LastAutoEmailChangeDate=\"05/20/2020\" AutoEmailChangeFrequencyDays=\"3\"
+        />\r\n      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\n
+        \       <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\n
+        \       <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n        <IsActive>false</IsActive>\r\n
+        \     </PremiumDnsSubscription>\r\n      <DnsDetails ProviderType=\"FREE\"
+        IsUsingOurDNS=\"true\" HostCount=\"4\" EmailType=\"FWD\" DynamicDNSStatus=\"false\"
+        IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\n
+        \       <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\n
+        \     <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\">OK</Rights>\r\n
+        \       <Rights Type=\"eforward\">OK</Rights>\r\n        <Rights Type=\"rlock\">OK</Rights>\r\n
+        \       <Rights Type=\"parkpage\">OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n
+        \       <Rights Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"extend\">OK</Rights>\r\n
+        \       <Rights Type=\"nameserver\">OK</Rights>\r\n        <Rights Type=\"autorenew\">OK</Rights>\r\n
+        \       <Rights Type=\"whoisguard\">OK</Rights>\r\n        <Rights Type=\"premiumDns\">OK</Rights>\r\n
+        \       <Rights Type=\"dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n
+        \   </DomainGetInfoResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.023</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['2034']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:43:53 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:02:18 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '2308'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest-seconddomain&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
-        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
-        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
-        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
-        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\"\
-        \ Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524195\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\"\
-        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524206\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524203\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"\
-        orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524200\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\"\
-        \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524202\" Name=\"random.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524204\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524208\" Name=\"\
-        updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.835</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest-seconddomain.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n
+        \     <host HostId=\"746390\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746391\" Name=\"docs\"
+        Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746357\" Name=\"www\" Type=\"CNAME\" Address=\"parkingpage.namecheap.com.\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"CNAME Record\"
+        IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746356\"
+        Name=\"@\" Type=\"URL\" Address=\"http://www.unittest-seconddomain.dev/\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL
+        Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.41</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['3752']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:43:54 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:02:19 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '1356'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'IsActive10=true&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524206&HostId9=524203&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524193&HostId5=524194&HostId6=524195&HostId7=524205&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&FriendlyName3=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524200&HostId13=524201&HostId10=524207&HostId11=524209&HostId16=524208&HostId17=524210&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=updated&Address9=challengetoken&IsActive9=true&IsActive8=true&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&HostName12=random.fqdntest&HostName13=random.fulltest&HostName10=orig.testfqdn&HostName11=orig.testfull&HostName16=updated.testfqdn&HostName17=updated.testfull&HostName14=random.test&Address1=127.0.0.1&HostName18=_acme-challenge.fqdn&MXPref5=10&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&Address12=challengetoken&Address18=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.fqdn&HostName5=_acme-challenge.full&HostName6=_acme-challenge.test&HostName7=orig.nameonly.test&HostName8=orig.nameonly.test&HostName9=orig.test&Address10=challengetoken&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken&TTL16=1800&FriendlyName16=&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=updated.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise-2&MXPref4=10&HostId14=524202&HostId15=524204'
+    body: HostId1=746390&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746391&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746357&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746356&Address4=http%3A%2F%2Fwww.unittest-seconddomain.dev%2F&MXPref4=10&TTL4=1800&AssociatedAppTitle4=URL+Forwarding&FriendlyName4=URL+Record&IsActive4=true&IsDDNSEnabled4=false&HostName4=%40&RecordType4=URL&Address5=challengetoken&TTL5=3600&HostName5=_acme-challenge.fqdn&RecordType5=TXT&SLD=unittest-seconddomain&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['3101']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '848'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.72</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest-seconddomain.dev\" IsSuccess=\"true\">\r\n      <Warnings
+        />\r\n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.814</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['560']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:43:55 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:02:21 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '569'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_full_name_and_content.yaml
+++ b/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_full_name_and_content.yaml
@@ -2,151 +2,168 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise-2.com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=unittest-seconddomain.dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
-        \ Status=\"Ok\" ID=\"277442\" DomainName=\"example-aptise-2.com\" OwnerName=\"\
-        jvsandbox2\" IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
-        \n        <CreatedDate>03/26/2018</CreatedDate>\r\n        <ExpiredDate>03/26/2019</ExpiredDate>\r\
-        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
-        \ />\r\n      <Whoisguard Enabled=\"True\">\r\n        <ID>233216</ID>\r\n\
-        \        <ExpiredDate>03/25/2019</ExpiredDate>\r\n        <EmailDetails WhoisGuardEmail=\"\
-        bdf487b65d844ddfafe33163f0e709f0.protect@whoisguard.com\" ForwardedTo=\"namecheap.sandbox.2@2xlp.com\"\
-        \ LastAutoEmailChangeDate=\"\" AutoEmailChangeFrequencyDays=\"0\" />\r\n \
-        \     </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
-        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
-        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
-        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
-        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"17\" EmailType=\"\
-        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
-        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
-        \n      <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\"\
-        >OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n        <Rights\
-        \ Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"nameserver\">OK</Rights>\r\
-        \n        <Rights Type=\"premiumDns\">OK</Rights>\r\n        <Rights Type=\"\
-        dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n    </DomainGetInfoResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.039</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult
+        Status=\"Ok\" ID=\"589668\" DomainName=\"unittest-seconddomain.dev\" OwnerName=\"phassberg2\"
+        IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\n        <CreatedDate>05/20/2020</CreatedDate>\r\n
+        \       <ExpiredDate>05/20/2021</ExpiredDate>\r\n        <NumYears>0</NumYears>\r\n
+        \     </DomainDetails>\r\n      <LockDetails />\r\n      <Whoisguard Enabled=\"True\">\r\n
+        \       <ID>481122</ID>\r\n        <ExpiredDate>05/20/2021</ExpiredDate>\r\n
+        \       <EmailDetails WhoisGuardEmail=\"af9bb0ea7b894617af45bb0fa4809b21.protect@whoisguard.com\"
+        ForwardedTo=\"drdoddo@gmail.com\" LastAutoEmailChangeDate=\"05/20/2020\" AutoEmailChangeFrequencyDays=\"3\"
+        />\r\n      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\n
+        \       <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\n
+        \       <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n        <IsActive>false</IsActive>\r\n
+        \     </PremiumDnsSubscription>\r\n      <DnsDetails ProviderType=\"FREE\"
+        IsUsingOurDNS=\"true\" HostCount=\"5\" EmailType=\"FWD\" DynamicDNSStatus=\"false\"
+        IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\n
+        \       <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\n
+        \     <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\">OK</Rights>\r\n
+        \       <Rights Type=\"eforward\">OK</Rights>\r\n        <Rights Type=\"rlock\">OK</Rights>\r\n
+        \       <Rights Type=\"parkpage\">OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n
+        \       <Rights Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"extend\">OK</Rights>\r\n
+        \       <Rights Type=\"nameserver\">OK</Rights>\r\n        <Rights Type=\"autorenew\">OK</Rights>\r\n
+        \       <Rights Type=\"whoisguard\">OK</Rights>\r\n        <Rights Type=\"premiumDns\">OK</Rights>\r\n
+        \       <Rights Type=\"dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n
+        \   </DomainGetInfoResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.023</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['2034']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:43:55 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:02:22 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '2308'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest-seconddomain&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
-        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
-        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
-        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
-        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\"\
-        \ Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524195\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\"\
-        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524206\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524203\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"\
-        orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524200\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\"\
-        \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524202\" Name=\"random.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524204\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524208\" Name=\"\
-        updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.945</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest-seconddomain.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n
+        \     <host HostId=\"746390\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746391\" Name=\"docs\"
+        Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746357\" Name=\"www\" Type=\"CNAME\" Address=\"parkingpage.namecheap.com.\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"CNAME Record\"
+        IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746392\"
+        Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746356\" Name=\"@\" Type=\"URL\" Address=\"http://www.unittest-seconddomain.dev/\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL
+        Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.289</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['3752']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:43:57 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:02:22 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '1552'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'IsActive10=true&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524206&HostId9=524203&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524193&HostId5=524194&HostId6=524195&HostId7=524205&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&FriendlyName3=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524200&HostId13=524201&HostId10=524207&HostId11=524209&HostId16=524208&HostId17=524210&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=updated&Address9=challengetoken&IsActive9=true&IsActive8=true&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&HostName12=random.fqdntest&HostName13=random.fulltest&HostName10=orig.testfqdn&HostName11=orig.testfull&HostName16=updated.testfqdn&HostName17=updated.testfull&HostName14=random.test&Address1=127.0.0.1&HostName18=_acme-challenge.full&MXPref5=10&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&Address12=challengetoken&Address18=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.fqdn&HostName5=_acme-challenge.full&HostName6=_acme-challenge.test&HostName7=orig.nameonly.test&HostName8=orig.nameonly.test&HostName9=orig.test&Address10=challengetoken&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken&TTL16=1800&FriendlyName16=&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=updated.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise-2&MXPref4=10&HostId14=524202&HostId15=524204'
+    body: HostId1=746390&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746391&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746357&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746392&Address4=challengetoken&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.fqdn&RecordType4=TXT&HostId5=746356&Address5=http%3A%2F%2Fwww.unittest-seconddomain.dev%2F&MXPref5=10&TTL5=1800&AssociatedAppTitle5=URL+Forwarding&FriendlyName5=URL+Record&IsActive5=true&IsDDNSEnabled5=false&HostName5=%40&RecordType5=URL&Address6=challengetoken&TTL6=3600&HostName6=_acme-challenge.full&RecordType6=TXT&SLD=unittest-seconddomain&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['3101']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1027'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.642</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest-seconddomain.dev\" IsSuccess=\"true\">\r\n      <Warnings
+        />\r\n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.365</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['561']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:43:58 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:02:23 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '569'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_valid_name_and_content.yaml
@@ -2,151 +2,171 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise-2.com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=unittest-seconddomain.dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
-        \ Status=\"Ok\" ID=\"277442\" DomainName=\"example-aptise-2.com\" OwnerName=\"\
-        jvsandbox2\" IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
-        \n        <CreatedDate>03/26/2018</CreatedDate>\r\n        <ExpiredDate>03/26/2019</ExpiredDate>\r\
-        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
-        \ />\r\n      <Whoisguard Enabled=\"True\">\r\n        <ID>233216</ID>\r\n\
-        \        <ExpiredDate>03/25/2019</ExpiredDate>\r\n        <EmailDetails WhoisGuardEmail=\"\
-        bdf487b65d844ddfafe33163f0e709f0.protect@whoisguard.com\" ForwardedTo=\"namecheap.sandbox.2@2xlp.com\"\
-        \ LastAutoEmailChangeDate=\"\" AutoEmailChangeFrequencyDays=\"0\" />\r\n \
-        \     </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
-        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
-        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
-        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
-        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"17\" EmailType=\"\
-        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
-        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
-        \n      <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\"\
-        >OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n        <Rights\
-        \ Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"nameserver\">OK</Rights>\r\
-        \n        <Rights Type=\"premiumDns\">OK</Rights>\r\n        <Rights Type=\"\
-        dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n    </DomainGetInfoResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.032</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult
+        Status=\"Ok\" ID=\"589668\" DomainName=\"unittest-seconddomain.dev\" OwnerName=\"phassberg2\"
+        IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\n        <CreatedDate>05/20/2020</CreatedDate>\r\n
+        \       <ExpiredDate>05/20/2021</ExpiredDate>\r\n        <NumYears>0</NumYears>\r\n
+        \     </DomainDetails>\r\n      <LockDetails />\r\n      <Whoisguard Enabled=\"True\">\r\n
+        \       <ID>481122</ID>\r\n        <ExpiredDate>05/20/2021</ExpiredDate>\r\n
+        \       <EmailDetails WhoisGuardEmail=\"af9bb0ea7b894617af45bb0fa4809b21.protect@whoisguard.com\"
+        ForwardedTo=\"drdoddo@gmail.com\" LastAutoEmailChangeDate=\"05/20/2020\" AutoEmailChangeFrequencyDays=\"3\"
+        />\r\n      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\n
+        \       <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\n
+        \       <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n        <IsActive>false</IsActive>\r\n
+        \     </PremiumDnsSubscription>\r\n      <DnsDetails ProviderType=\"FREE\"
+        IsUsingOurDNS=\"true\" HostCount=\"6\" EmailType=\"FWD\" DynamicDNSStatus=\"false\"
+        IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\n
+        \       <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\n
+        \     <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\">OK</Rights>\r\n
+        \       <Rights Type=\"eforward\">OK</Rights>\r\n        <Rights Type=\"rlock\">OK</Rights>\r\n
+        \       <Rights Type=\"parkpage\">OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n
+        \       <Rights Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"extend\">OK</Rights>\r\n
+        \       <Rights Type=\"nameserver\">OK</Rights>\r\n        <Rights Type=\"autorenew\">OK</Rights>\r\n
+        \       <Rights Type=\"whoisguard\">OK</Rights>\r\n        <Rights Type=\"premiumDns\">OK</Rights>\r\n
+        \       <Rights Type=\"dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n
+        \   </DomainGetInfoResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.025</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['2034']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:43:58 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:02:23 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '2308'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest-seconddomain&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
-        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
-        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
-        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
-        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\"\
-        \ Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524195\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\"\
-        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524206\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524203\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"\
-        orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524200\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\"\
-        \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524202\" Name=\"random.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524204\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524208\" Name=\"\
-        updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.814</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest-seconddomain.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n
+        \     <host HostId=\"746390\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746391\" Name=\"docs\"
+        Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746357\" Name=\"www\" Type=\"CNAME\" Address=\"parkingpage.namecheap.com.\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"CNAME Record\"
+        IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746392\"
+        Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746393\" Name=\"_acme-challenge.full\" Type=\"TXT\"
+        Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746356\" Name=\"@\" Type=\"URL\" Address=\"http://www.unittest-seconddomain.dev/\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL
+        Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.623</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['3752']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:44:00 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:02:26 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '1747'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'IsActive10=true&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524206&HostId9=524203&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524193&HostId5=524194&HostId6=524195&HostId7=524205&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&FriendlyName3=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524200&HostId13=524201&HostId10=524207&HostId11=524209&HostId16=524208&HostId17=524210&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=updated&Address9=challengetoken&IsActive9=true&IsActive8=true&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&HostName12=random.fqdntest&HostName13=random.fulltest&HostName10=orig.testfqdn&HostName11=orig.testfull&HostName16=updated.testfqdn&HostName17=updated.testfull&HostName14=random.test&Address1=127.0.0.1&HostName18=_acme-challenge.test&MXPref5=10&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&Address12=challengetoken&Address18=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.fqdn&HostName5=_acme-challenge.full&HostName6=_acme-challenge.test&HostName7=orig.nameonly.test&HostName8=orig.nameonly.test&HostName9=orig.test&Address10=challengetoken&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken&TTL16=1800&FriendlyName16=&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=updated.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise-2&MXPref4=10&HostId14=524202&HostId15=524204'
+    body: HostId1=746390&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746391&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746357&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746392&Address4=challengetoken&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.fqdn&RecordType4=TXT&HostId5=746393&Address5=challengetoken&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.full&RecordType5=TXT&HostId6=746356&Address6=http%3A%2F%2Fwww.unittest-seconddomain.dev%2F&MXPref6=10&TTL6=1800&AssociatedAppTitle6=URL+Forwarding&FriendlyName6=URL+Record&IsActive6=true&IsDDNSEnabled6=false&HostName6=%40&RecordType6=URL&Address7=challengetoken&TTL7=3600&HostName7=_acme-challenge.test&RecordType7=TXT&SLD=unittest-seconddomain&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['3101']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1206'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>1.16</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest-seconddomain.dev\" IsSuccess=\"true\">\r\n      <Warnings
+        />\r\n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.741</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['560']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:44:02 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:02:27 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '569'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_provider_when_calling_create_record_multiple_times_should_create_record_set.yaml
+++ b/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_provider_when_calling_create_record_multiple_times_should_create_record_set.yaml
@@ -2,257 +2,285 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise-2.com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=unittest-seconddomain.dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
-        \ Status=\"Ok\" ID=\"277442\" DomainName=\"example-aptise-2.com\" OwnerName=\"\
-        jvsandbox2\" IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
-        \n        <CreatedDate>03/26/2018</CreatedDate>\r\n        <ExpiredDate>03/26/2019</ExpiredDate>\r\
-        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
-        \ />\r\n      <Whoisguard Enabled=\"True\">\r\n        <ID>233216</ID>\r\n\
-        \        <ExpiredDate>03/25/2019</ExpiredDate>\r\n        <EmailDetails WhoisGuardEmail=\"\
-        bdf487b65d844ddfafe33163f0e709f0.protect@whoisguard.com\" ForwardedTo=\"namecheap.sandbox.2@2xlp.com\"\
-        \ LastAutoEmailChangeDate=\"\" AutoEmailChangeFrequencyDays=\"0\" />\r\n \
-        \     </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
-        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
-        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
-        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
-        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"17\" EmailType=\"\
-        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
-        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
-        \n      <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\"\
-        >OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n        <Rights\
-        \ Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"nameserver\">OK</Rights>\r\
-        \n        <Rights Type=\"premiumDns\">OK</Rights>\r\n        <Rights Type=\"\
-        dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n    </DomainGetInfoResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.066</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult
+        Status=\"Ok\" ID=\"589668\" DomainName=\"unittest-seconddomain.dev\" OwnerName=\"phassberg2\"
+        IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\n        <CreatedDate>05/20/2020</CreatedDate>\r\n
+        \       <ExpiredDate>05/20/2021</ExpiredDate>\r\n        <NumYears>0</NumYears>\r\n
+        \     </DomainDetails>\r\n      <LockDetails />\r\n      <Whoisguard Enabled=\"True\">\r\n
+        \       <ID>481122</ID>\r\n        <ExpiredDate>05/20/2021</ExpiredDate>\r\n
+        \       <EmailDetails WhoisGuardEmail=\"af9bb0ea7b894617af45bb0fa4809b21.protect@whoisguard.com\"
+        ForwardedTo=\"drdoddo@gmail.com\" LastAutoEmailChangeDate=\"05/20/2020\" AutoEmailChangeFrequencyDays=\"3\"
+        />\r\n      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\n
+        \       <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\n
+        \       <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n        <IsActive>false</IsActive>\r\n
+        \     </PremiumDnsSubscription>\r\n      <DnsDetails ProviderType=\"FREE\"
+        IsUsingOurDNS=\"true\" HostCount=\"7\" EmailType=\"FWD\" DynamicDNSStatus=\"false\"
+        IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\n
+        \       <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\n
+        \     <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\">OK</Rights>\r\n
+        \       <Rights Type=\"eforward\">OK</Rights>\r\n        <Rights Type=\"rlock\">OK</Rights>\r\n
+        \       <Rights Type=\"parkpage\">OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n
+        \       <Rights Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"extend\">OK</Rights>\r\n
+        \       <Rights Type=\"nameserver\">OK</Rights>\r\n        <Rights Type=\"autorenew\">OK</Rights>\r\n
+        \       <Rights Type=\"whoisguard\">OK</Rights>\r\n        <Rights Type=\"premiumDns\">OK</Rights>\r\n
+        \       <Rights Type=\"dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n
+        \   </DomainGetInfoResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.168</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['2034']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:44:02 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:02:27 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '2308'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest-seconddomain&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
-        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
-        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
-        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
-        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\"\
-        \ Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524195\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\"\
-        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524206\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524203\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"\
-        orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524200\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\"\
-        \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524202\" Name=\"random.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524204\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524208\" Name=\"\
-        updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.874</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest-seconddomain.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n
+        \     <host HostId=\"746390\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746391\" Name=\"docs\"
+        Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746357\" Name=\"www\" Type=\"CNAME\" Address=\"parkingpage.namecheap.com.\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"CNAME Record\"
+        IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746392\"
+        Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"
+        TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\"
+        />\r\n      <host HostId=\"746393\" Name=\"_acme-challenge.full\" Type=\"TXT\"
+        Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746394\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746356\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest-seconddomain.dev/\" MXPref=\"10\" TTL=\"1800\"
+        AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n
+        \ <Server>PHX01SBAPIEXT02</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.142</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['3752']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:44:04 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:02:28 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '1942'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'IsActive10=true&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524206&HostId9=524203&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524193&HostId5=524194&HostId6=524195&HostId7=524205&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&FriendlyName3=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524200&HostId13=524201&HostId10=524207&HostId11=524209&HostId16=524208&HostId17=524210&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=updated&Address9=challengetoken&IsActive9=true&IsActive8=true&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&HostName12=random.fqdntest&HostName13=random.fulltest&HostName10=orig.testfqdn&HostName11=orig.testfull&HostName16=updated.testfqdn&HostName17=updated.testfull&HostName14=random.test&Address1=127.0.0.1&HostName18=_acme-challenge.createrecordset&MXPref5=10&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&Address12=challengetoken&Address18=challengetoken1&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.fqdn&HostName5=_acme-challenge.full&HostName6=_acme-challenge.test&HostName7=orig.nameonly.test&HostName8=orig.nameonly.test&HostName9=orig.test&Address10=challengetoken&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken&TTL16=1800&FriendlyName16=&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=updated.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise-2&MXPref4=10&HostId14=524202&HostId15=524204'
+    body: HostId1=746390&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746391&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746357&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746392&Address4=challengetoken&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.fqdn&RecordType4=TXT&HostId5=746393&Address5=challengetoken&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.full&RecordType5=TXT&HostId6=746394&Address6=challengetoken&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.test&RecordType6=TXT&HostId7=746356&Address7=http%3A%2F%2Fwww.unittest-seconddomain.dev%2F&MXPref7=10&TTL7=1800&AssociatedAppTitle7=URL+Forwarding&FriendlyName7=URL+Record&IsActive7=true&IsDDNSEnabled7=false&HostName7=%40&RecordType7=URL&Address8=challengetoken1&TTL8=3600&HostName8=_acme-challenge.createrecordset&RecordType8=TXT&SLD=unittest-seconddomain&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['3113']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1397'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.963</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest-seconddomain.dev\" IsSuccess=\"true\">\r\n      <Warnings
+        />\r\n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.407</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['561']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:44:05 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:02:31 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '569'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest-seconddomain&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
-        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
-        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
-        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
-        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
-        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
-        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524195\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\"\
-        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524206\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524203\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"\
-        orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524200\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\"\
-        \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524202\" Name=\"random.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524204\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524208\" Name=\"\
-        updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.874</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest-seconddomain.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n
+        \     <host HostId=\"746390\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746391\" Name=\"docs\"
+        Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746357\" Name=\"www\" Type=\"CNAME\" Address=\"parkingpage.namecheap.com.\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"CNAME Record\"
+        IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746395\"
+        Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746392\" Name=\"_acme-challenge.fqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746393\" Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746394\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746356\" Name=\"@\" Type=\"URL\" Address=\"http://www.unittest-seconddomain.dev/\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL
+        Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.626</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['3959']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:44:06 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:02:32 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '2149'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'IsActive10=true&IsDDNSEnabled18=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524205&HostId9=524206&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524845&HostId5=524193&HostId6=524194&HostId7=524195&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&FriendlyName3=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524209&HostId13=524200&HostId10=524203&HostId11=524207&HostId16=524204&HostId17=524208&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=challengetoken&Address9=updated&IsActive9=true&IsActive8=true&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&HostName12=orig.testfull&HostName13=random.fqdntest&HostName10=orig.test&HostName11=orig.testfqdn&HostName16=updated.test&HostName17=updated.testfqdn&HostName14=random.fulltest&Address1=127.0.0.1&HostName18=updated.testfull&HostName19=_acme-challenge.createrecordset&MXPref5=10&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&Address12=challengetoken&Address18=challengetoken&Address19=challengetoken2&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref18=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.fqdn&HostName6=_acme-challenge.full&HostName7=_acme-challenge.test&HostName8=orig.nameonly.test&HostName9=orig.nameonly.test&Address10=challengetoken&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken&TTL16=1800&FriendlyName16=&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=random.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise-2&MXPref4=10&TTL18=1800&AssociatedAppTitle18=&HostId14=524201&HostId15=524202&HostId18=524210'
+    body: HostId1=746390&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746391&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746357&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746395&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746392&Address5=challengetoken&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.fqdn&RecordType5=TXT&HostId6=746393&Address6=challengetoken&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.full&RecordType6=TXT&HostId7=746394&Address7=challengetoken&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.test&RecordType7=TXT&HostId8=746356&Address8=http%3A%2F%2Fwww.unittest-seconddomain.dev%2F&MXPref8=10&TTL8=1800&AssociatedAppTitle8=URL+Forwarding&FriendlyName8=URL+Record&IsActive8=true&IsDDNSEnabled8=false&HostName8=%40&RecordType8=URL&Address9=challengetoken2&TTL9=3600&HostName9=_acme-challenge.createrecordset&RecordType9=TXT&SLD=unittest-seconddomain&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['3314']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1588'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.715</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest-seconddomain.dev\" IsSuccess=\"true\">\r\n      <Warnings
+        />\r\n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.679</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['561']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:44:07 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:02:33 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '569'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_provider_when_calling_create_record_with_duplicate_records_should_be_noop.yaml
+++ b/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_provider_when_calling_create_record_with_duplicate_records_should_be_noop.yaml
@@ -2,351 +2,365 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise-2.com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=unittest-seconddomain.dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
-        \ Status=\"Ok\" ID=\"277442\" DomainName=\"example-aptise-2.com\" OwnerName=\"\
-        jvsandbox2\" IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
-        \n        <CreatedDate>03/26/2018</CreatedDate>\r\n        <ExpiredDate>03/26/2019</ExpiredDate>\r\
-        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
-        \ />\r\n      <Whoisguard Enabled=\"True\">\r\n        <ID>233216</ID>\r\n\
-        \        <ExpiredDate>03/25/2019</ExpiredDate>\r\n        <EmailDetails WhoisGuardEmail=\"\
-        bdf487b65d844ddfafe33163f0e709f0.protect@whoisguard.com\" ForwardedTo=\"namecheap.sandbox.2@2xlp.com\"\
-        \ LastAutoEmailChangeDate=\"\" AutoEmailChangeFrequencyDays=\"0\" />\r\n \
-        \     </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
-        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
-        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
-        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
-        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"19\" EmailType=\"\
-        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
-        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
-        \n      <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\"\
-        >OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n        <Rights\
-        \ Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"nameserver\">OK</Rights>\r\
-        \n        <Rights Type=\"premiumDns\">OK</Rights>\r\n        <Rights Type=\"\
-        dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n    </DomainGetInfoResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.035</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult
+        Status=\"Ok\" ID=\"589668\" DomainName=\"unittest-seconddomain.dev\" OwnerName=\"phassberg2\"
+        IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\n        <CreatedDate>05/20/2020</CreatedDate>\r\n
+        \       <ExpiredDate>05/20/2021</ExpiredDate>\r\n        <NumYears>0</NumYears>\r\n
+        \     </DomainDetails>\r\n      <LockDetails />\r\n      <Whoisguard Enabled=\"True\">\r\n
+        \       <ID>481122</ID>\r\n        <ExpiredDate>05/20/2021</ExpiredDate>\r\n
+        \       <EmailDetails WhoisGuardEmail=\"af9bb0ea7b894617af45bb0fa4809b21.protect@whoisguard.com\"
+        ForwardedTo=\"drdoddo@gmail.com\" LastAutoEmailChangeDate=\"05/20/2020\" AutoEmailChangeFrequencyDays=\"3\"
+        />\r\n      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\n
+        \       <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\n
+        \       <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n        <IsActive>false</IsActive>\r\n
+        \     </PremiumDnsSubscription>\r\n      <DnsDetails ProviderType=\"FREE\"
+        IsUsingOurDNS=\"true\" HostCount=\"9\" EmailType=\"FWD\" DynamicDNSStatus=\"false\"
+        IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\n
+        \       <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\n
+        \     <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\">OK</Rights>\r\n
+        \       <Rights Type=\"eforward\">OK</Rights>\r\n        <Rights Type=\"rlock\">OK</Rights>\r\n
+        \       <Rights Type=\"parkpage\">OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n
+        \       <Rights Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"extend\">OK</Rights>\r\n
+        \       <Rights Type=\"nameserver\">OK</Rights>\r\n        <Rights Type=\"autorenew\">OK</Rights>\r\n
+        \       <Rights Type=\"whoisguard\">OK</Rights>\r\n        <Rights Type=\"premiumDns\">OK</Rights>\r\n
+        \       <Rights Type=\"dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n
+        \   </DomainGetInfoResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.183</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['2034']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:44:07 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:02:35 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '2308'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest-seconddomain&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
-        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
-        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
-        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
-        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
-        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
-        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
-        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524195\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\"\
-        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524206\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524203\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"\
-        orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524200\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\"\
-        \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524202\" Name=\"random.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524204\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524208\" Name=\"\
-        updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.846</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest-seconddomain.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n
+        \     <host HostId=\"746390\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746391\" Name=\"docs\"
+        Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746357\" Name=\"www\" Type=\"CNAME\" Address=\"parkingpage.namecheap.com.\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"CNAME Record\"
+        IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746395\"
+        Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746396\" Name=\"_acme-challenge.createrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746392\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746393\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746394\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746356\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest-seconddomain.dev/\" MXPref=\"10\" TTL=\"1800\"
+        AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n
+        \ <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.322</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4166']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:44:09 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:02:36 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '2356'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'HostId19=524210&RecordType20=TXT&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524195&HostId9=524205&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524845&HostId5=524846&HostId6=524193&HostId7=524194&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&FriendlyName3=&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524207&HostId13=524209&HostId10=524206&HostId11=524203&HostId16=524202&HostId17=524204&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&HostName12=orig.testfqdn&HostName13=orig.testfull&HostName10=orig.nameonly.test&HostName11=orig.test&HostName16=random.test&HostName17=updated.test&HostName14=random.fqdntest&Address1=127.0.0.1&HostName18=updated.testfqdn&HostName19=updated.testfull&MXPref5=10&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&Address12=challengetoken&Address18=challengetoken&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.fqdn&HostName7=_acme-challenge.full&HostName8=_acme-challenge.test&HostName9=orig.nameonly.test&Address10=updated&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName20=_acme-challenge.noop&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=random.fulltest&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise-2&MXPref4=10&TTL18=1800&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524200&AssociatedAppTitle19=&HostId15=524201&HostId18=524208'
+    body: HostId1=746390&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746391&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746357&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746395&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746396&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746392&Address6=challengetoken&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.fqdn&RecordType6=TXT&HostId7=746393&Address7=challengetoken&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.full&RecordType7=TXT&HostId8=746394&Address8=challengetoken&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.test&RecordType8=TXT&HostId9=746356&Address9=http%3A%2F%2Fwww.unittest-seconddomain.dev%2F&MXPref9=10&TTL9=1800&AssociatedAppTitle9=URL+Forwarding&FriendlyName9=URL+Record&IsActive9=true&IsDDNSEnabled9=false&HostName9=%40&RecordType9=URL&Address10=challengetoken&TTL10=3600&HostName10=_acme-challenge.noop&RecordType10=TXT&SLD=unittest-seconddomain&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['3503']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1771'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.777</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest-seconddomain.dev\" IsSuccess=\"true\">\r\n      <Warnings
+        />\r\n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.958</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['561']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:44:10 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:02:37 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '569'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest-seconddomain&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
-        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
-        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
-        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
-        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
-        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
-        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
-        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.938</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest-seconddomain.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n
+        \     <host HostId=\"746390\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746391\" Name=\"docs\"
+        Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746357\" Name=\"www\" Type=\"CNAME\" Address=\"parkingpage.namecheap.com.\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"CNAME Record\"
+        IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746395\"
+        Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746396\" Name=\"_acme-challenge.createrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746392\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746393\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746397\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746394\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746356\" Name=\"@\" Type=\"URL\" Address=\"http://www.unittest-seconddomain.dev/\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL
+        Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.694</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4361']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:44:12 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:02:39 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '2551'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'RecordType21=TXT&HostId19=524208&RecordType20=TXT&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524847&HostId9=524195&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524845&HostId5=524846&HostId6=524193&HostId7=524194&HostId20=524210&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&MXPref20=10&FriendlyName3=&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524203&HostId13=524207&HostId10=524205&HostId11=524206&HostId16=524201&HostId17=524202&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&HostName12=orig.test&HostName13=orig.testfqdn&HostName10=orig.nameonly.test&HostName11=orig.nameonly.test&HostName16=random.fulltest&HostName17=random.test&HostName14=orig.testfull&Address1=127.0.0.1&HostName18=updated.test&HostName19=updated.testfqdn&MXPref5=10&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&AssociatedAppTitle20=&Address12=challengetoken&Address18=challengetoken&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.fqdn&HostName7=_acme-challenge.full&HostName8=_acme-challenge.noop&HostName9=_acme-challenge.test&Address10=challengetoken&Address11=updated&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName21=_acme-challenge.noop&HostName20=updated.testfull&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=random.fqdntest&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise-2&MXPref4=10&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524209&AssociatedAppTitle19=&HostId15=524200&HostId18=524204'
+    body: HostId1=746390&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746391&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746357&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746395&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746396&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746392&Address6=challengetoken&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.fqdn&RecordType6=TXT&HostId7=746393&Address7=challengetoken&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.full&RecordType7=TXT&HostId8=746397&Address8=challengetoken&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.noop&RecordType8=TXT&HostId9=746394&Address9=challengetoken&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.test&RecordType9=TXT&HostId10=746356&Address10=http%3A%2F%2Fwww.unittest-seconddomain.dev%2F&MXPref10=10&TTL10=1800&AssociatedAppTitle10=URL+Forwarding&FriendlyName10=URL+Record&IsActive10=true&IsDDNSEnabled10=false&HostName10=%40&RecordType10=URL&Address11=challengetoken&TTL11=3600&HostName11=_acme-challenge.noop&RecordType11=TXT&SLD=unittest-seconddomain&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['3692']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1960'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>1.061</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest-seconddomain.dev\" IsSuccess=\"true\">\r\n      <Warnings
+        />\r\n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.616</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['561']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:44:13 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:02:40 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '569'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest-seconddomain&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
-        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
-        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
-        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
-        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
-        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
-        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
-        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.717</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest-seconddomain.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n
+        \     <host HostId=\"746390\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746391\" Name=\"docs\"
+        Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746357\" Name=\"www\" Type=\"CNAME\" Address=\"parkingpage.namecheap.com.\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"CNAME Record\"
+        IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746395\"
+        Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746396\" Name=\"_acme-challenge.createrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746392\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746393\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746397\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746394\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746356\" Name=\"@\" Type=\"URL\" Address=\"http://www.unittest-seconddomain.dev/\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL
+        Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.356</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4361']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:44:15 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:02:41 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '2551'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_provider_when_calling_delete_record_by_filter_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_provider_when_calling_delete_record_by_filter_should_remove_record.yaml
@@ -2,442 +2,443 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise-2.com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=unittest-seconddomain.dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
-        \ Status=\"Ok\" ID=\"277442\" DomainName=\"example-aptise-2.com\" OwnerName=\"\
-        jvsandbox2\" IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
-        \n        <CreatedDate>03/26/2018</CreatedDate>\r\n        <ExpiredDate>03/26/2019</ExpiredDate>\r\
-        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
-        \ />\r\n      <Whoisguard Enabled=\"True\">\r\n        <ID>233216</ID>\r\n\
-        \        <ExpiredDate>03/25/2019</ExpiredDate>\r\n        <EmailDetails WhoisGuardEmail=\"\
-        bdf487b65d844ddfafe33163f0e709f0.protect@whoisguard.com\" ForwardedTo=\"namecheap.sandbox.2@2xlp.com\"\
-        \ LastAutoEmailChangeDate=\"\" AutoEmailChangeFrequencyDays=\"0\" />\r\n \
-        \     </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
-        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
-        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
-        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
-        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"20\" EmailType=\"\
-        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
-        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
-        \n      <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\"\
-        >OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n        <Rights\
-        \ Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"nameserver\">OK</Rights>\r\
-        \n        <Rights Type=\"premiumDns\">OK</Rights>\r\n        <Rights Type=\"\
-        dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n    </DomainGetInfoResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.044</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult
+        Status=\"Ok\" ID=\"589668\" DomainName=\"unittest-seconddomain.dev\" OwnerName=\"phassberg2\"
+        IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\n        <CreatedDate>05/20/2020</CreatedDate>\r\n
+        \       <ExpiredDate>05/20/2021</ExpiredDate>\r\n        <NumYears>0</NumYears>\r\n
+        \     </DomainDetails>\r\n      <LockDetails />\r\n      <Whoisguard Enabled=\"True\">\r\n
+        \       <ID>481122</ID>\r\n        <ExpiredDate>05/20/2021</ExpiredDate>\r\n
+        \       <EmailDetails WhoisGuardEmail=\"af9bb0ea7b894617af45bb0fa4809b21.protect@whoisguard.com\"
+        ForwardedTo=\"drdoddo@gmail.com\" LastAutoEmailChangeDate=\"05/20/2020\" AutoEmailChangeFrequencyDays=\"3\"
+        />\r\n      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\n
+        \       <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\n
+        \       <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n        <IsActive>false</IsActive>\r\n
+        \     </PremiumDnsSubscription>\r\n      <DnsDetails ProviderType=\"FREE\"
+        IsUsingOurDNS=\"true\" HostCount=\"10\" EmailType=\"FWD\" DynamicDNSStatus=\"false\"
+        IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\n
+        \       <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\n
+        \     <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\">OK</Rights>\r\n
+        \       <Rights Type=\"eforward\">OK</Rights>\r\n        <Rights Type=\"rlock\">OK</Rights>\r\n
+        \       <Rights Type=\"parkpage\">OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n
+        \       <Rights Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"extend\">OK</Rights>\r\n
+        \       <Rights Type=\"nameserver\">OK</Rights>\r\n        <Rights Type=\"autorenew\">OK</Rights>\r\n
+        \       <Rights Type=\"whoisguard\">OK</Rights>\r\n        <Rights Type=\"premiumDns\">OK</Rights>\r\n
+        \       <Rights Type=\"dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n
+        \   </DomainGetInfoResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.02</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['2034']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:44:15 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:02:42 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '2308'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest-seconddomain&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
-        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
-        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
-        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
-        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
-        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
-        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
-        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.738</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest-seconddomain.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n
+        \     <host HostId=\"746390\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746391\" Name=\"docs\"
+        Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746357\" Name=\"www\" Type=\"CNAME\" Address=\"parkingpage.namecheap.com.\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"CNAME Record\"
+        IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746395\"
+        Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746396\" Name=\"_acme-challenge.createrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746392\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746393\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746397\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746394\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746356\" Name=\"@\" Type=\"URL\" Address=\"http://www.unittest-seconddomain.dev/\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL
+        Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.141</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4361']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:44:16 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:02:43 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '2551'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'RecordType21=TXT&HostId19=524208&RecordType20=TXT&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524847&HostId9=524195&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524845&HostId5=524846&HostId6=524193&HostId7=524194&HostId20=524210&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&MXPref20=10&FriendlyName3=&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524203&HostId13=524207&HostId10=524205&HostId11=524206&HostId16=524201&HostId17=524202&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&HostName12=orig.test&HostName13=orig.testfqdn&HostName10=orig.nameonly.test&HostName11=orig.nameonly.test&HostName16=random.fulltest&HostName17=random.test&HostName14=orig.testfull&Address1=127.0.0.1&HostName18=updated.test&HostName19=updated.testfqdn&MXPref5=10&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&AssociatedAppTitle20=&Address12=challengetoken&Address18=challengetoken&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.fqdn&HostName7=_acme-challenge.full&HostName8=_acme-challenge.noop&HostName9=_acme-challenge.test&Address10=challengetoken&Address11=updated&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName21=delete.testfilt&HostName20=updated.testfull&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=random.fqdntest&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise-2&MXPref4=10&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524209&AssociatedAppTitle19=&HostId15=524200&HostId18=524204'
+    body: HostId1=746390&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746391&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746357&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746395&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746396&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746392&Address6=challengetoken&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.fqdn&RecordType6=TXT&HostId7=746393&Address7=challengetoken&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.full&RecordType7=TXT&HostId8=746397&Address8=challengetoken&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.noop&RecordType8=TXT&HostId9=746394&Address9=challengetoken&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.test&RecordType9=TXT&HostId10=746356&Address10=http%3A%2F%2Fwww.unittest-seconddomain.dev%2F&MXPref10=10&TTL10=1800&AssociatedAppTitle10=URL+Forwarding&FriendlyName10=URL+Record&IsActive10=true&IsDDNSEnabled10=false&HostName10=%40&RecordType10=URL&Address11=challengetoken&TTL11=3600&HostName11=delete.testfilt&RecordType11=TXT&SLD=unittest-seconddomain&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['3687']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1955'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.915</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest-seconddomain.dev\" IsSuccess=\"true\">\r\n      <Warnings
+        />\r\n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>1.059</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['561']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:44:18 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:02:46 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '569'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest-seconddomain&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
-        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
-        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
-        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
-        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
-        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
-        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
-        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524848\" Name=\"delete.testfilt\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524205\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524206\"\
-        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"updated\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\" Name=\"orig.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524207\" Name=\"orig.testfqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524209\"\
-        \ Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\" Name=\"random.fqdntest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524201\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524202\"\
-        \ Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"updated.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524210\"\
-        \ Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\
-        \n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.876</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest-seconddomain.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n
+        \     <host HostId=\"746390\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746391\" Name=\"docs\"
+        Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746357\" Name=\"www\" Type=\"CNAME\" Address=\"parkingpage.namecheap.com.\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"CNAME Record\"
+        IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746395\"
+        Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746396\" Name=\"_acme-challenge.createrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746392\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746393\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746397\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746394\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746398\" Name=\"delete.testfilt\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746356\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest-seconddomain.dev/\" MXPref=\"10\" TTL=\"1800\"
+        AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n
+        \ <Server>PHX01SBAPIEXT02</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.636</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4551']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:44:19 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:02:46 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '2741'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest-seconddomain&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
-        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
-        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
-        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
-        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
-        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
-        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
-        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524848\" Name=\"delete.testfilt\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524205\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524206\"\
-        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"updated\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\" Name=\"orig.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524207\" Name=\"orig.testfqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524209\"\
-        \ Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\" Name=\"random.fqdntest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524201\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524202\"\
-        \ Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"updated.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524210\"\
-        \ Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\
-        \n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>1.137</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest-seconddomain.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n
+        \     <host HostId=\"746390\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746391\" Name=\"docs\"
+        Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746357\" Name=\"www\" Type=\"CNAME\" Address=\"parkingpage.namecheap.com.\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"CNAME Record\"
+        IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746395\"
+        Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746396\" Name=\"_acme-challenge.createrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746392\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746393\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746397\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746394\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746398\" Name=\"delete.testfilt\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746356\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest-seconddomain.dev/\" MXPref=\"10\" TTL=\"1800\"
+        AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n
+        \ <Server>PHX01SBAPIEXT02</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.167</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4551']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:44:21 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:02:48 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '2741'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'HostId19=524208&RecordType20=TXT&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524847&HostId9=524195&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524845&HostId5=524846&HostId6=524193&HostId7=524194&HostId20=524210&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&MXPref20=10&FriendlyName3=&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524203&HostId13=524207&HostId10=524205&HostId11=524206&HostId16=524201&HostId17=524202&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&HostName12=orig.test&HostName13=orig.testfqdn&HostName10=orig.nameonly.test&HostName11=orig.nameonly.test&HostName16=random.fulltest&HostName17=random.test&HostName14=orig.testfull&Address1=127.0.0.1&HostName18=updated.test&HostName19=updated.testfqdn&MXPref5=10&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&AssociatedAppTitle20=&Address12=challengetoken&Address18=challengetoken&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.fqdn&HostName7=_acme-challenge.full&HostName8=_acme-challenge.noop&HostName9=_acme-challenge.test&Address10=challengetoken&Address11=updated&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName20=updated.testfull&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=random.fqdntest&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise-2&MXPref4=10&TTL18=1800&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524209&AssociatedAppTitle19=&HostId15=524200&HostId18=524204'
+    body: HostId1=746390&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746391&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746357&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746395&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746396&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746392&Address6=challengetoken&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.fqdn&RecordType6=TXT&HostId7=746393&Address7=challengetoken&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.full&RecordType7=TXT&HostId8=746397&Address8=challengetoken&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.noop&RecordType8=TXT&HostId9=746394&Address9=challengetoken&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.test&RecordType9=TXT&HostId10=746356&Address10=http%3A%2F%2Fwww.unittest-seconddomain.dev%2F&MXPref10=10&TTL10=1800&AssociatedAppTitle10=URL+Forwarding&FriendlyName10=URL+Record&IsActive10=true&IsDDNSEnabled10=false&HostName10=%40&RecordType10=URL&SLD=unittest-seconddomain&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['3618']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1875'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.658</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest-seconddomain.dev\" IsSuccess=\"true\">\r\n      <Warnings
+        />\r\n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.81</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['561']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:44:22 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:02:50 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '568'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest-seconddomain&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
-        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
-        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
-        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
-        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
-        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
-        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
-        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.754</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest-seconddomain.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n
+        \     <host HostId=\"746390\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746391\" Name=\"docs\"
+        Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746357\" Name=\"www\" Type=\"CNAME\" Address=\"parkingpage.namecheap.com.\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"CNAME Record\"
+        IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746395\"
+        Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746396\" Name=\"_acme-challenge.createrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746392\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746393\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746397\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746394\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746356\" Name=\"@\" Type=\"URL\" Address=\"http://www.unittest-seconddomain.dev/\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL
+        Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.145</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4361']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:44:23 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:02:51 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '2551'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_provider_when_calling_delete_record_by_filter_with_fqdn_name_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_provider_when_calling_delete_record_by_filter_with_fqdn_name_should_remove_record.yaml
@@ -2,442 +2,443 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise-2.com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=unittest-seconddomain.dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
-        \ Status=\"Ok\" ID=\"277442\" DomainName=\"example-aptise-2.com\" OwnerName=\"\
-        jvsandbox2\" IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
-        \n        <CreatedDate>03/26/2018</CreatedDate>\r\n        <ExpiredDate>03/26/2019</ExpiredDate>\r\
-        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
-        \ />\r\n      <Whoisguard Enabled=\"True\">\r\n        <ID>233216</ID>\r\n\
-        \        <ExpiredDate>03/25/2019</ExpiredDate>\r\n        <EmailDetails WhoisGuardEmail=\"\
-        bdf487b65d844ddfafe33163f0e709f0.protect@whoisguard.com\" ForwardedTo=\"namecheap.sandbox.2@2xlp.com\"\
-        \ LastAutoEmailChangeDate=\"\" AutoEmailChangeFrequencyDays=\"0\" />\r\n \
-        \     </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
-        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
-        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
-        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
-        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"20\" EmailType=\"\
-        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
-        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
-        \n      <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\"\
-        >OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n        <Rights\
-        \ Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"nameserver\">OK</Rights>\r\
-        \n        <Rights Type=\"premiumDns\">OK</Rights>\r\n        <Rights Type=\"\
-        dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n    </DomainGetInfoResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.292</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult
+        Status=\"Ok\" ID=\"589668\" DomainName=\"unittest-seconddomain.dev\" OwnerName=\"phassberg2\"
+        IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\n        <CreatedDate>05/20/2020</CreatedDate>\r\n
+        \       <ExpiredDate>05/20/2021</ExpiredDate>\r\n        <NumYears>0</NumYears>\r\n
+        \     </DomainDetails>\r\n      <LockDetails />\r\n      <Whoisguard Enabled=\"True\">\r\n
+        \       <ID>481122</ID>\r\n        <ExpiredDate>05/20/2021</ExpiredDate>\r\n
+        \       <EmailDetails WhoisGuardEmail=\"af9bb0ea7b894617af45bb0fa4809b21.protect@whoisguard.com\"
+        ForwardedTo=\"drdoddo@gmail.com\" LastAutoEmailChangeDate=\"05/20/2020\" AutoEmailChangeFrequencyDays=\"3\"
+        />\r\n      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\n
+        \       <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\n
+        \       <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n        <IsActive>false</IsActive>\r\n
+        \     </PremiumDnsSubscription>\r\n      <DnsDetails ProviderType=\"FREE\"
+        IsUsingOurDNS=\"true\" HostCount=\"10\" EmailType=\"FWD\" DynamicDNSStatus=\"false\"
+        IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\n
+        \       <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\n
+        \     <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\">OK</Rights>\r\n
+        \       <Rights Type=\"eforward\">OK</Rights>\r\n        <Rights Type=\"rlock\">OK</Rights>\r\n
+        \       <Rights Type=\"parkpage\">OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n
+        \       <Rights Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"extend\">OK</Rights>\r\n
+        \       <Rights Type=\"nameserver\">OK</Rights>\r\n        <Rights Type=\"autorenew\">OK</Rights>\r\n
+        \       <Rights Type=\"whoisguard\">OK</Rights>\r\n        <Rights Type=\"premiumDns\">OK</Rights>\r\n
+        \       <Rights Type=\"dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n
+        \   </DomainGetInfoResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.242</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['2034']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:44:23 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:02:51 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '2309'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest-seconddomain&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
-        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
-        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
-        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
-        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
-        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
-        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
-        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.829</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest-seconddomain.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n
+        \     <host HostId=\"746390\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746391\" Name=\"docs\"
+        Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746357\" Name=\"www\" Type=\"CNAME\" Address=\"parkingpage.namecheap.com.\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"CNAME Record\"
+        IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746395\"
+        Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746396\" Name=\"_acme-challenge.createrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746392\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746393\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746397\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746394\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746356\" Name=\"@\" Type=\"URL\" Address=\"http://www.unittest-seconddomain.dev/\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL
+        Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.469</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4361']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:44:27 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:02:54 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '2551'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'RecordType21=TXT&HostId19=524208&RecordType20=TXT&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524847&HostId9=524195&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524845&HostId5=524846&HostId6=524193&HostId7=524194&HostId20=524210&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&MXPref20=10&FriendlyName3=&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524203&HostId13=524207&HostId10=524205&HostId11=524206&HostId16=524201&HostId17=524202&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&HostName12=orig.test&HostName13=orig.testfqdn&HostName10=orig.nameonly.test&HostName11=orig.nameonly.test&HostName16=random.fulltest&HostName17=random.test&HostName14=orig.testfull&Address1=127.0.0.1&HostName18=updated.test&HostName19=updated.testfqdn&MXPref5=10&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&AssociatedAppTitle20=&Address12=challengetoken&Address18=challengetoken&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.fqdn&HostName7=_acme-challenge.full&HostName8=_acme-challenge.noop&HostName9=_acme-challenge.test&Address10=challengetoken&Address11=updated&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName21=delete.testfqdn&HostName20=updated.testfull&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=random.fqdntest&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise-2&MXPref4=10&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524209&AssociatedAppTitle19=&HostId15=524200&HostId18=524204'
+    body: HostId1=746390&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746391&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746357&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746395&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746396&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746392&Address6=challengetoken&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.fqdn&RecordType6=TXT&HostId7=746393&Address7=challengetoken&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.full&RecordType7=TXT&HostId8=746397&Address8=challengetoken&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.noop&RecordType8=TXT&HostId9=746394&Address9=challengetoken&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.test&RecordType9=TXT&HostId10=746356&Address10=http%3A%2F%2Fwww.unittest-seconddomain.dev%2F&MXPref10=10&TTL10=1800&AssociatedAppTitle10=URL+Forwarding&FriendlyName10=URL+Record&IsActive10=true&IsDDNSEnabled10=false&HostName10=%40&RecordType10=URL&Address11=challengetoken&TTL11=3600&HostName11=delete.testfqdn&RecordType11=TXT&SLD=unittest-seconddomain&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['3687']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1955'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.989</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest-seconddomain.dev\" IsSuccess=\"true\">\r\n      <Warnings
+        />\r\n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.835</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['561']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:44:29 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:02:55 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '569'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest-seconddomain&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
-        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
-        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
-        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
-        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
-        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
-        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
-        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524849\" Name=\"delete.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524205\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524206\"\
-        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"updated\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\" Name=\"orig.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524207\" Name=\"orig.testfqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524209\"\
-        \ Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\" Name=\"random.fqdntest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524201\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524202\"\
-        \ Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"updated.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524210\"\
-        \ Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\
-        \n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.95</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest-seconddomain.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n
+        \     <host HostId=\"746390\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746391\" Name=\"docs\"
+        Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746357\" Name=\"www\" Type=\"CNAME\" Address=\"parkingpage.namecheap.com.\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"CNAME Record\"
+        IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746395\"
+        Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746396\" Name=\"_acme-challenge.createrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746392\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746393\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746397\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746394\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746399\" Name=\"delete.testfqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746356\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest-seconddomain.dev/\" MXPref=\"10\" TTL=\"1800\"
+        AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n
+        \ <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.494</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4550']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:44:31 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:02:56 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '2741'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest-seconddomain&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
-        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
-        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
-        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
-        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
-        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
-        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
-        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524849\" Name=\"delete.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524205\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524206\"\
-        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"updated\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\" Name=\"orig.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524207\" Name=\"orig.testfqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524209\"\
-        \ Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\" Name=\"random.fqdntest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524201\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524202\"\
-        \ Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"updated.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524210\"\
-        \ Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\
-        \n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.981</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest-seconddomain.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n
+        \     <host HostId=\"746390\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746391\" Name=\"docs\"
+        Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746357\" Name=\"www\" Type=\"CNAME\" Address=\"parkingpage.namecheap.com.\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"CNAME Record\"
+        IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746395\"
+        Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746396\" Name=\"_acme-challenge.createrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746392\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746393\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746397\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746394\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746399\" Name=\"delete.testfqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746356\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest-seconddomain.dev/\" MXPref=\"10\" TTL=\"1800\"
+        AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n
+        \ <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.364</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4551']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:44:33 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:02:58 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '2741'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'HostId19=524208&RecordType20=TXT&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524847&HostId9=524195&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524845&HostId5=524846&HostId6=524193&HostId7=524194&HostId20=524210&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&MXPref20=10&FriendlyName3=&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524203&HostId13=524207&HostId10=524205&HostId11=524206&HostId16=524201&HostId17=524202&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&HostName12=orig.test&HostName13=orig.testfqdn&HostName10=orig.nameonly.test&HostName11=orig.nameonly.test&HostName16=random.fulltest&HostName17=random.test&HostName14=orig.testfull&Address1=127.0.0.1&HostName18=updated.test&HostName19=updated.testfqdn&MXPref5=10&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&AssociatedAppTitle20=&Address12=challengetoken&Address18=challengetoken&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.fqdn&HostName7=_acme-challenge.full&HostName8=_acme-challenge.noop&HostName9=_acme-challenge.test&Address10=challengetoken&Address11=updated&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName20=updated.testfull&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=random.fqdntest&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise-2&MXPref4=10&TTL18=1800&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524209&AssociatedAppTitle19=&HostId15=524200&HostId18=524204'
+    body: HostId1=746390&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746391&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746357&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746395&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746396&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746392&Address6=challengetoken&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.fqdn&RecordType6=TXT&HostId7=746393&Address7=challengetoken&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.full&RecordType7=TXT&HostId8=746397&Address8=challengetoken&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.noop&RecordType8=TXT&HostId9=746394&Address9=challengetoken&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.test&RecordType9=TXT&HostId10=746356&Address10=http%3A%2F%2Fwww.unittest-seconddomain.dev%2F&MXPref10=10&TTL10=1800&AssociatedAppTitle10=URL+Forwarding&FriendlyName10=URL+Record&IsActive10=true&IsDDNSEnabled10=false&HostName10=%40&RecordType10=URL&SLD=unittest-seconddomain&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['3618']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1875'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.721</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest-seconddomain.dev\" IsSuccess=\"true\">\r\n      <Warnings
+        />\r\n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.367</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['561']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:44:34 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:02:58 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '569'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest-seconddomain&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
-        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
-        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
-        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
-        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
-        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
-        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
-        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.895</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest-seconddomain.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n
+        \     <host HostId=\"746390\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746391\" Name=\"docs\"
+        Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746357\" Name=\"www\" Type=\"CNAME\" Address=\"parkingpage.namecheap.com.\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"CNAME Record\"
+        IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746395\"
+        Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746396\" Name=\"_acme-challenge.createrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746392\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746393\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746397\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746394\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746356\" Name=\"@\" Type=\"URL\" Address=\"http://www.unittest-seconddomain.dev/\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL
+        Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.153</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4361']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:44:35 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:03:00 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '2551'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_provider_when_calling_delete_record_by_filter_with_full_name_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_provider_when_calling_delete_record_by_filter_with_full_name_should_remove_record.yaml
@@ -2,442 +2,443 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise-2.com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=unittest-seconddomain.dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
-        \ Status=\"Ok\" ID=\"277442\" DomainName=\"example-aptise-2.com\" OwnerName=\"\
-        jvsandbox2\" IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
-        \n        <CreatedDate>03/26/2018</CreatedDate>\r\n        <ExpiredDate>03/26/2019</ExpiredDate>\r\
-        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
-        \ />\r\n      <Whoisguard Enabled=\"True\">\r\n        <ID>233216</ID>\r\n\
-        \        <ExpiredDate>03/25/2019</ExpiredDate>\r\n        <EmailDetails WhoisGuardEmail=\"\
-        bdf487b65d844ddfafe33163f0e709f0.protect@whoisguard.com\" ForwardedTo=\"namecheap.sandbox.2@2xlp.com\"\
-        \ LastAutoEmailChangeDate=\"\" AutoEmailChangeFrequencyDays=\"0\" />\r\n \
-        \     </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
-        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
-        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
-        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
-        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"20\" EmailType=\"\
-        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
-        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
-        \n      <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\"\
-        >OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n        <Rights\
-        \ Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"nameserver\">OK</Rights>\r\
-        \n        <Rights Type=\"premiumDns\">OK</Rights>\r\n        <Rights Type=\"\
-        dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n    </DomainGetInfoResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.199</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult
+        Status=\"Ok\" ID=\"589668\" DomainName=\"unittest-seconddomain.dev\" OwnerName=\"phassberg2\"
+        IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\n        <CreatedDate>05/20/2020</CreatedDate>\r\n
+        \       <ExpiredDate>05/20/2021</ExpiredDate>\r\n        <NumYears>0</NumYears>\r\n
+        \     </DomainDetails>\r\n      <LockDetails />\r\n      <Whoisguard Enabled=\"True\">\r\n
+        \       <ID>481122</ID>\r\n        <ExpiredDate>05/20/2021</ExpiredDate>\r\n
+        \       <EmailDetails WhoisGuardEmail=\"af9bb0ea7b894617af45bb0fa4809b21.protect@whoisguard.com\"
+        ForwardedTo=\"drdoddo@gmail.com\" LastAutoEmailChangeDate=\"05/20/2020\" AutoEmailChangeFrequencyDays=\"3\"
+        />\r\n      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\n
+        \       <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\n
+        \       <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n        <IsActive>false</IsActive>\r\n
+        \     </PremiumDnsSubscription>\r\n      <DnsDetails ProviderType=\"FREE\"
+        IsUsingOurDNS=\"true\" HostCount=\"10\" EmailType=\"FWD\" DynamicDNSStatus=\"false\"
+        IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\n
+        \       <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\n
+        \     <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\">OK</Rights>\r\n
+        \       <Rights Type=\"eforward\">OK</Rights>\r\n        <Rights Type=\"rlock\">OK</Rights>\r\n
+        \       <Rights Type=\"parkpage\">OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n
+        \       <Rights Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"extend\">OK</Rights>\r\n
+        \       <Rights Type=\"nameserver\">OK</Rights>\r\n        <Rights Type=\"autorenew\">OK</Rights>\r\n
+        \       <Rights Type=\"whoisguard\">OK</Rights>\r\n        <Rights Type=\"premiumDns\">OK</Rights>\r\n
+        \       <Rights Type=\"dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n
+        \   </DomainGetInfoResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.172</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['2034']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:44:37 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:03:01 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '2309'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest-seconddomain&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
-        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
-        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
-        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
-        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
-        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
-        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
-        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.736</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest-seconddomain.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n
+        \     <host HostId=\"746390\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746391\" Name=\"docs\"
+        Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746357\" Name=\"www\" Type=\"CNAME\" Address=\"parkingpage.namecheap.com.\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"CNAME Record\"
+        IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746395\"
+        Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746396\" Name=\"_acme-challenge.createrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746392\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746393\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746397\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746394\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746356\" Name=\"@\" Type=\"URL\" Address=\"http://www.unittest-seconddomain.dev/\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL
+        Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.49</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4361']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:44:38 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:03:02 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '2550'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'RecordType21=TXT&HostId19=524208&RecordType20=TXT&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524847&HostId9=524195&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524845&HostId5=524846&HostId6=524193&HostId7=524194&HostId20=524210&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&MXPref20=10&FriendlyName3=&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524203&HostId13=524207&HostId10=524205&HostId11=524206&HostId16=524201&HostId17=524202&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&HostName12=orig.test&HostName13=orig.testfqdn&HostName10=orig.nameonly.test&HostName11=orig.nameonly.test&HostName16=random.fulltest&HostName17=random.test&HostName14=orig.testfull&Address1=127.0.0.1&HostName18=updated.test&HostName19=updated.testfqdn&MXPref5=10&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&AssociatedAppTitle20=&Address12=challengetoken&Address18=challengetoken&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.fqdn&HostName7=_acme-challenge.full&HostName8=_acme-challenge.noop&HostName9=_acme-challenge.test&Address10=challengetoken&Address11=updated&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName21=delete.testfull&HostName20=updated.testfull&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=random.fqdntest&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise-2&MXPref4=10&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524209&AssociatedAppTitle19=&HostId15=524200&HostId18=524204'
+    body: HostId1=746390&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746391&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746357&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746395&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746396&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746392&Address6=challengetoken&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.fqdn&RecordType6=TXT&HostId7=746393&Address7=challengetoken&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.full&RecordType7=TXT&HostId8=746397&Address8=challengetoken&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.noop&RecordType8=TXT&HostId9=746394&Address9=challengetoken&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.test&RecordType9=TXT&HostId10=746356&Address10=http%3A%2F%2Fwww.unittest-seconddomain.dev%2F&MXPref10=10&TTL10=1800&AssociatedAppTitle10=URL+Forwarding&FriendlyName10=URL+Record&IsActive10=true&IsDDNSEnabled10=false&HostName10=%40&RecordType10=URL&Address11=challengetoken&TTL11=3600&HostName11=delete.testfull&RecordType11=TXT&SLD=unittest-seconddomain&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['3687']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1955'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.767</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest-seconddomain.dev\" IsSuccess=\"true\">\r\n      <Warnings
+        />\r\n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.688</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['561']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:44:39 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:03:04 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '569'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest-seconddomain&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
-        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
-        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
-        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
-        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
-        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
-        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
-        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524850\" Name=\"delete.testfull\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524205\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524206\"\
-        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"updated\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\" Name=\"orig.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524207\" Name=\"orig.testfqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524209\"\
-        \ Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\" Name=\"random.fqdntest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524201\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524202\"\
-        \ Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"updated.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524210\"\
-        \ Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\
-        \n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.636</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest-seconddomain.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n
+        \     <host HostId=\"746390\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746391\" Name=\"docs\"
+        Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746357\" Name=\"www\" Type=\"CNAME\" Address=\"parkingpage.namecheap.com.\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"CNAME Record\"
+        IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746395\"
+        Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746396\" Name=\"_acme-challenge.createrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746392\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746393\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746397\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746394\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746400\" Name=\"delete.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746356\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest-seconddomain.dev/\" MXPref=\"10\" TTL=\"1800\"
+        AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n
+        \ <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.571</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4551']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:44:40 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:03:05 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '2741'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest-seconddomain&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
-        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
-        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
-        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
-        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
-        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
-        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
-        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524850\" Name=\"delete.testfull\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524205\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524206\"\
-        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"updated\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\" Name=\"orig.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524207\" Name=\"orig.testfqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524209\"\
-        \ Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\" Name=\"random.fqdntest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524201\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524202\"\
-        \ Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"updated.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524210\"\
-        \ Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\
-        \n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.599</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest-seconddomain.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n
+        \     <host HostId=\"746390\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746391\" Name=\"docs\"
+        Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746357\" Name=\"www\" Type=\"CNAME\" Address=\"parkingpage.namecheap.com.\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"CNAME Record\"
+        IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746395\"
+        Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746396\" Name=\"_acme-challenge.createrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746392\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746393\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746397\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746394\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746400\" Name=\"delete.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746356\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest-seconddomain.dev/\" MXPref=\"10\" TTL=\"1800\"
+        AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n
+        \ <Server>PHX01SBAPIEXT02</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.312</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4551']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:44:40 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:03:06 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '2741'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'HostId19=524208&RecordType20=TXT&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524847&HostId9=524195&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524845&HostId5=524846&HostId6=524193&HostId7=524194&HostId20=524210&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&MXPref20=10&FriendlyName3=&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524203&HostId13=524207&HostId10=524205&HostId11=524206&HostId16=524201&HostId17=524202&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&HostName12=orig.test&HostName13=orig.testfqdn&HostName10=orig.nameonly.test&HostName11=orig.nameonly.test&HostName16=random.fulltest&HostName17=random.test&HostName14=orig.testfull&Address1=127.0.0.1&HostName18=updated.test&HostName19=updated.testfqdn&MXPref5=10&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&AssociatedAppTitle20=&Address12=challengetoken&Address18=challengetoken&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.fqdn&HostName7=_acme-challenge.full&HostName8=_acme-challenge.noop&HostName9=_acme-challenge.test&Address10=challengetoken&Address11=updated&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName20=updated.testfull&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=random.fqdntest&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise-2&MXPref4=10&TTL18=1800&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524209&AssociatedAppTitle19=&HostId15=524200&HostId18=524204'
+    body: HostId1=746390&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746391&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746357&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746395&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746396&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746392&Address6=challengetoken&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.fqdn&RecordType6=TXT&HostId7=746393&Address7=challengetoken&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.full&RecordType7=TXT&HostId8=746397&Address8=challengetoken&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.noop&RecordType8=TXT&HostId9=746394&Address9=challengetoken&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.test&RecordType9=TXT&HostId10=746356&Address10=http%3A%2F%2Fwww.unittest-seconddomain.dev%2F&MXPref10=10&TTL10=1800&AssociatedAppTitle10=URL+Forwarding&FriendlyName10=URL+Record&IsActive10=true&IsDDNSEnabled10=false&HostName10=%40&RecordType10=URL&SLD=unittest-seconddomain&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['3618']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1875'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.733</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest-seconddomain.dev\" IsSuccess=\"true\">\r\n      <Warnings
+        />\r\n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>1.005</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['561']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:44:42 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:03:08 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '569'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest-seconddomain&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
-        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
-        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
-        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
-        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
-        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
-        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
-        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.758</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest-seconddomain.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n
+        \     <host HostId=\"746390\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746391\" Name=\"docs\"
+        Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746357\" Name=\"www\" Type=\"CNAME\" Address=\"parkingpage.namecheap.com.\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"CNAME Record\"
+        IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746395\"
+        Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746396\" Name=\"_acme-challenge.createrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746392\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746393\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746397\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746394\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746356\" Name=\"@\" Type=\"URL\" Address=\"http://www.unittest-seconddomain.dev/\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL
+        Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.344</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4361']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:44:44 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:03:10 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '2551'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_provider_when_calling_delete_record_by_identifier_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_provider_when_calling_delete_record_by_identifier_should_remove_record.yaml
@@ -2,527 +2,516 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise-2.com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=unittest-seconddomain.dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
-        \ Status=\"Ok\" ID=\"277442\" DomainName=\"example-aptise-2.com\" OwnerName=\"\
-        jvsandbox2\" IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
-        \n        <CreatedDate>03/26/2018</CreatedDate>\r\n        <ExpiredDate>03/26/2019</ExpiredDate>\r\
-        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
-        \ />\r\n      <Whoisguard Enabled=\"True\">\r\n        <ID>233216</ID>\r\n\
-        \        <ExpiredDate>03/25/2019</ExpiredDate>\r\n        <EmailDetails WhoisGuardEmail=\"\
-        bdf487b65d844ddfafe33163f0e709f0.protect@whoisguard.com\" ForwardedTo=\"namecheap.sandbox.2@2xlp.com\"\
-        \ LastAutoEmailChangeDate=\"\" AutoEmailChangeFrequencyDays=\"0\" />\r\n \
-        \     </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
-        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
-        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
-        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
-        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"20\" EmailType=\"\
-        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
-        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
-        \n      <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\"\
-        >OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n        <Rights\
-        \ Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"nameserver\">OK</Rights>\r\
-        \n        <Rights Type=\"premiumDns\">OK</Rights>\r\n        <Rights Type=\"\
-        dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n    </DomainGetInfoResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.035</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult
+        Status=\"Ok\" ID=\"589668\" DomainName=\"unittest-seconddomain.dev\" OwnerName=\"phassberg2\"
+        IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\n        <CreatedDate>05/20/2020</CreatedDate>\r\n
+        \       <ExpiredDate>05/20/2021</ExpiredDate>\r\n        <NumYears>0</NumYears>\r\n
+        \     </DomainDetails>\r\n      <LockDetails />\r\n      <Whoisguard Enabled=\"True\">\r\n
+        \       <ID>481122</ID>\r\n        <ExpiredDate>05/20/2021</ExpiredDate>\r\n
+        \       <EmailDetails WhoisGuardEmail=\"af9bb0ea7b894617af45bb0fa4809b21.protect@whoisguard.com\"
+        ForwardedTo=\"drdoddo@gmail.com\" LastAutoEmailChangeDate=\"05/20/2020\" AutoEmailChangeFrequencyDays=\"3\"
+        />\r\n      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\n
+        \       <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\n
+        \       <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n        <IsActive>false</IsActive>\r\n
+        \     </PremiumDnsSubscription>\r\n      <DnsDetails ProviderType=\"FREE\"
+        IsUsingOurDNS=\"true\" HostCount=\"10\" EmailType=\"FWD\" DynamicDNSStatus=\"false\"
+        IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\n
+        \       <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\n
+        \     <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\">OK</Rights>\r\n
+        \       <Rights Type=\"eforward\">OK</Rights>\r\n        <Rights Type=\"rlock\">OK</Rights>\r\n
+        \       <Rights Type=\"parkpage\">OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n
+        \       <Rights Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"extend\">OK</Rights>\r\n
+        \       <Rights Type=\"nameserver\">OK</Rights>\r\n        <Rights Type=\"autorenew\">OK</Rights>\r\n
+        \       <Rights Type=\"whoisguard\">OK</Rights>\r\n        <Rights Type=\"premiumDns\">OK</Rights>\r\n
+        \       <Rights Type=\"dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n
+        \   </DomainGetInfoResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.018</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['2034']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:44:44 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:03:10 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '2309'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest-seconddomain&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
-        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
-        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
-        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
-        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
-        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
-        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
-        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.692</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest-seconddomain.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n
+        \     <host HostId=\"746390\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746391\" Name=\"docs\"
+        Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746357\" Name=\"www\" Type=\"CNAME\" Address=\"parkingpage.namecheap.com.\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"CNAME Record\"
+        IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746395\"
+        Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746396\" Name=\"_acme-challenge.createrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746392\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746393\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746397\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746394\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746356\" Name=\"@\" Type=\"URL\" Address=\"http://www.unittest-seconddomain.dev/\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL
+        Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.663</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4361']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:44:45 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:03:11 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '2551'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'RecordType21=TXT&HostId19=524208&RecordType20=TXT&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524847&HostId9=524195&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524845&HostId5=524846&HostId6=524193&HostId7=524194&HostId20=524210&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&MXPref20=10&FriendlyName3=&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524203&HostId13=524207&HostId10=524205&HostId11=524206&HostId16=524201&HostId17=524202&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&HostName12=orig.test&HostName13=orig.testfqdn&HostName10=orig.nameonly.test&HostName11=orig.nameonly.test&HostName16=random.fulltest&HostName17=random.test&HostName14=orig.testfull&Address1=127.0.0.1&HostName18=updated.test&HostName19=updated.testfqdn&MXPref5=10&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&AssociatedAppTitle20=&Address12=challengetoken&Address18=challengetoken&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.fqdn&HostName7=_acme-challenge.full&HostName8=_acme-challenge.noop&HostName9=_acme-challenge.test&Address10=challengetoken&Address11=updated&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName21=delete.testid&HostName20=updated.testfull&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=random.fqdntest&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise-2&MXPref4=10&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524209&AssociatedAppTitle19=&HostId15=524200&HostId18=524204'
+    body: HostId1=746390&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746391&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746357&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746395&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746396&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746392&Address6=challengetoken&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.fqdn&RecordType6=TXT&HostId7=746393&Address7=challengetoken&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.full&RecordType7=TXT&HostId8=746397&Address8=challengetoken&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.noop&RecordType8=TXT&HostId9=746394&Address9=challengetoken&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.test&RecordType9=TXT&HostId10=746356&Address10=http%3A%2F%2Fwww.unittest-seconddomain.dev%2F&MXPref10=10&TTL10=1800&AssociatedAppTitle10=URL+Forwarding&FriendlyName10=URL+Record&IsActive10=true&IsDDNSEnabled10=false&HostName10=%40&RecordType10=URL&Address11=challengetoken&TTL11=3600&HostName11=delete.testid&RecordType11=TXT&SLD=unittest-seconddomain&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['3685']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1953'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.82</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest-seconddomain.dev\" IsSuccess=\"true\">\r\n      <Warnings
+        />\r\n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.917</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['560']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:44:47 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:03:13 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '569'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest-seconddomain&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
-        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
-        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
-        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
-        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
-        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
-        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
-        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524851\" Name=\"delete.testid\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524205\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524206\"\
-        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"updated\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\" Name=\"orig.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524207\" Name=\"orig.testfqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524209\"\
-        \ Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\" Name=\"random.fqdntest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524201\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524202\"\
-        \ Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"updated.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524210\"\
-        \ Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\
-        \n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>1.191</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest-seconddomain.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n
+        \     <host HostId=\"746390\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746391\" Name=\"docs\"
+        Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746357\" Name=\"www\" Type=\"CNAME\" Address=\"parkingpage.namecheap.com.\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"CNAME Record\"
+        IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746395\"
+        Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746396\" Name=\"_acme-challenge.createrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746392\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746393\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746397\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746394\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746401\" Name=\"delete.testid\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746356\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest-seconddomain.dev/\" MXPref=\"10\" TTL=\"1800\"
+        AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n
+        \ <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.439</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4549']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:44:48 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:03:15 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '2739'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest-seconddomain&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
-        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
-        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
-        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
-        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
-        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
-        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
-        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524851\" Name=\"delete.testid\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524205\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524206\"\
-        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"updated\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\" Name=\"orig.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524207\" Name=\"orig.testfqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524209\"\
-        \ Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\" Name=\"random.fqdntest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524201\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524202\"\
-        \ Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"updated.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524210\"\
-        \ Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\
-        \n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.772</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest-seconddomain.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n
+        \     <host HostId=\"746390\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746391\" Name=\"docs\"
+        Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746357\" Name=\"www\" Type=\"CNAME\" Address=\"parkingpage.namecheap.com.\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"CNAME Record\"
+        IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746395\"
+        Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746396\" Name=\"_acme-challenge.createrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746392\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746393\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746397\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746394\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746401\" Name=\"delete.testid\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746356\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest-seconddomain.dev/\" MXPref=\"10\" TTL=\"1800\"
+        AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n
+        \ <Server>PHX01SBAPIEXT02</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.142</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4549']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:44:50 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:03:16 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '2739'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest-seconddomain&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
-        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
-        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
-        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
-        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
-        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
-        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
-        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524851\" Name=\"delete.testid\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524205\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524206\"\
-        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"updated\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\" Name=\"orig.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524207\" Name=\"orig.testfqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524209\"\
-        \ Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\" Name=\"random.fqdntest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524201\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524202\"\
-        \ Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"updated.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524210\"\
-        \ Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\
-        \n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>1.094</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest-seconddomain.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n
+        \     <host HostId=\"746390\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746391\" Name=\"docs\"
+        Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746357\" Name=\"www\" Type=\"CNAME\" Address=\"parkingpage.namecheap.com.\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"CNAME Record\"
+        IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746395\"
+        Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746396\" Name=\"_acme-challenge.createrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746392\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746393\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746397\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746394\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746401\" Name=\"delete.testid\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746356\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest-seconddomain.dev/\" MXPref=\"10\" TTL=\"1800\"
+        AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n
+        \ <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.625</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4549']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:44:52 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:03:17 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '2739'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'HostId19=524208&RecordType20=TXT&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524847&HostId9=524195&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524845&HostId5=524846&HostId6=524193&HostId7=524194&HostId20=524210&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&MXPref20=10&FriendlyName3=&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524203&HostId13=524207&HostId10=524205&HostId11=524206&HostId16=524201&HostId17=524202&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&HostName12=orig.test&HostName13=orig.testfqdn&HostName10=orig.nameonly.test&HostName11=orig.nameonly.test&HostName16=random.fulltest&HostName17=random.test&HostName14=orig.testfull&Address1=127.0.0.1&HostName18=updated.test&HostName19=updated.testfqdn&MXPref5=10&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&AssociatedAppTitle20=&Address12=challengetoken&Address18=challengetoken&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.fqdn&HostName7=_acme-challenge.full&HostName8=_acme-challenge.noop&HostName9=_acme-challenge.test&Address10=challengetoken&Address11=updated&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName20=updated.testfull&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=random.fqdntest&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise-2&MXPref4=10&TTL18=1800&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524209&AssociatedAppTitle19=&HostId15=524200&HostId18=524204'
+    body: HostId1=746390&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746391&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746357&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746395&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746396&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746392&Address6=challengetoken&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.fqdn&RecordType6=TXT&HostId7=746393&Address7=challengetoken&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.full&RecordType7=TXT&HostId8=746397&Address8=challengetoken&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.noop&RecordType8=TXT&HostId9=746394&Address9=challengetoken&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.test&RecordType9=TXT&HostId10=746356&Address10=http%3A%2F%2Fwww.unittest-seconddomain.dev%2F&MXPref10=10&TTL10=1800&AssociatedAppTitle10=URL+Forwarding&FriendlyName10=URL+Record&IsActive10=true&IsDDNSEnabled10=false&HostName10=%40&RecordType10=URL&SLD=unittest-seconddomain&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['3618']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1875'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.742</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest-seconddomain.dev\" IsSuccess=\"true\">\r\n      <Warnings
+        />\r\n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.611</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['561']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:44:53 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:03:18 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '569'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest-seconddomain&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
-        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
-        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
-        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
-        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
-        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
-        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
-        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.672</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest-seconddomain.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n
+        \     <host HostId=\"746390\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746391\" Name=\"docs\"
+        Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746357\" Name=\"www\" Type=\"CNAME\" Address=\"parkingpage.namecheap.com.\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"CNAME Record\"
+        IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746395\"
+        Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746396\" Name=\"_acme-challenge.createrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746392\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746393\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746397\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746394\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746356\" Name=\"@\" Type=\"URL\" Address=\"http://www.unittest-seconddomain.dev/\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL
+        Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.302</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4361']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:44:54 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:03:20 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '2551'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_provider_when_calling_delete_record_with_record_set_by_content_should_leave_others_untouched.yaml
+++ b/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_provider_when_calling_delete_record_with_record_set_by_content_should_leave_others_untouched.yaml
@@ -2,566 +2,571 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise-2.com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=unittest-seconddomain.dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
-        \ Status=\"Ok\" ID=\"277442\" DomainName=\"example-aptise-2.com\" OwnerName=\"\
-        jvsandbox2\" IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
-        \n        <CreatedDate>03/26/2018</CreatedDate>\r\n        <ExpiredDate>03/26/2019</ExpiredDate>\r\
-        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
-        \ />\r\n      <Whoisguard Enabled=\"True\">\r\n        <ID>233216</ID>\r\n\
-        \        <ExpiredDate>03/25/2019</ExpiredDate>\r\n        <EmailDetails WhoisGuardEmail=\"\
-        bdf487b65d844ddfafe33163f0e709f0.protect@whoisguard.com\" ForwardedTo=\"namecheap.sandbox.2@2xlp.com\"\
-        \ LastAutoEmailChangeDate=\"\" AutoEmailChangeFrequencyDays=\"0\" />\r\n \
-        \     </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
-        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
-        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
-        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
-        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"20\" EmailType=\"\
-        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
-        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
-        \n      <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\"\
-        >OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n        <Rights\
-        \ Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"nameserver\">OK</Rights>\r\
-        \n        <Rights Type=\"premiumDns\">OK</Rights>\r\n        <Rights Type=\"\
-        dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n    </DomainGetInfoResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.354</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult
+        Status=\"Ok\" ID=\"589668\" DomainName=\"unittest-seconddomain.dev\" OwnerName=\"phassberg2\"
+        IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\n        <CreatedDate>05/20/2020</CreatedDate>\r\n
+        \       <ExpiredDate>05/20/2021</ExpiredDate>\r\n        <NumYears>0</NumYears>\r\n
+        \     </DomainDetails>\r\n      <LockDetails />\r\n      <Whoisguard Enabled=\"True\">\r\n
+        \       <ID>481122</ID>\r\n        <ExpiredDate>05/20/2021</ExpiredDate>\r\n
+        \       <EmailDetails WhoisGuardEmail=\"af9bb0ea7b894617af45bb0fa4809b21.protect@whoisguard.com\"
+        ForwardedTo=\"drdoddo@gmail.com\" LastAutoEmailChangeDate=\"05/20/2020\" AutoEmailChangeFrequencyDays=\"3\"
+        />\r\n      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\n
+        \       <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\n
+        \       <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n        <IsActive>false</IsActive>\r\n
+        \     </PremiumDnsSubscription>\r\n      <DnsDetails ProviderType=\"FREE\"
+        IsUsingOurDNS=\"true\" HostCount=\"10\" EmailType=\"FWD\" DynamicDNSStatus=\"false\"
+        IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\n
+        \       <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\n
+        \     <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\">OK</Rights>\r\n
+        \       <Rights Type=\"eforward\">OK</Rights>\r\n        <Rights Type=\"rlock\">OK</Rights>\r\n
+        \       <Rights Type=\"parkpage\">OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n
+        \       <Rights Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"extend\">OK</Rights>\r\n
+        \       <Rights Type=\"nameserver\">OK</Rights>\r\n        <Rights Type=\"autorenew\">OK</Rights>\r\n
+        \       <Rights Type=\"whoisguard\">OK</Rights>\r\n        <Rights Type=\"premiumDns\">OK</Rights>\r\n
+        \       <Rights Type=\"dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n
+        \   </DomainGetInfoResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.025</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['2034']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:44:54 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:03:20 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '2309'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest-seconddomain&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
-        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
-        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
-        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
-        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
-        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
-        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
-        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>1.002</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest-seconddomain.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n
+        \     <host HostId=\"746390\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746391\" Name=\"docs\"
+        Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746357\" Name=\"www\" Type=\"CNAME\" Address=\"parkingpage.namecheap.com.\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"CNAME Record\"
+        IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746395\"
+        Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746396\" Name=\"_acme-challenge.createrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746392\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746393\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746397\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746394\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746356\" Name=\"@\" Type=\"URL\" Address=\"http://www.unittest-seconddomain.dev/\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL
+        Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.138</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4361']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:44:56 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:03:22 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '2551'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'RecordType21=TXT&HostId19=524208&RecordType20=TXT&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524847&HostId9=524195&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524845&HostId5=524846&HostId6=524193&HostId7=524194&HostId20=524210&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&MXPref20=10&FriendlyName3=&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524203&HostId13=524207&HostId10=524205&HostId11=524206&HostId16=524201&HostId17=524202&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&HostName12=orig.test&HostName13=orig.testfqdn&HostName10=orig.nameonly.test&HostName11=orig.nameonly.test&HostName16=random.fulltest&HostName17=random.test&HostName14=orig.testfull&Address1=127.0.0.1&HostName18=updated.test&HostName19=updated.testfqdn&MXPref5=10&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&AssociatedAppTitle20=&Address12=challengetoken&Address18=challengetoken&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.fqdn&HostName7=_acme-challenge.full&HostName8=_acme-challenge.noop&HostName9=_acme-challenge.test&Address10=challengetoken&Address11=updated&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName21=_acme-challenge.deleterecordinset&HostName20=updated.testfull&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=random.fqdntest&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise-2&MXPref4=10&TTL18=1800&Address21=challengetoken1&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524209&AssociatedAppTitle19=&HostId15=524200&HostId18=524204'
+    body: HostId1=746390&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746391&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746357&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746395&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746396&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746392&Address6=challengetoken&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.fqdn&RecordType6=TXT&HostId7=746393&Address7=challengetoken&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.full&RecordType7=TXT&HostId8=746397&Address8=challengetoken&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.noop&RecordType8=TXT&HostId9=746394&Address9=challengetoken&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.test&RecordType9=TXT&HostId10=746356&Address10=http%3A%2F%2Fwww.unittest-seconddomain.dev%2F&MXPref10=10&TTL10=1800&AssociatedAppTitle10=URL+Forwarding&FriendlyName10=URL+Record&IsActive10=true&IsDDNSEnabled10=false&HostName10=%40&RecordType10=URL&Address11=challengetoken1&TTL11=3600&HostName11=_acme-challenge.deleterecordinset&RecordType11=TXT&SLD=unittest-seconddomain&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['3706']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1974'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.93</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest-seconddomain.dev\" IsSuccess=\"true\">\r\n      <Warnings
+        />\r\n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.776</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['560']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:44:58 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:03:23 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '569'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest-seconddomain&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
-        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
-        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
-        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
-        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
-        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
-        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524852\" Name=\"\
-        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
-        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.863</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest-seconddomain.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n
+        \     <host HostId=\"746390\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746391\" Name=\"docs\"
+        Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746357\" Name=\"www\" Type=\"CNAME\" Address=\"parkingpage.namecheap.com.\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"CNAME Record\"
+        IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746395\"
+        Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746396\" Name=\"_acme-challenge.createrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746402\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746392\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746393\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746397\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746394\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746356\" Name=\"@\" Type=\"URL\" Address=\"http://www.unittest-seconddomain.dev/\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL
+        Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.876</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4570']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:45:00 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:03:26 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '2760'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'RecordType21=TXT&HostId19=524204&RecordType20=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524194&HostId9=524847&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524845&HostId5=524846&HostId6=524852&HostId7=524193&HostId21=524210&HostId20=524208&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524206&HostId13=524203&HostId10=524195&HostId11=524205&HostId16=524200&HostId17=524201&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken2&HostName12=orig.nameonly.test&HostName13=orig.test&HostName10=_acme-challenge.test&HostName11=orig.nameonly.test&HostName16=random.fqdntest&HostName17=random.fulltest&HostName14=orig.testfqdn&Address1=127.0.0.1&HostName18=random.test&HostName19=updated.test&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=updated&Address18=challengetoken&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.noop&Address10=challengetoken&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName22=_acme-challenge.deleterecordinset&HostName21=updated.testfull&HostName20=updated.testfqdn&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.testfull&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken1&SLD=example-aptise-2&MXPref4=10&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524207&AssociatedAppTitle19=&HostId15=524209&HostId18=524202'
+    body: HostId1=746390&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746391&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746357&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746395&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746396&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746402&Address6=challengetoken1&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.deleterecordinset&RecordType6=TXT&HostId7=746392&Address7=challengetoken&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.fqdn&RecordType7=TXT&HostId8=746393&Address8=challengetoken&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.full&RecordType8=TXT&HostId9=746397&Address9=challengetoken&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.noop&RecordType9=TXT&HostId10=746394&Address10=challengetoken&MXPref10=10&TTL10=3600&AssociatedAppTitle10=&FriendlyName10=&IsActive10=true&IsDDNSEnabled10=false&HostName10=_acme-challenge.test&RecordType10=TXT&HostId11=746356&Address11=http%3A%2F%2Fwww.unittest-seconddomain.dev%2F&MXPref11=10&TTL11=1800&AssociatedAppTitle11=URL+Forwarding&FriendlyName11=URL+Record&IsActive11=true&IsDDNSEnabled11=false&HostName11=%40&RecordType11=URL&Address12=challengetoken2&TTL12=3600&HostName12=_acme-challenge.deleterecordinset&RecordType12=TXT&SLD=unittest-seconddomain&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['3909']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2177'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.752</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest-seconddomain.dev\" IsSuccess=\"true\">\r\n      <Warnings
+        />\r\n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.663</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['561']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:45:01 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:03:27 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '569'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest-seconddomain&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
-        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
-        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
-        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
-        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
-        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
-        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524852\" Name=\"\
-        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
-        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
-        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>1.251</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest-seconddomain.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n
+        \     <host HostId=\"746390\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746391\" Name=\"docs\"
+        Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746357\" Name=\"www\" Type=\"CNAME\" Address=\"parkingpage.namecheap.com.\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"CNAME Record\"
+        IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746395\"
+        Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746396\" Name=\"_acme-challenge.createrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746402\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746403\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746392\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746393\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746397\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746394\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746356\" Name=\"@\" Type=\"URL\" Address=\"http://www.unittest-seconddomain.dev/\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL
+        Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.141</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4779']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:45:02 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:03:27 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '2969'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest-seconddomain&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
-        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
-        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
-        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
-        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
-        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
-        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524852\" Name=\"\
-        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
-        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
-        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.707</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest-seconddomain.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n
+        \     <host HostId=\"746390\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746391\" Name=\"docs\"
+        Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746357\" Name=\"www\" Type=\"CNAME\" Address=\"parkingpage.namecheap.com.\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"CNAME Record\"
+        IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746395\"
+        Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746396\" Name=\"_acme-challenge.createrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746402\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken1\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746403\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746392\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746393\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746397\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746394\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746356\" Name=\"@\" Type=\"URL\" Address=\"http://www.unittest-seconddomain.dev/\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL
+        Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.537</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4779']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:45:04 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:03:29 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '2969'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'RecordType21=TXT&HostId19=524204&RecordType20=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524194&HostId9=524847&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524845&HostId5=524846&HostId6=524853&HostId7=524193&HostId21=524210&HostId20=524208&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524206&HostId13=524203&HostId10=524195&HostId11=524205&HostId16=524200&HostId17=524201&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&HostName12=orig.nameonly.test&HostName13=orig.test&HostName10=_acme-challenge.test&HostName11=orig.nameonly.test&HostName16=random.fqdntest&HostName17=random.fulltest&HostName14=orig.testfqdn&Address1=127.0.0.1&HostName18=random.test&HostName19=updated.test&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=updated&Address18=challengetoken&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.noop&Address10=challengetoken&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName21=updated.testfull&HostName20=updated.testfqdn&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.testfull&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&SLD=example-aptise-2&MXPref4=10&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524207&AssociatedAppTitle19=&HostId15=524209&HostId18=524202'
+    body: HostId1=746390&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746391&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746357&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746395&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746396&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746403&Address6=challengetoken2&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.deleterecordinset&RecordType6=TXT&HostId7=746392&Address7=challengetoken&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.fqdn&RecordType7=TXT&HostId8=746393&Address8=challengetoken&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.full&RecordType8=TXT&HostId9=746397&Address9=challengetoken&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.noop&RecordType9=TXT&HostId10=746394&Address10=challengetoken&MXPref10=10&TTL10=3600&AssociatedAppTitle10=&FriendlyName10=&IsActive10=true&IsDDNSEnabled10=false&HostName10=_acme-challenge.test&RecordType10=TXT&HostId11=746356&Address11=http%3A%2F%2Fwww.unittest-seconddomain.dev%2F&MXPref11=10&TTL11=1800&AssociatedAppTitle11=URL+Forwarding&FriendlyName11=URL+Record&IsActive11=true&IsDDNSEnabled11=false&HostName11=%40&RecordType11=URL&SLD=unittest-seconddomain&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['3821']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2078'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.826</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest-seconddomain.dev\" IsSuccess=\"true\">\r\n      <Warnings
+        />\r\n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>1.117</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['561']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:45:05 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:03:31 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '569'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest-seconddomain&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
-        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
-        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
-        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
-        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
-        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
-        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
-        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
-        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.651</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest-seconddomain.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n
+        \     <host HostId=\"746390\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746391\" Name=\"docs\"
+        Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746357\" Name=\"www\" Type=\"CNAME\" Address=\"parkingpage.namecheap.com.\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"CNAME Record\"
+        IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746395\"
+        Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746396\" Name=\"_acme-challenge.createrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746403\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746392\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746393\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746397\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746394\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746356\" Name=\"@\" Type=\"URL\" Address=\"http://www.unittest-seconddomain.dev/\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL
+        Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.302</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4570']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:45:06 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:03:33 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '2760'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_provider_when_calling_delete_record_with_record_set_name_remove_all.yaml
+++ b/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_provider_when_calling_delete_record_with_record_set_name_remove_all.yaml
@@ -2,696 +2,703 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise-2.com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=unittest-seconddomain.dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
-        \ Status=\"Ok\" ID=\"277442\" DomainName=\"example-aptise-2.com\" OwnerName=\"\
-        jvsandbox2\" IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
-        \n        <CreatedDate>03/26/2018</CreatedDate>\r\n        <ExpiredDate>03/26/2019</ExpiredDate>\r\
-        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
-        \ />\r\n      <Whoisguard Enabled=\"True\">\r\n        <ID>233216</ID>\r\n\
-        \        <ExpiredDate>03/25/2019</ExpiredDate>\r\n        <EmailDetails WhoisGuardEmail=\"\
-        bdf487b65d844ddfafe33163f0e709f0.protect@whoisguard.com\" ForwardedTo=\"namecheap.sandbox.2@2xlp.com\"\
-        \ LastAutoEmailChangeDate=\"\" AutoEmailChangeFrequencyDays=\"0\" />\r\n \
-        \     </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
-        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
-        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
-        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
-        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"21\" EmailType=\"\
-        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
-        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
-        \n      <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\"\
-        >OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n        <Rights\
-        \ Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"nameserver\">OK</Rights>\r\
-        \n        <Rights Type=\"premiumDns\">OK</Rights>\r\n        <Rights Type=\"\
-        dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n    </DomainGetInfoResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.219</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult
+        Status=\"Ok\" ID=\"589668\" DomainName=\"unittest-seconddomain.dev\" OwnerName=\"phassberg2\"
+        IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\n        <CreatedDate>05/20/2020</CreatedDate>\r\n
+        \       <ExpiredDate>05/20/2021</ExpiredDate>\r\n        <NumYears>0</NumYears>\r\n
+        \     </DomainDetails>\r\n      <LockDetails />\r\n      <Whoisguard Enabled=\"True\">\r\n
+        \       <ID>481122</ID>\r\n        <ExpiredDate>05/20/2021</ExpiredDate>\r\n
+        \       <EmailDetails WhoisGuardEmail=\"af9bb0ea7b894617af45bb0fa4809b21.protect@whoisguard.com\"
+        ForwardedTo=\"drdoddo@gmail.com\" LastAutoEmailChangeDate=\"05/20/2020\" AutoEmailChangeFrequencyDays=\"3\"
+        />\r\n      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\n
+        \       <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\n
+        \       <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n        <IsActive>false</IsActive>\r\n
+        \     </PremiumDnsSubscription>\r\n      <DnsDetails ProviderType=\"FREE\"
+        IsUsingOurDNS=\"true\" HostCount=\"11\" EmailType=\"FWD\" DynamicDNSStatus=\"false\"
+        IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\n
+        \       <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\n
+        \     <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\">OK</Rights>\r\n
+        \       <Rights Type=\"eforward\">OK</Rights>\r\n        <Rights Type=\"rlock\">OK</Rights>\r\n
+        \       <Rights Type=\"parkpage\">OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n
+        \       <Rights Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"extend\">OK</Rights>\r\n
+        \       <Rights Type=\"nameserver\">OK</Rights>\r\n        <Rights Type=\"autorenew\">OK</Rights>\r\n
+        \       <Rights Type=\"whoisguard\">OK</Rights>\r\n        <Rights Type=\"premiumDns\">OK</Rights>\r\n
+        \       <Rights Type=\"dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n
+        \   </DomainGetInfoResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.022</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['2034']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:45:06 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:03:34 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '2309'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest-seconddomain&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
-        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
-        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
-        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
-        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
-        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
-        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
-        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
-        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.925</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest-seconddomain.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n
+        \     <host HostId=\"746390\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746391\" Name=\"docs\"
+        Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746357\" Name=\"www\" Type=\"CNAME\" Address=\"parkingpage.namecheap.com.\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"CNAME Record\"
+        IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746395\"
+        Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746396\" Name=\"_acme-challenge.createrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746403\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746392\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746393\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746397\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746394\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746356\" Name=\"@\" Type=\"URL\" Address=\"http://www.unittest-seconddomain.dev/\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL
+        Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.15</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4570']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:45:08 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:03:35 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '2759'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'RecordType21=TXT&HostId19=524204&RecordType20=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524194&HostId9=524847&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524845&HostId5=524846&HostId6=524853&HostId7=524193&HostId21=524210&HostId20=524208&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524206&HostId13=524203&HostId10=524195&HostId11=524205&HostId16=524200&HostId17=524201&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken1&HostName12=orig.nameonly.test&HostName13=orig.test&HostName10=_acme-challenge.test&HostName11=orig.nameonly.test&HostName16=random.fqdntest&HostName17=random.fulltest&HostName14=orig.testfqdn&Address1=127.0.0.1&HostName18=random.test&HostName19=updated.test&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=updated&Address18=challengetoken&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.noop&Address10=challengetoken&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName22=_acme-challenge.deleterecordset&HostName21=updated.testfull&HostName20=updated.testfqdn&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.testfull&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&SLD=example-aptise-2&MXPref4=10&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524207&AssociatedAppTitle19=&HostId15=524209&HostId18=524202'
+    body: HostId1=746390&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746391&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746357&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746395&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746396&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746403&Address6=challengetoken2&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.deleterecordinset&RecordType6=TXT&HostId7=746392&Address7=challengetoken&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.fqdn&RecordType7=TXT&HostId8=746393&Address8=challengetoken&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.full&RecordType8=TXT&HostId9=746397&Address9=challengetoken&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.noop&RecordType9=TXT&HostId10=746394&Address10=challengetoken&MXPref10=10&TTL10=3600&AssociatedAppTitle10=&FriendlyName10=&IsActive10=true&IsDDNSEnabled10=false&HostName10=_acme-challenge.test&RecordType10=TXT&HostId11=746356&Address11=http%3A%2F%2Fwww.unittest-seconddomain.dev%2F&MXPref11=10&TTL11=1800&AssociatedAppTitle11=URL+Forwarding&FriendlyName11=URL+Record&IsActive11=true&IsDDNSEnabled11=false&HostName11=%40&RecordType11=URL&Address12=challengetoken1&TTL12=3600&HostName12=_acme-challenge.deleterecordset&RecordType12=TXT&SLD=unittest-seconddomain&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['3907']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2175'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.797</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest-seconddomain.dev\" IsSuccess=\"true\">\r\n      <Warnings
+        />\r\n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>1.053</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['561']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:45:10 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:03:37 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '569'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest-seconddomain&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
-        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
-        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
-        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
-        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
-        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
-        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
-        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524854\" Name=\"\
-        _acme-challenge.deleterecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
-        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.691</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest-seconddomain.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n
+        \     <host HostId=\"746390\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746391\" Name=\"docs\"
+        Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746357\" Name=\"www\" Type=\"CNAME\" Address=\"parkingpage.namecheap.com.\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"CNAME Record\"
+        IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746395\"
+        Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746396\" Name=\"_acme-challenge.createrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746403\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746404\" Name=\"_acme-challenge.deleterecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746392\" Name=\"_acme-challenge.fqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746393\" Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746397\" Name=\"_acme-challenge.noop\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746394\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746356\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest-seconddomain.dev/\" MXPref=\"10\" TTL=\"1800\"
+        AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n
+        \ <Server>PHX01SBAPIEXT02</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.578</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4777']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:45:11 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:03:38 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '2967'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'RecordType21=TXT&HostId19=524202&RecordType20=TXT&RecordType23=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524193&HostId9=524194&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524845&HostId5=524846&HostId6=524853&HostId7=524854&IsDDNSEnabled22=false&HostId22=524210&HostId21=524208&HostId20=524204&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524205&HostId13=524206&HostId10=524847&HostId11=524195&HostId16=524209&HostId17=524200&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&HostName12=orig.nameonly.test&HostName13=orig.nameonly.test&HostName10=_acme-challenge.noop&HostName11=_acme-challenge.test&HostName16=orig.testfull&HostName17=random.fqdntest&HostName14=orig.test&Address1=127.0.0.1&HostName18=random.fulltest&HostName19=random.test&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken1&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&Address13=updated&TTL21=1800&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&AssociatedAppTitle22=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.deleterecordset&HostName8=_acme-challenge.fqdn&HostName9=_acme-challenge.full&Address10=challengetoken&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName23=_acme-challenge.deleterecordset&HostName22=updated.testfull&HostName21=updated.testfqdn&HostName20=updated.test&TTL10=1800&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.testfqdn&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&SLD=example-aptise-2&MXPref4=10&Address23=challengetoken2&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524203&AssociatedAppTitle19=&HostId15=524207&HostId18=524201'
+    body: HostId1=746390&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746391&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746357&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746395&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746396&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746403&Address6=challengetoken2&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.deleterecordinset&RecordType6=TXT&HostId7=746404&Address7=challengetoken1&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.deleterecordset&RecordType7=TXT&HostId8=746392&Address8=challengetoken&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.fqdn&RecordType8=TXT&HostId9=746393&Address9=challengetoken&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.full&RecordType9=TXT&HostId10=746397&Address10=challengetoken&MXPref10=10&TTL10=3600&AssociatedAppTitle10=&FriendlyName10=&IsActive10=true&IsDDNSEnabled10=false&HostName10=_acme-challenge.noop&RecordType10=TXT&HostId11=746394&Address11=challengetoken&MXPref11=10&TTL11=3600&AssociatedAppTitle11=&FriendlyName11=&IsActive11=true&IsDDNSEnabled11=false&HostName11=_acme-challenge.test&RecordType11=TXT&HostId12=746356&Address12=http%3A%2F%2Fwww.unittest-seconddomain.dev%2F&MXPref12=10&TTL12=1800&AssociatedAppTitle12=URL+Forwarding&FriendlyName12=URL+Record&IsActive12=true&IsDDNSEnabled12=false&HostName12=%40&RecordType12=URL&Address13=challengetoken2&TTL13=3600&HostName13=_acme-challenge.deleterecordset&RecordType13=TXT&SLD=unittest-seconddomain&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['4108']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2376'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>1.077</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest-seconddomain.dev\" IsSuccess=\"true\">\r\n      <Warnings
+        />\r\n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.546</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['561']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:45:12 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:03:40 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '569'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest-seconddomain&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
-        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
-        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
-        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
-        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
-        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
-        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
-        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524854\" Name=\"\
-        _acme-challenge.deleterecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524855\" Name=\"\
-        _acme-challenge.deleterecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
-        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.866</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest-seconddomain.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n
+        \     <host HostId=\"746390\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746391\" Name=\"docs\"
+        Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746357\" Name=\"www\" Type=\"CNAME\" Address=\"parkingpage.namecheap.com.\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"CNAME Record\"
+        IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746395\"
+        Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746396\" Name=\"_acme-challenge.createrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746403\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746404\" Name=\"_acme-challenge.deleterecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746405\" Name=\"_acme-challenge.deleterecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746392\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746393\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746397\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746394\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746356\" Name=\"@\" Type=\"URL\" Address=\"http://www.unittest-seconddomain.dev/\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL
+        Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.162</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4984']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:45:14 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:03:41 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '3174'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest-seconddomain&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
-        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
-        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
-        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
-        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
-        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
-        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
-        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524854\" Name=\"\
-        _acme-challenge.deleterecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524855\" Name=\"\
-        _acme-challenge.deleterecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
-        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.622</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest-seconddomain.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n
+        \     <host HostId=\"746390\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746391\" Name=\"docs\"
+        Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746357\" Name=\"www\" Type=\"CNAME\" Address=\"parkingpage.namecheap.com.\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"CNAME Record\"
+        IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746395\"
+        Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746396\" Name=\"_acme-challenge.createrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746403\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746404\" Name=\"_acme-challenge.deleterecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746405\" Name=\"_acme-challenge.deleterecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746392\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746393\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746397\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746394\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746356\" Name=\"@\" Type=\"URL\" Address=\"http://www.unittest-seconddomain.dev/\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL
+        Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.629</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4984']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:45:15 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:03:42 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '3174'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'RecordType21=TXT&HostId19=524202&RecordType20=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524193&HostId9=524194&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524845&HostId5=524846&HostId6=524853&HostId7=524855&IsDDNSEnabled22=false&HostId22=524210&HostId21=524208&HostId20=524204&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524205&HostId13=524206&HostId10=524847&HostId11=524195&HostId16=524209&HostId17=524200&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&HostName12=orig.nameonly.test&HostName13=orig.nameonly.test&HostName10=_acme-challenge.noop&HostName11=_acme-challenge.test&HostName16=orig.testfull&HostName17=random.fqdntest&HostName14=orig.test&Address1=127.0.0.1&HostName18=random.fulltest&HostName19=random.test&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken2&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&Address13=updated&TTL21=1800&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&AssociatedAppTitle22=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.deleterecordset&HostName8=_acme-challenge.fqdn&HostName9=_acme-challenge.full&Address10=challengetoken&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName22=updated.testfull&HostName21=updated.testfqdn&HostName20=updated.test&TTL10=1800&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.testfqdn&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&SLD=example-aptise-2&MXPref4=10&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524203&AssociatedAppTitle19=&HostId15=524207&HostId18=524201'
+    body: HostId1=746390&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746391&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746357&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746395&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746396&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746403&Address6=challengetoken2&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.deleterecordinset&RecordType6=TXT&HostId7=746405&Address7=challengetoken2&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.deleterecordset&RecordType7=TXT&HostId8=746392&Address8=challengetoken&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.fqdn&RecordType8=TXT&HostId9=746393&Address9=challengetoken&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.full&RecordType9=TXT&HostId10=746397&Address10=challengetoken&MXPref10=10&TTL10=3600&AssociatedAppTitle10=&FriendlyName10=&IsActive10=true&IsDDNSEnabled10=false&HostName10=_acme-challenge.noop&RecordType10=TXT&HostId11=746394&Address11=challengetoken&MXPref11=10&TTL11=3600&AssociatedAppTitle11=&FriendlyName11=&IsActive11=true&IsDDNSEnabled11=false&HostName11=_acme-challenge.test&RecordType11=TXT&HostId12=746356&Address12=http%3A%2F%2Fwww.unittest-seconddomain.dev%2F&MXPref12=10&TTL12=1800&AssociatedAppTitle12=URL+Forwarding&FriendlyName12=URL+Record&IsActive12=true&IsDDNSEnabled12=false&HostName12=%40&RecordType12=URL&SLD=unittest-seconddomain&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['4022']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2279'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>1.029</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest-seconddomain.dev\" IsSuccess=\"true\">\r\n      <Warnings
+        />\r\n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.8</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['561']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:45:16 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:03:45 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '567'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest-seconddomain&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
-        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
-        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
-        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
-        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
-        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
-        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
-        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524855\" Name=\"\
-        _acme-challenge.deleterecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
-        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.865</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest-seconddomain.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n
+        \     <host HostId=\"746390\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746391\" Name=\"docs\"
+        Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746357\" Name=\"www\" Type=\"CNAME\" Address=\"parkingpage.namecheap.com.\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"CNAME Record\"
+        IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746395\"
+        Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746396\" Name=\"_acme-challenge.createrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746403\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746405\" Name=\"_acme-challenge.deleterecordset\" Type=\"TXT\" Address=\"challengetoken2\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746392\" Name=\"_acme-challenge.fqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746393\" Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746397\" Name=\"_acme-challenge.noop\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746394\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746356\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest-seconddomain.dev/\" MXPref=\"10\" TTL=\"1800\"
+        AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n
+        \ <Server>PHX01SBAPIEXT02</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.309</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4777']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:45:18 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:03:45 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '2967'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'RecordType21=TXT&HostId19=524204&RecordType20=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524194&HostId9=524847&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524845&HostId5=524846&HostId6=524853&HostId7=524193&HostId21=524210&HostId20=524208&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524206&HostId13=524203&HostId10=524195&HostId11=524205&HostId16=524200&HostId17=524201&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&HostName12=orig.nameonly.test&HostName13=orig.test&HostName10=_acme-challenge.test&HostName11=orig.nameonly.test&HostName16=random.fqdntest&HostName17=random.fulltest&HostName14=orig.testfqdn&Address1=127.0.0.1&HostName18=random.test&HostName19=updated.test&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=updated&Address18=challengetoken&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.noop&Address10=challengetoken&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName21=updated.testfull&HostName20=updated.testfqdn&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.testfull&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&SLD=example-aptise-2&MXPref4=10&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524207&AssociatedAppTitle19=&HostId15=524209&HostId18=524202'
+    body: HostId1=746390&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746391&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746357&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746395&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746396&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746403&Address6=challengetoken2&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.deleterecordinset&RecordType6=TXT&HostId7=746392&Address7=challengetoken&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.fqdn&RecordType7=TXT&HostId8=746393&Address8=challengetoken&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.full&RecordType8=TXT&HostId9=746397&Address9=challengetoken&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.noop&RecordType9=TXT&HostId10=746394&Address10=challengetoken&MXPref10=10&TTL10=3600&AssociatedAppTitle10=&FriendlyName10=&IsActive10=true&IsDDNSEnabled10=false&HostName10=_acme-challenge.test&RecordType10=TXT&HostId11=746356&Address11=http%3A%2F%2Fwww.unittest-seconddomain.dev%2F&MXPref11=10&TTL11=1800&AssociatedAppTitle11=URL+Forwarding&FriendlyName11=URL+Record&IsActive11=true&IsDDNSEnabled11=false&HostName11=%40&RecordType11=URL&SLD=unittest-seconddomain&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['3821']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2078'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.778</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest-seconddomain.dev\" IsSuccess=\"true\">\r\n      <Warnings
+        />\r\n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.524</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['561']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:45:19 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:03:46 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '569'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest-seconddomain&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
-        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
-        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
-        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
-        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
-        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
-        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
-        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
-        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.719</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest-seconddomain.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n
+        \     <host HostId=\"746390\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746391\" Name=\"docs\"
+        Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746357\" Name=\"www\" Type=\"CNAME\" Address=\"parkingpage.namecheap.com.\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"CNAME Record\"
+        IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746395\"
+        Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746396\" Name=\"_acme-challenge.createrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746403\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746392\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746393\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746397\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746394\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746356\" Name=\"@\" Type=\"URL\" Address=\"http://www.unittest-seconddomain.dev/\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL
+        Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.465</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4570']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:45:21 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:03:48 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '2760'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_provider_when_calling_list_records_should_handle_record_sets.yaml
+++ b/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_provider_when_calling_list_records_should_handle_record_sets.yaml
@@ -2,372 +2,384 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise-2.com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=unittest-seconddomain.dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
-        \ Status=\"Ok\" ID=\"277442\" DomainName=\"example-aptise-2.com\" OwnerName=\"\
-        jvsandbox2\" IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
-        \n        <CreatedDate>03/26/2018</CreatedDate>\r\n        <ExpiredDate>03/26/2019</ExpiredDate>\r\
-        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
-        \ />\r\n      <Whoisguard Enabled=\"True\">\r\n        <ID>233216</ID>\r\n\
-        \        <ExpiredDate>03/25/2019</ExpiredDate>\r\n        <EmailDetails WhoisGuardEmail=\"\
-        bdf487b65d844ddfafe33163f0e709f0.protect@whoisguard.com\" ForwardedTo=\"namecheap.sandbox.2@2xlp.com\"\
-        \ LastAutoEmailChangeDate=\"\" AutoEmailChangeFrequencyDays=\"0\" />\r\n \
-        \     </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
-        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
-        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
-        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
-        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"21\" EmailType=\"\
-        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
-        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
-        \n      <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\"\
-        >OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n        <Rights\
-        \ Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"nameserver\">OK</Rights>\r\
-        \n        <Rights Type=\"premiumDns\">OK</Rights>\r\n        <Rights Type=\"\
-        dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n    </DomainGetInfoResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.204</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult
+        Status=\"Ok\" ID=\"589668\" DomainName=\"unittest-seconddomain.dev\" OwnerName=\"phassberg2\"
+        IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\n        <CreatedDate>05/20/2020</CreatedDate>\r\n
+        \       <ExpiredDate>05/20/2021</ExpiredDate>\r\n        <NumYears>0</NumYears>\r\n
+        \     </DomainDetails>\r\n      <LockDetails />\r\n      <Whoisguard Enabled=\"True\">\r\n
+        \       <ID>481122</ID>\r\n        <ExpiredDate>05/20/2021</ExpiredDate>\r\n
+        \       <EmailDetails WhoisGuardEmail=\"af9bb0ea7b894617af45bb0fa4809b21.protect@whoisguard.com\"
+        ForwardedTo=\"drdoddo@gmail.com\" LastAutoEmailChangeDate=\"05/20/2020\" AutoEmailChangeFrequencyDays=\"3\"
+        />\r\n      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\n
+        \       <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\n
+        \       <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n        <IsActive>false</IsActive>\r\n
+        \     </PremiumDnsSubscription>\r\n      <DnsDetails ProviderType=\"FREE\"
+        IsUsingOurDNS=\"true\" HostCount=\"11\" EmailType=\"FWD\" DynamicDNSStatus=\"false\"
+        IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\n
+        \       <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\n
+        \     <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\">OK</Rights>\r\n
+        \       <Rights Type=\"eforward\">OK</Rights>\r\n        <Rights Type=\"rlock\">OK</Rights>\r\n
+        \       <Rights Type=\"parkpage\">OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n
+        \       <Rights Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"extend\">OK</Rights>\r\n
+        \       <Rights Type=\"nameserver\">OK</Rights>\r\n        <Rights Type=\"autorenew\">OK</Rights>\r\n
+        \       <Rights Type=\"whoisguard\">OK</Rights>\r\n        <Rights Type=\"premiumDns\">OK</Rights>\r\n
+        \       <Rights Type=\"dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n
+        \   </DomainGetInfoResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.039</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['2034']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:45:21 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:03:48 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '2309'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest-seconddomain&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
-        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
-        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
-        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
-        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
-        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
-        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
-        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
-        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.875</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest-seconddomain.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n
+        \     <host HostId=\"746390\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746391\" Name=\"docs\"
+        Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746357\" Name=\"www\" Type=\"CNAME\" Address=\"parkingpage.namecheap.com.\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"CNAME Record\"
+        IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746395\"
+        Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746396\" Name=\"_acme-challenge.createrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746403\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746392\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746393\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746397\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746394\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746356\" Name=\"@\" Type=\"URL\" Address=\"http://www.unittest-seconddomain.dev/\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL
+        Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.648</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4570']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:45:23 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:03:51 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '2760'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'RecordType21=TXT&HostId19=524204&RecordType20=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524194&HostId9=524847&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524845&HostId5=524846&HostId6=524853&HostId7=524193&HostId21=524210&HostId20=524208&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524206&HostId13=524203&HostId10=524195&HostId11=524205&HostId16=524200&HostId17=524201&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken1&HostName12=orig.nameonly.test&HostName13=orig.test&HostName10=_acme-challenge.test&HostName11=orig.nameonly.test&HostName16=random.fqdntest&HostName17=random.fulltest&HostName14=orig.testfqdn&Address1=127.0.0.1&HostName18=random.test&HostName19=updated.test&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=updated&Address18=challengetoken&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.noop&Address10=challengetoken&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName22=_acme-challenge.listrecordset&HostName21=updated.testfull&HostName20=updated.testfqdn&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.testfull&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&SLD=example-aptise-2&MXPref4=10&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524207&AssociatedAppTitle19=&HostId15=524209&HostId18=524202'
+    body: HostId1=746390&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746391&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746357&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746395&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746396&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746403&Address6=challengetoken2&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.deleterecordinset&RecordType6=TXT&HostId7=746392&Address7=challengetoken&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.fqdn&RecordType7=TXT&HostId8=746393&Address8=challengetoken&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.full&RecordType8=TXT&HostId9=746397&Address9=challengetoken&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.noop&RecordType9=TXT&HostId10=746394&Address10=challengetoken&MXPref10=10&TTL10=3600&AssociatedAppTitle10=&FriendlyName10=&IsActive10=true&IsDDNSEnabled10=false&HostName10=_acme-challenge.test&RecordType10=TXT&HostId11=746356&Address11=http%3A%2F%2Fwww.unittest-seconddomain.dev%2F&MXPref11=10&TTL11=1800&AssociatedAppTitle11=URL+Forwarding&FriendlyName11=URL+Record&IsActive11=true&IsDDNSEnabled11=false&HostName11=%40&RecordType11=URL&Address12=challengetoken1&TTL12=3600&HostName12=_acme-challenge.listrecordset&RecordType12=TXT&SLD=unittest-seconddomain&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['3905']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2173'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.932</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest-seconddomain.dev\" IsSuccess=\"true\">\r\n      <Warnings
+        />\r\n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.983</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['561']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:45:25 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:03:52 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '569'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest-seconddomain&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
-        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
-        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
-        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
-        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
-        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
-        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
-        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
-        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524856\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.662</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest-seconddomain.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n
+        \     <host HostId=\"746390\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746391\" Name=\"docs\"
+        Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746357\" Name=\"www\" Type=\"CNAME\" Address=\"parkingpage.namecheap.com.\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"CNAME Record\"
+        IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746395\"
+        Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746396\" Name=\"_acme-challenge.createrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746403\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746392\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746393\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746406\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746397\" Name=\"_acme-challenge.noop\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746394\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746356\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest-seconddomain.dev/\" MXPref=\"10\" TTL=\"1800\"
+        AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n
+        \ <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.157</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4775']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:45:26 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:03:54 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '2965'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'RecordType21=TXT&HostId19=524202&RecordType20=TXT&RecordType23=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524194&HostId9=524856&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524845&HostId5=524846&HostId6=524853&HostId7=524193&IsDDNSEnabled22=false&HostId22=524210&HostId21=524208&HostId20=524204&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524205&HostId13=524206&HostId10=524847&HostId11=524195&HostId16=524209&HostId17=524200&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken1&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&HostName12=orig.nameonly.test&HostName13=orig.nameonly.test&HostName10=_acme-challenge.noop&HostName11=_acme-challenge.test&HostName16=orig.testfull&HostName17=random.fqdntest&HostName14=orig.test&Address1=127.0.0.1&HostName18=random.fulltest&HostName19=random.test&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&Address13=updated&TTL21=1800&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&AssociatedAppTitle22=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.listrecordset&Address10=challengetoken&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName23=_acme-challenge.listrecordset&HostName22=updated.testfull&HostName21=updated.testfqdn&HostName20=updated.test&TTL10=1800&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.testfqdn&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&SLD=example-aptise-2&MXPref4=10&Address23=challengetoken2&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524203&AssociatedAppTitle19=&HostId15=524207&HostId18=524201'
+    body: HostId1=746390&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746391&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746357&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746395&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746396&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746403&Address6=challengetoken2&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.deleterecordinset&RecordType6=TXT&HostId7=746392&Address7=challengetoken&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.fqdn&RecordType7=TXT&HostId8=746393&Address8=challengetoken&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.full&RecordType8=TXT&HostId9=746406&Address9=challengetoken1&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.listrecordset&RecordType9=TXT&HostId10=746397&Address10=challengetoken&MXPref10=10&TTL10=3600&AssociatedAppTitle10=&FriendlyName10=&IsActive10=true&IsDDNSEnabled10=false&HostName10=_acme-challenge.noop&RecordType10=TXT&HostId11=746394&Address11=challengetoken&MXPref11=10&TTL11=3600&AssociatedAppTitle11=&FriendlyName11=&IsActive11=true&IsDDNSEnabled11=false&HostName11=_acme-challenge.test&RecordType11=TXT&HostId12=746356&Address12=http%3A%2F%2Fwww.unittest-seconddomain.dev%2F&MXPref12=10&TTL12=1800&AssociatedAppTitle12=URL+Forwarding&FriendlyName12=URL+Record&IsActive12=true&IsDDNSEnabled12=false&HostName12=%40&RecordType12=URL&Address13=challengetoken2&TTL13=3600&HostName13=_acme-challenge.listrecordset&RecordType13=TXT&SLD=unittest-seconddomain&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['4104']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2372'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.717</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest-seconddomain.dev\" IsSuccess=\"true\">\r\n      <Warnings
+        />\r\n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.565</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['561']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:45:27 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:03:55 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '569'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest-seconddomain&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
-        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
-        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
-        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
-        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
-        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
-        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
-        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
-        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524856\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524857\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.881</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest-seconddomain.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n
+        \     <host HostId=\"746390\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746391\" Name=\"docs\"
+        Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746357\" Name=\"www\" Type=\"CNAME\" Address=\"parkingpage.namecheap.com.\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"CNAME Record\"
+        IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746395\"
+        Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746396\" Name=\"_acme-challenge.createrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746403\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746392\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746393\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746406\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746407\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746397\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746394\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746356\" Name=\"@\" Type=\"URL\" Address=\"http://www.unittest-seconddomain.dev/\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL
+        Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.36</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4980']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:45:28 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:03:56 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '3169'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_provider_when_calling_list_records_with_fqdn_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_provider_when_calling_list_records_with_fqdn_name_filter_should_return_record.yaml
@@ -2,260 +2,270 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise-2.com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=unittest-seconddomain.dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
-        \ Status=\"Ok\" ID=\"277442\" DomainName=\"example-aptise-2.com\" OwnerName=\"\
-        jvsandbox2\" IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
-        \n        <CreatedDate>03/26/2018</CreatedDate>\r\n        <ExpiredDate>03/26/2019</ExpiredDate>\r\
-        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
-        \ />\r\n      <Whoisguard Enabled=\"True\">\r\n        <ID>233216</ID>\r\n\
-        \        <ExpiredDate>03/25/2019</ExpiredDate>\r\n        <EmailDetails WhoisGuardEmail=\"\
-        bdf487b65d844ddfafe33163f0e709f0.protect@whoisguard.com\" ForwardedTo=\"namecheap.sandbox.2@2xlp.com\"\
-        \ LastAutoEmailChangeDate=\"\" AutoEmailChangeFrequencyDays=\"0\" />\r\n \
-        \     </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
-        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
-        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
-        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
-        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"23\" EmailType=\"\
-        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
-        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
-        \n      <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\"\
-        >OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n        <Rights\
-        \ Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"nameserver\">OK</Rights>\r\
-        \n        <Rights Type=\"premiumDns\">OK</Rights>\r\n        <Rights Type=\"\
-        dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n    </DomainGetInfoResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.039</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult
+        Status=\"Ok\" ID=\"589668\" DomainName=\"unittest-seconddomain.dev\" OwnerName=\"phassberg2\"
+        IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\n        <CreatedDate>05/20/2020</CreatedDate>\r\n
+        \       <ExpiredDate>05/20/2021</ExpiredDate>\r\n        <NumYears>0</NumYears>\r\n
+        \     </DomainDetails>\r\n      <LockDetails />\r\n      <Whoisguard Enabled=\"True\">\r\n
+        \       <ID>481122</ID>\r\n        <ExpiredDate>05/20/2021</ExpiredDate>\r\n
+        \       <EmailDetails WhoisGuardEmail=\"af9bb0ea7b894617af45bb0fa4809b21.protect@whoisguard.com\"
+        ForwardedTo=\"drdoddo@gmail.com\" LastAutoEmailChangeDate=\"05/20/2020\" AutoEmailChangeFrequencyDays=\"3\"
+        />\r\n      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\n
+        \       <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\n
+        \       <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n        <IsActive>false</IsActive>\r\n
+        \     </PremiumDnsSubscription>\r\n      <DnsDetails ProviderType=\"FREE\"
+        IsUsingOurDNS=\"true\" HostCount=\"13\" EmailType=\"FWD\" DynamicDNSStatus=\"false\"
+        IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\n
+        \       <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\n
+        \     <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\">OK</Rights>\r\n
+        \       <Rights Type=\"eforward\">OK</Rights>\r\n        <Rights Type=\"rlock\">OK</Rights>\r\n
+        \       <Rights Type=\"parkpage\">OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n
+        \       <Rights Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"extend\">OK</Rights>\r\n
+        \       <Rights Type=\"nameserver\">OK</Rights>\r\n        <Rights Type=\"autorenew\">OK</Rights>\r\n
+        \       <Rights Type=\"whoisguard\">OK</Rights>\r\n        <Rights Type=\"premiumDns\">OK</Rights>\r\n
+        \       <Rights Type=\"dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n
+        \   </DomainGetInfoResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.019</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['2034']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:45:28 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:03:57 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '2309'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest-seconddomain&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
-        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
-        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
-        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
-        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
-        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
-        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
-        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
-        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524856\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524857\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.699</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest-seconddomain.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n
+        \     <host HostId=\"746390\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746391\" Name=\"docs\"
+        Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746357\" Name=\"www\" Type=\"CNAME\" Address=\"parkingpage.namecheap.com.\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"CNAME Record\"
+        IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746395\"
+        Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746396\" Name=\"_acme-challenge.createrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746403\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746392\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746393\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746406\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746407\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746397\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746394\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746356\" Name=\"@\" Type=\"URL\" Address=\"http://www.unittest-seconddomain.dev/\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL
+        Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.608</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4980']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:45:30 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:03:59 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '3170'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'RecordType21=TXT&HostId19=524201&RecordType20=TXT&RecordType23=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&IsDDNSEnabled23=false&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524194&HostId9=524856&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524845&HostId5=524846&HostId6=524853&HostId7=524193&IsDDNSEnabled22=false&MXPref23=10&HostId23=524210&HostId22=524208&HostId21=524204&HostId20=524202&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524195&HostId13=524205&HostId10=524857&HostId11=524847&HostId16=524207&HostId17=524209&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken1&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=&FriendlyName23=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&AssociatedAppTitle23=&HostName12=_acme-challenge.test&HostName13=orig.nameonly.test&HostName10=_acme-challenge.listrecordset&HostName11=_acme-challenge.noop&HostName16=orig.testfqdn&HostName17=orig.testfull&HostName14=orig.nameonly.test&Address1=127.0.0.1&HostName18=random.fqdntest&HostName19=random.fulltest&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&RecordType24=TXT&TTL23=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&HostName24=random.fqdntest&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&AssociatedAppTitle22=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.listrecordset&Address10=challengetoken2&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=updated&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName23=updated.testfull&HostName22=updated.testfqdn&HostName21=updated.test&HostName20=random.test&TTL10=1800&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&IsActive23=true&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&SLD=example-aptise-2&MXPref4=10&Address24=challengetoken&Address23=challengetoken&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524206&AssociatedAppTitle19=&HostId15=524203&HostId18=524200'
+    body: HostId1=746390&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746391&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746357&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746395&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746396&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746403&Address6=challengetoken2&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.deleterecordinset&RecordType6=TXT&HostId7=746392&Address7=challengetoken&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.fqdn&RecordType7=TXT&HostId8=746393&Address8=challengetoken&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.full&RecordType8=TXT&HostId9=746406&Address9=challengetoken1&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.listrecordset&RecordType9=TXT&HostId10=746407&Address10=challengetoken2&MXPref10=10&TTL10=3600&AssociatedAppTitle10=&FriendlyName10=&IsActive10=true&IsDDNSEnabled10=false&HostName10=_acme-challenge.listrecordset&RecordType10=TXT&HostId11=746397&Address11=challengetoken&MXPref11=10&TTL11=3600&AssociatedAppTitle11=&FriendlyName11=&IsActive11=true&IsDDNSEnabled11=false&HostName11=_acme-challenge.noop&RecordType11=TXT&HostId12=746394&Address12=challengetoken&MXPref12=10&TTL12=3600&AssociatedAppTitle12=&FriendlyName12=&IsActive12=true&IsDDNSEnabled12=false&HostName12=_acme-challenge.test&RecordType12=TXT&HostId13=746356&Address13=http%3A%2F%2Fwww.unittest-seconddomain.dev%2F&MXPref13=10&TTL13=1800&AssociatedAppTitle13=URL+Forwarding&FriendlyName13=URL+Record&IsActive13=true&IsDDNSEnabled13=false&HostName13=%40&RecordType13=URL&Address14=challengetoken&TTL14=3600&HostName14=random.fqdntest&RecordType14=TXT&SLD=unittest-seconddomain&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['4288']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2556'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.945</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest-seconddomain.dev\" IsSuccess=\"true\">\r\n      <Warnings
+        />\r\n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.641</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['561']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:45:32 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:04:00 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '569'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest-seconddomain&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
-        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
-        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
-        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
-        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
-        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
-        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
-        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
-        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524856\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524857\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.681</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest-seconddomain.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n
+        \     <host HostId=\"746390\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746391\" Name=\"docs\"
+        Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746357\" Name=\"www\" Type=\"CNAME\" Address=\"parkingpage.namecheap.com.\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"CNAME Record\"
+        IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746395\"
+        Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746396\" Name=\"_acme-challenge.createrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746403\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746392\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746393\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746406\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746407\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746397\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746394\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746408\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746356\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest-seconddomain.dev/\" MXPref=\"10\" TTL=\"1800\"
+        AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n
+        \ <Server>PHX01SBAPIEXT02</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.464</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4980']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:45:33 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:04:01 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '3360'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_provider_when_calling_list_records_with_full_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_provider_when_calling_list_records_with_full_name_filter_should_return_record.yaml
@@ -2,260 +2,275 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise-2.com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=unittest-seconddomain.dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
-        \ Status=\"Ok\" ID=\"277442\" DomainName=\"example-aptise-2.com\" OwnerName=\"\
-        jvsandbox2\" IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
-        \n        <CreatedDate>03/26/2018</CreatedDate>\r\n        <ExpiredDate>03/26/2019</ExpiredDate>\r\
-        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
-        \ />\r\n      <Whoisguard Enabled=\"True\">\r\n        <ID>233216</ID>\r\n\
-        \        <ExpiredDate>03/25/2019</ExpiredDate>\r\n        <EmailDetails WhoisGuardEmail=\"\
-        bdf487b65d844ddfafe33163f0e709f0.protect@whoisguard.com\" ForwardedTo=\"namecheap.sandbox.2@2xlp.com\"\
-        \ LastAutoEmailChangeDate=\"\" AutoEmailChangeFrequencyDays=\"0\" />\r\n \
-        \     </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
-        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
-        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
-        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
-        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"23\" EmailType=\"\
-        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
-        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
-        \n      <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\"\
-        >OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n        <Rights\
-        \ Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"nameserver\">OK</Rights>\r\
-        \n        <Rights Type=\"premiumDns\">OK</Rights>\r\n        <Rights Type=\"\
-        dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n    </DomainGetInfoResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.029</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult
+        Status=\"Ok\" ID=\"589668\" DomainName=\"unittest-seconddomain.dev\" OwnerName=\"phassberg2\"
+        IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\n        <CreatedDate>05/20/2020</CreatedDate>\r\n
+        \       <ExpiredDate>05/20/2021</ExpiredDate>\r\n        <NumYears>0</NumYears>\r\n
+        \     </DomainDetails>\r\n      <LockDetails />\r\n      <Whoisguard Enabled=\"True\">\r\n
+        \       <ID>481122</ID>\r\n        <ExpiredDate>05/20/2021</ExpiredDate>\r\n
+        \       <EmailDetails WhoisGuardEmail=\"af9bb0ea7b894617af45bb0fa4809b21.protect@whoisguard.com\"
+        ForwardedTo=\"drdoddo@gmail.com\" LastAutoEmailChangeDate=\"05/20/2020\" AutoEmailChangeFrequencyDays=\"3\"
+        />\r\n      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\n
+        \       <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\n
+        \       <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n        <IsActive>false</IsActive>\r\n
+        \     </PremiumDnsSubscription>\r\n      <DnsDetails ProviderType=\"FREE\"
+        IsUsingOurDNS=\"true\" HostCount=\"14\" EmailType=\"FWD\" DynamicDNSStatus=\"false\"
+        IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\n
+        \       <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\n
+        \     <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\">OK</Rights>\r\n
+        \       <Rights Type=\"eforward\">OK</Rights>\r\n        <Rights Type=\"rlock\">OK</Rights>\r\n
+        \       <Rights Type=\"parkpage\">OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n
+        \       <Rights Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"extend\">OK</Rights>\r\n
+        \       <Rights Type=\"nameserver\">OK</Rights>\r\n        <Rights Type=\"autorenew\">OK</Rights>\r\n
+        \       <Rights Type=\"whoisguard\">OK</Rights>\r\n        <Rights Type=\"premiumDns\">OK</Rights>\r\n
+        \       <Rights Type=\"dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n
+        \   </DomainGetInfoResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.021</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['2034']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:45:33 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:04:01 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '2309'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest-seconddomain&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
-        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
-        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
-        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
-        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
-        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
-        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
-        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
-        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524856\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524857\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.968</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest-seconddomain.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n
+        \     <host HostId=\"746390\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746391\" Name=\"docs\"
+        Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746357\" Name=\"www\" Type=\"CNAME\" Address=\"parkingpage.namecheap.com.\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"CNAME Record\"
+        IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746395\"
+        Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746396\" Name=\"_acme-challenge.createrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746403\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746392\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746393\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746406\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746407\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746397\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746394\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746408\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746356\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest-seconddomain.dev/\" MXPref=\"10\" TTL=\"1800\"
+        AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n
+        \ <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.315</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4980']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:45:35 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:04:04 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '3360'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'RecordType21=TXT&HostId19=524201&RecordType20=TXT&RecordType23=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&IsDDNSEnabled23=false&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524194&HostId9=524856&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524845&HostId5=524846&HostId6=524853&HostId7=524193&IsDDNSEnabled22=false&MXPref23=10&HostId23=524210&HostId22=524208&HostId21=524204&HostId20=524202&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524195&HostId13=524205&HostId10=524857&HostId11=524847&HostId16=524207&HostId17=524209&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken1&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=&FriendlyName23=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&AssociatedAppTitle23=&HostName12=_acme-challenge.test&HostName13=orig.nameonly.test&HostName10=_acme-challenge.listrecordset&HostName11=_acme-challenge.noop&HostName16=orig.testfqdn&HostName17=orig.testfull&HostName14=orig.nameonly.test&Address1=127.0.0.1&HostName18=random.fqdntest&HostName19=random.fulltest&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&RecordType24=TXT&TTL23=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&HostName24=random.fulltest&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&AssociatedAppTitle22=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.listrecordset&Address10=challengetoken2&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=updated&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName23=updated.testfull&HostName22=updated.testfqdn&HostName21=updated.test&HostName20=random.test&TTL10=1800&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&IsActive23=true&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&SLD=example-aptise-2&MXPref4=10&Address24=challengetoken&Address23=challengetoken&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524206&AssociatedAppTitle19=&HostId15=524203&HostId18=524200'
+    body: HostId1=746390&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746391&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746357&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746395&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746396&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746403&Address6=challengetoken2&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.deleterecordinset&RecordType6=TXT&HostId7=746392&Address7=challengetoken&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.fqdn&RecordType7=TXT&HostId8=746393&Address8=challengetoken&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.full&RecordType8=TXT&HostId9=746406&Address9=challengetoken1&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.listrecordset&RecordType9=TXT&HostId10=746407&Address10=challengetoken2&MXPref10=10&TTL10=3600&AssociatedAppTitle10=&FriendlyName10=&IsActive10=true&IsDDNSEnabled10=false&HostName10=_acme-challenge.listrecordset&RecordType10=TXT&HostId11=746397&Address11=challengetoken&MXPref11=10&TTL11=3600&AssociatedAppTitle11=&FriendlyName11=&IsActive11=true&IsDDNSEnabled11=false&HostName11=_acme-challenge.noop&RecordType11=TXT&HostId12=746394&Address12=challengetoken&MXPref12=10&TTL12=3600&AssociatedAppTitle12=&FriendlyName12=&IsActive12=true&IsDDNSEnabled12=false&HostName12=_acme-challenge.test&RecordType12=TXT&HostId13=746408&Address13=challengetoken&MXPref13=10&TTL13=3600&AssociatedAppTitle13=&FriendlyName13=&IsActive13=true&IsDDNSEnabled13=false&HostName13=random.fqdntest&RecordType13=TXT&HostId14=746356&Address14=http%3A%2F%2Fwww.unittest-seconddomain.dev%2F&MXPref14=10&TTL14=1800&AssociatedAppTitle14=URL+Forwarding&FriendlyName14=URL+Record&IsActive14=true&IsDDNSEnabled14=false&HostName14=%40&RecordType14=URL&Address15=challengetoken&TTL15=3600&HostName15=random.fulltest&RecordType15=TXT&SLD=unittest-seconddomain&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['4288']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2740'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.885</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest-seconddomain.dev\" IsSuccess=\"true\">\r\n      <Warnings
+        />\r\n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>1.102</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['561']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:45:37 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:04:05 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '569'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest-seconddomain&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
-        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
-        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
-        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
-        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
-        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
-        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
-        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
-        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524856\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524857\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.831</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest-seconddomain.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n
+        \     <host HostId=\"746390\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746391\" Name=\"docs\"
+        Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746357\" Name=\"www\" Type=\"CNAME\" Address=\"parkingpage.namecheap.com.\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"CNAME Record\"
+        IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746395\"
+        Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746396\" Name=\"_acme-challenge.createrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746403\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746392\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746393\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746406\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746407\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746397\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746394\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746408\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746409\" Name=\"random.fulltest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746356\" Name=\"@\" Type=\"URL\" Address=\"http://www.unittest-seconddomain.dev/\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL
+        Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.312</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4980']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:45:38 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:04:08 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '3550'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_provider_when_calling_list_records_with_invalid_filter_should_be_empty_list.yaml
+++ b/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_provider_when_calling_list_records_with_invalid_filter_should_be_empty_list.yaml
@@ -2,139 +2,148 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise-2.com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=unittest-seconddomain.dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
-        \ Status=\"Ok\" ID=\"277442\" DomainName=\"example-aptise-2.com\" OwnerName=\"\
-        jvsandbox2\" IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
-        \n        <CreatedDate>03/26/2018</CreatedDate>\r\n        <ExpiredDate>03/26/2019</ExpiredDate>\r\
-        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
-        \ />\r\n      <Whoisguard Enabled=\"True\">\r\n        <ID>233216</ID>\r\n\
-        \        <ExpiredDate>03/25/2019</ExpiredDate>\r\n        <EmailDetails WhoisGuardEmail=\"\
-        bdf487b65d844ddfafe33163f0e709f0.protect@whoisguard.com\" ForwardedTo=\"namecheap.sandbox.2@2xlp.com\"\
-        \ LastAutoEmailChangeDate=\"\" AutoEmailChangeFrequencyDays=\"0\" />\r\n \
-        \     </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
-        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
-        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
-        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
-        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"23\" EmailType=\"\
-        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
-        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
-        \n      <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\"\
-        >OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n        <Rights\
-        \ Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"nameserver\">OK</Rights>\r\
-        \n        <Rights Type=\"premiumDns\">OK</Rights>\r\n        <Rights Type=\"\
-        dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n    </DomainGetInfoResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.189</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult
+        Status=\"Ok\" ID=\"589668\" DomainName=\"unittest-seconddomain.dev\" OwnerName=\"phassberg2\"
+        IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\n        <CreatedDate>05/20/2020</CreatedDate>\r\n
+        \       <ExpiredDate>05/20/2021</ExpiredDate>\r\n        <NumYears>0</NumYears>\r\n
+        \     </DomainDetails>\r\n      <LockDetails />\r\n      <Whoisguard Enabled=\"True\">\r\n
+        \       <ID>481122</ID>\r\n        <ExpiredDate>05/20/2021</ExpiredDate>\r\n
+        \       <EmailDetails WhoisGuardEmail=\"af9bb0ea7b894617af45bb0fa4809b21.protect@whoisguard.com\"
+        ForwardedTo=\"drdoddo@gmail.com\" LastAutoEmailChangeDate=\"05/20/2020\" AutoEmailChangeFrequencyDays=\"3\"
+        />\r\n      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\n
+        \       <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\n
+        \       <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n        <IsActive>false</IsActive>\r\n
+        \     </PremiumDnsSubscription>\r\n      <DnsDetails ProviderType=\"FREE\"
+        IsUsingOurDNS=\"true\" HostCount=\"15\" EmailType=\"FWD\" DynamicDNSStatus=\"false\"
+        IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\n
+        \       <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\n
+        \     <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\">OK</Rights>\r\n
+        \       <Rights Type=\"eforward\">OK</Rights>\r\n        <Rights Type=\"rlock\">OK</Rights>\r\n
+        \       <Rights Type=\"parkpage\">OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n
+        \       <Rights Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"extend\">OK</Rights>\r\n
+        \       <Rights Type=\"nameserver\">OK</Rights>\r\n        <Rights Type=\"autorenew\">OK</Rights>\r\n
+        \       <Rights Type=\"whoisguard\">OK</Rights>\r\n        <Rights Type=\"premiumDns\">OK</Rights>\r\n
+        \       <Rights Type=\"dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n
+        \   </DomainGetInfoResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.022</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['2034']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:45:38 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:04:08 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '2309'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest-seconddomain&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
-        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
-        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
-        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
-        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
-        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
-        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
-        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
-        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524856\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524857\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.886</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest-seconddomain.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n
+        \     <host HostId=\"746390\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746391\" Name=\"docs\"
+        Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746357\" Name=\"www\" Type=\"CNAME\" Address=\"parkingpage.namecheap.com.\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"CNAME Record\"
+        IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746395\"
+        Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746396\" Name=\"_acme-challenge.createrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746403\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746392\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746393\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746406\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746407\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746397\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746394\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746408\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746409\" Name=\"random.fulltest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746356\" Name=\"@\" Type=\"URL\" Address=\"http://www.unittest-seconddomain.dev/\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL
+        Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.622</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4980']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:45:40 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:04:10 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '3550'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_provider_when_calling_list_records_with_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_provider_when_calling_list_records_with_name_filter_should_return_record.yaml
@@ -2,260 +2,280 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise-2.com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=unittest-seconddomain.dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
-        \ Status=\"Ok\" ID=\"277442\" DomainName=\"example-aptise-2.com\" OwnerName=\"\
-        jvsandbox2\" IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
-        \n        <CreatedDate>03/26/2018</CreatedDate>\r\n        <ExpiredDate>03/26/2019</ExpiredDate>\r\
-        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
-        \ />\r\n      <Whoisguard Enabled=\"True\">\r\n        <ID>233216</ID>\r\n\
-        \        <ExpiredDate>03/25/2019</ExpiredDate>\r\n        <EmailDetails WhoisGuardEmail=\"\
-        bdf487b65d844ddfafe33163f0e709f0.protect@whoisguard.com\" ForwardedTo=\"namecheap.sandbox.2@2xlp.com\"\
-        \ LastAutoEmailChangeDate=\"\" AutoEmailChangeFrequencyDays=\"0\" />\r\n \
-        \     </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
-        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
-        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
-        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
-        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"23\" EmailType=\"\
-        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
-        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
-        \n      <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\"\
-        >OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n        <Rights\
-        \ Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"nameserver\">OK</Rights>\r\
-        \n        <Rights Type=\"premiumDns\">OK</Rights>\r\n        <Rights Type=\"\
-        dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n    </DomainGetInfoResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.067</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult
+        Status=\"Ok\" ID=\"589668\" DomainName=\"unittest-seconddomain.dev\" OwnerName=\"phassberg2\"
+        IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\n        <CreatedDate>05/20/2020</CreatedDate>\r\n
+        \       <ExpiredDate>05/20/2021</ExpiredDate>\r\n        <NumYears>0</NumYears>\r\n
+        \     </DomainDetails>\r\n      <LockDetails />\r\n      <Whoisguard Enabled=\"True\">\r\n
+        \       <ID>481122</ID>\r\n        <ExpiredDate>05/20/2021</ExpiredDate>\r\n
+        \       <EmailDetails WhoisGuardEmail=\"af9bb0ea7b894617af45bb0fa4809b21.protect@whoisguard.com\"
+        ForwardedTo=\"drdoddo@gmail.com\" LastAutoEmailChangeDate=\"05/20/2020\" AutoEmailChangeFrequencyDays=\"3\"
+        />\r\n      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\n
+        \       <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\n
+        \       <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n        <IsActive>false</IsActive>\r\n
+        \     </PremiumDnsSubscription>\r\n      <DnsDetails ProviderType=\"FREE\"
+        IsUsingOurDNS=\"true\" HostCount=\"15\" EmailType=\"FWD\" DynamicDNSStatus=\"false\"
+        IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\n
+        \       <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\n
+        \     <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\">OK</Rights>\r\n
+        \       <Rights Type=\"eforward\">OK</Rights>\r\n        <Rights Type=\"rlock\">OK</Rights>\r\n
+        \       <Rights Type=\"parkpage\">OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n
+        \       <Rights Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"extend\">OK</Rights>\r\n
+        \       <Rights Type=\"nameserver\">OK</Rights>\r\n        <Rights Type=\"autorenew\">OK</Rights>\r\n
+        \       <Rights Type=\"whoisguard\">OK</Rights>\r\n        <Rights Type=\"premiumDns\">OK</Rights>\r\n
+        \       <Rights Type=\"dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n
+        \   </DomainGetInfoResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.023</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['2034']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:45:40 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:04:10 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '2309'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest-seconddomain&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
-        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
-        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
-        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
-        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
-        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
-        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
-        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
-        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524856\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524857\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.781</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest-seconddomain.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n
+        \     <host HostId=\"746390\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746391\" Name=\"docs\"
+        Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746357\" Name=\"www\" Type=\"CNAME\" Address=\"parkingpage.namecheap.com.\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"CNAME Record\"
+        IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746395\"
+        Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746396\" Name=\"_acme-challenge.createrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746403\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746392\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746393\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746406\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746407\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746397\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746394\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746408\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746409\" Name=\"random.fulltest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746356\" Name=\"@\" Type=\"URL\" Address=\"http://www.unittest-seconddomain.dev/\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL
+        Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.295</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4980']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:45:42 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:04:12 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '3550'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'RecordType21=TXT&HostId19=524201&RecordType20=TXT&RecordType23=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&IsDDNSEnabled23=false&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524194&HostId9=524856&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524845&HostId5=524846&HostId6=524853&HostId7=524193&IsDDNSEnabled22=false&MXPref23=10&HostId23=524210&HostId22=524208&HostId21=524204&HostId20=524202&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524195&HostId13=524205&HostId10=524857&HostId11=524847&HostId16=524207&HostId17=524209&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken1&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=&FriendlyName23=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&AssociatedAppTitle23=&HostName12=_acme-challenge.test&HostName13=orig.nameonly.test&HostName10=_acme-challenge.listrecordset&HostName11=_acme-challenge.noop&HostName16=orig.testfqdn&HostName17=orig.testfull&HostName14=orig.nameonly.test&Address1=127.0.0.1&HostName18=random.fqdntest&HostName19=random.fulltest&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&RecordType24=TXT&TTL23=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&HostName24=random.test&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&AssociatedAppTitle22=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.listrecordset&Address10=challengetoken2&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=updated&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName23=updated.testfull&HostName22=updated.testfqdn&HostName21=updated.test&HostName20=random.test&TTL10=1800&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&IsActive23=true&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&SLD=example-aptise-2&MXPref4=10&Address24=challengetoken&Address23=challengetoken&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524206&AssociatedAppTitle19=&HostId15=524203&HostId18=524200'
+    body: HostId1=746390&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746391&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746357&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746395&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746396&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746403&Address6=challengetoken2&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.deleterecordinset&RecordType6=TXT&HostId7=746392&Address7=challengetoken&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.fqdn&RecordType7=TXT&HostId8=746393&Address8=challengetoken&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.full&RecordType8=TXT&HostId9=746406&Address9=challengetoken1&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.listrecordset&RecordType9=TXT&HostId10=746407&Address10=challengetoken2&MXPref10=10&TTL10=3600&AssociatedAppTitle10=&FriendlyName10=&IsActive10=true&IsDDNSEnabled10=false&HostName10=_acme-challenge.listrecordset&RecordType10=TXT&HostId11=746397&Address11=challengetoken&MXPref11=10&TTL11=3600&AssociatedAppTitle11=&FriendlyName11=&IsActive11=true&IsDDNSEnabled11=false&HostName11=_acme-challenge.noop&RecordType11=TXT&HostId12=746394&Address12=challengetoken&MXPref12=10&TTL12=3600&AssociatedAppTitle12=&FriendlyName12=&IsActive12=true&IsDDNSEnabled12=false&HostName12=_acme-challenge.test&RecordType12=TXT&HostId13=746408&Address13=challengetoken&MXPref13=10&TTL13=3600&AssociatedAppTitle13=&FriendlyName13=&IsActive13=true&IsDDNSEnabled13=false&HostName13=random.fqdntest&RecordType13=TXT&HostId14=746409&Address14=challengetoken&MXPref14=10&TTL14=3600&AssociatedAppTitle14=&FriendlyName14=&IsActive14=true&IsDDNSEnabled14=false&HostName14=random.fulltest&RecordType14=TXT&HostId15=746356&Address15=http%3A%2F%2Fwww.unittest-seconddomain.dev%2F&MXPref15=10&TTL15=1800&AssociatedAppTitle15=URL+Forwarding&FriendlyName15=URL+Record&IsActive15=true&IsDDNSEnabled15=false&HostName15=%40&RecordType15=URL&Address16=challengetoken&TTL16=3600&HostName16=random.test&RecordType16=TXT&SLD=unittest-seconddomain&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['4284']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2920'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.863</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest-seconddomain.dev\" IsSuccess=\"true\">\r\n      <Warnings
+        />\r\n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.848</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['561']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:45:43 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:04:14 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '569'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest-seconddomain&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
-        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
-        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
-        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
-        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
-        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
-        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
-        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
-        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524856\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524857\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.96</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest-seconddomain.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n
+        \     <host HostId=\"746390\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746391\" Name=\"docs\"
+        Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746357\" Name=\"www\" Type=\"CNAME\" Address=\"parkingpage.namecheap.com.\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"CNAME Record\"
+        IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746395\"
+        Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746396\" Name=\"_acme-challenge.createrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746403\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746392\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746393\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746406\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746407\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746397\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746394\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746408\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746409\" Name=\"random.fulltest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746410\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746356\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest-seconddomain.dev/\" MXPref=\"10\" TTL=\"1800\"
+        AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n
+        \ <Server>PHX01SBAPIEXT02</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.165</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4979']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:45:45 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:04:15 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '3736'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_provider_when_calling_list_records_with_no_arguments_should_list_all.yaml
+++ b/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_provider_when_calling_list_records_with_no_arguments_should_list_all.yaml
@@ -2,139 +2,151 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise-2.com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=unittest-seconddomain.dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
-        \ Status=\"Ok\" ID=\"277442\" DomainName=\"example-aptise-2.com\" OwnerName=\"\
-        jvsandbox2\" IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
-        \n        <CreatedDate>03/26/2018</CreatedDate>\r\n        <ExpiredDate>03/26/2019</ExpiredDate>\r\
-        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
-        \ />\r\n      <Whoisguard Enabled=\"True\">\r\n        <ID>233216</ID>\r\n\
-        \        <ExpiredDate>03/25/2019</ExpiredDate>\r\n        <EmailDetails WhoisGuardEmail=\"\
-        bdf487b65d844ddfafe33163f0e709f0.protect@whoisguard.com\" ForwardedTo=\"namecheap.sandbox.2@2xlp.com\"\
-        \ LastAutoEmailChangeDate=\"\" AutoEmailChangeFrequencyDays=\"0\" />\r\n \
-        \     </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
-        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
-        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
-        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
-        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"23\" EmailType=\"\
-        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
-        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
-        \n      <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\"\
-        >OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n        <Rights\
-        \ Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"nameserver\">OK</Rights>\r\
-        \n        <Rights Type=\"premiumDns\">OK</Rights>\r\n        <Rights Type=\"\
-        dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n    </DomainGetInfoResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.047</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult
+        Status=\"Ok\" ID=\"589668\" DomainName=\"unittest-seconddomain.dev\" OwnerName=\"phassberg2\"
+        IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\n        <CreatedDate>05/20/2020</CreatedDate>\r\n
+        \       <ExpiredDate>05/20/2021</ExpiredDate>\r\n        <NumYears>0</NumYears>\r\n
+        \     </DomainDetails>\r\n      <LockDetails />\r\n      <Whoisguard Enabled=\"True\">\r\n
+        \       <ID>481122</ID>\r\n        <ExpiredDate>05/20/2021</ExpiredDate>\r\n
+        \       <EmailDetails WhoisGuardEmail=\"af9bb0ea7b894617af45bb0fa4809b21.protect@whoisguard.com\"
+        ForwardedTo=\"drdoddo@gmail.com\" LastAutoEmailChangeDate=\"05/20/2020\" AutoEmailChangeFrequencyDays=\"3\"
+        />\r\n      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\n
+        \       <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\n
+        \       <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n        <IsActive>false</IsActive>\r\n
+        \     </PremiumDnsSubscription>\r\n      <DnsDetails ProviderType=\"FREE\"
+        IsUsingOurDNS=\"true\" HostCount=\"16\" EmailType=\"FWD\" DynamicDNSStatus=\"false\"
+        IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\n
+        \       <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\n
+        \     <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\">OK</Rights>\r\n
+        \       <Rights Type=\"eforward\">OK</Rights>\r\n        <Rights Type=\"rlock\">OK</Rights>\r\n
+        \       <Rights Type=\"parkpage\">OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n
+        \       <Rights Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"extend\">OK</Rights>\r\n
+        \       <Rights Type=\"nameserver\">OK</Rights>\r\n        <Rights Type=\"autorenew\">OK</Rights>\r\n
+        \       <Rights Type=\"whoisguard\">OK</Rights>\r\n        <Rights Type=\"premiumDns\">OK</Rights>\r\n
+        \       <Rights Type=\"dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n
+        \   </DomainGetInfoResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.185</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['2034']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:45:45 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:04:16 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '2309'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest-seconddomain&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
-        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
-        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
-        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
-        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
-        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
-        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
-        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
-        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524856\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524857\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.752</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest-seconddomain.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n
+        \     <host HostId=\"746390\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746391\" Name=\"docs\"
+        Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746357\" Name=\"www\" Type=\"CNAME\" Address=\"parkingpage.namecheap.com.\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"CNAME Record\"
+        IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746395\"
+        Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746396\" Name=\"_acme-challenge.createrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746403\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746392\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746393\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746406\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746407\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746397\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746394\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746408\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746409\" Name=\"random.fulltest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746410\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746356\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest-seconddomain.dev/\" MXPref=\"10\" TTL=\"1800\"
+        AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n
+        \ <Server>PHX01SBAPIEXT02</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.714</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4980']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:45:47 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:04:17 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '3736'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_provider_when_calling_update_record_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_provider_when_calling_update_record_should_modify_record.yaml
@@ -2,472 +2,507 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise-2.com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=unittest-seconddomain.dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
-        \ Status=\"Ok\" ID=\"277442\" DomainName=\"example-aptise-2.com\" OwnerName=\"\
-        jvsandbox2\" IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
-        \n        <CreatedDate>03/26/2018</CreatedDate>\r\n        <ExpiredDate>03/26/2019</ExpiredDate>\r\
-        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
-        \ />\r\n      <Whoisguard Enabled=\"True\">\r\n        <ID>233216</ID>\r\n\
-        \        <ExpiredDate>03/25/2019</ExpiredDate>\r\n        <EmailDetails WhoisGuardEmail=\"\
-        bdf487b65d844ddfafe33163f0e709f0.protect@whoisguard.com\" ForwardedTo=\"namecheap.sandbox.2@2xlp.com\"\
-        \ LastAutoEmailChangeDate=\"\" AutoEmailChangeFrequencyDays=\"0\" />\r\n \
-        \     </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
-        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
-        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
-        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
-        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"23\" EmailType=\"\
-        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
-        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
-        \n      <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\"\
-        >OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n        <Rights\
-        \ Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"nameserver\">OK</Rights>\r\
-        \n        <Rights Type=\"premiumDns\">OK</Rights>\r\n        <Rights Type=\"\
-        dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n    </DomainGetInfoResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.238</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult
+        Status=\"Ok\" ID=\"589668\" DomainName=\"unittest-seconddomain.dev\" OwnerName=\"phassberg2\"
+        IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\n        <CreatedDate>05/20/2020</CreatedDate>\r\n
+        \       <ExpiredDate>05/20/2021</ExpiredDate>\r\n        <NumYears>0</NumYears>\r\n
+        \     </DomainDetails>\r\n      <LockDetails />\r\n      <Whoisguard Enabled=\"True\">\r\n
+        \       <ID>481122</ID>\r\n        <ExpiredDate>05/20/2021</ExpiredDate>\r\n
+        \       <EmailDetails WhoisGuardEmail=\"af9bb0ea7b894617af45bb0fa4809b21.protect@whoisguard.com\"
+        ForwardedTo=\"drdoddo@gmail.com\" LastAutoEmailChangeDate=\"05/20/2020\" AutoEmailChangeFrequencyDays=\"3\"
+        />\r\n      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\n
+        \       <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\n
+        \       <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n        <IsActive>false</IsActive>\r\n
+        \     </PremiumDnsSubscription>\r\n      <DnsDetails ProviderType=\"FREE\"
+        IsUsingOurDNS=\"true\" HostCount=\"16\" EmailType=\"FWD\" DynamicDNSStatus=\"false\"
+        IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\n
+        \       <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\n
+        \     <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\">OK</Rights>\r\n
+        \       <Rights Type=\"eforward\">OK</Rights>\r\n        <Rights Type=\"rlock\">OK</Rights>\r\n
+        \       <Rights Type=\"parkpage\">OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n
+        \       <Rights Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"extend\">OK</Rights>\r\n
+        \       <Rights Type=\"nameserver\">OK</Rights>\r\n        <Rights Type=\"autorenew\">OK</Rights>\r\n
+        \       <Rights Type=\"whoisguard\">OK</Rights>\r\n        <Rights Type=\"premiumDns\">OK</Rights>\r\n
+        \       <Rights Type=\"dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n
+        \   </DomainGetInfoResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.212</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['2034']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:45:47 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:04:19 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '2309'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest-seconddomain&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
-        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
-        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
-        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
-        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
-        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
-        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
-        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
-        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524856\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524857\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>1.004</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest-seconddomain.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n
+        \     <host HostId=\"746390\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746391\" Name=\"docs\"
+        Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746357\" Name=\"www\" Type=\"CNAME\" Address=\"parkingpage.namecheap.com.\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"CNAME Record\"
+        IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746395\"
+        Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746396\" Name=\"_acme-challenge.createrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746403\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746392\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746393\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746406\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746407\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746397\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746394\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746408\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746409\" Name=\"random.fulltest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746410\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746356\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest-seconddomain.dev/\" MXPref=\"10\" TTL=\"1800\"
+        AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n
+        \ <Server>PHX01SBAPIEXT02</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.635</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4980']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:45:49 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:04:20 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '3736'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'RecordType21=TXT&HostId19=524201&RecordType20=TXT&RecordType23=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&IsDDNSEnabled23=false&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524194&HostId9=524856&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524845&HostId5=524846&HostId6=524853&HostId7=524193&IsDDNSEnabled22=false&MXPref23=10&HostId23=524210&HostId22=524208&HostId21=524204&HostId20=524202&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524195&HostId13=524205&HostId10=524857&HostId11=524847&HostId16=524207&HostId17=524209&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken1&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=&FriendlyName23=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&AssociatedAppTitle23=&HostName12=_acme-challenge.test&HostName13=orig.nameonly.test&HostName10=_acme-challenge.listrecordset&HostName11=_acme-challenge.noop&HostName16=orig.testfqdn&HostName17=orig.testfull&HostName14=orig.nameonly.test&Address1=127.0.0.1&HostName18=random.fqdntest&HostName19=random.fulltest&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&RecordType24=TXT&TTL23=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&HostName24=orig.test&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&AssociatedAppTitle22=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.listrecordset&Address10=challengetoken2&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=updated&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName23=updated.testfull&HostName22=updated.testfqdn&HostName21=updated.test&HostName20=random.test&TTL10=1800&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&IsActive23=true&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&SLD=example-aptise-2&MXPref4=10&Address24=challengetoken&Address23=challengetoken&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524206&AssociatedAppTitle19=&HostId15=524203&HostId18=524200'
+    body: HostId1=746390&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746391&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746357&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746395&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746396&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746403&Address6=challengetoken2&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.deleterecordinset&RecordType6=TXT&HostId7=746392&Address7=challengetoken&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.fqdn&RecordType7=TXT&HostId8=746393&Address8=challengetoken&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.full&RecordType8=TXT&HostId9=746406&Address9=challengetoken1&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.listrecordset&RecordType9=TXT&HostId10=746407&Address10=challengetoken2&MXPref10=10&TTL10=3600&AssociatedAppTitle10=&FriendlyName10=&IsActive10=true&IsDDNSEnabled10=false&HostName10=_acme-challenge.listrecordset&RecordType10=TXT&HostId11=746397&Address11=challengetoken&MXPref11=10&TTL11=3600&AssociatedAppTitle11=&FriendlyName11=&IsActive11=true&IsDDNSEnabled11=false&HostName11=_acme-challenge.noop&RecordType11=TXT&HostId12=746394&Address12=challengetoken&MXPref12=10&TTL12=3600&AssociatedAppTitle12=&FriendlyName12=&IsActive12=true&IsDDNSEnabled12=false&HostName12=_acme-challenge.test&RecordType12=TXT&HostId13=746408&Address13=challengetoken&MXPref13=10&TTL13=3600&AssociatedAppTitle13=&FriendlyName13=&IsActive13=true&IsDDNSEnabled13=false&HostName13=random.fqdntest&RecordType13=TXT&HostId14=746409&Address14=challengetoken&MXPref14=10&TTL14=3600&AssociatedAppTitle14=&FriendlyName14=&IsActive14=true&IsDDNSEnabled14=false&HostName14=random.fulltest&RecordType14=TXT&HostId15=746410&Address15=challengetoken&MXPref15=10&TTL15=3600&AssociatedAppTitle15=&FriendlyName15=&IsActive15=true&IsDDNSEnabled15=false&HostName15=random.test&RecordType15=TXT&HostId16=746356&Address16=http%3A%2F%2Fwww.unittest-seconddomain.dev%2F&MXPref16=10&TTL16=1800&AssociatedAppTitle16=URL+Forwarding&FriendlyName16=URL+Record&IsActive16=true&IsDDNSEnabled16=false&HostName16=%40&RecordType16=URL&Address17=challengetoken&TTL17=3600&HostName17=orig.test&RecordType17=TXT&SLD=unittest-seconddomain&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['4282']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '3098'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>1.037</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest-seconddomain.dev\" IsSuccess=\"true\">\r\n      <Warnings
+        />\r\n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.448</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['561']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:45:50 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:04:21 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '569'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest-seconddomain&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
-        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
-        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
-        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
-        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
-        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
-        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
-        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
-        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524856\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524857\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.806</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest-seconddomain.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n
+        \     <host HostId=\"746390\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746391\" Name=\"docs\"
+        Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746357\" Name=\"www\" Type=\"CNAME\" Address=\"parkingpage.namecheap.com.\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"CNAME Record\"
+        IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746395\"
+        Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746396\" Name=\"_acme-challenge.createrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746403\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746392\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746393\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746406\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746407\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746397\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746394\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746411\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746408\" Name=\"random.fqdntest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746409\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746410\" Name=\"random.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746356\" Name=\"@\" Type=\"URL\" Address=\"http://www.unittest-seconddomain.dev/\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL
+        Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.399</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4980']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:45:51 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:04:22 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '3920'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest-seconddomain&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
-        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
-        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
-        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
-        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
-        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
-        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
-        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
-        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524856\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524857\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.782</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest-seconddomain.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n
+        \     <host HostId=\"746390\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746391\" Name=\"docs\"
+        Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746357\" Name=\"www\" Type=\"CNAME\" Address=\"parkingpage.namecheap.com.\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"CNAME Record\"
+        IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746395\"
+        Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746396\" Name=\"_acme-challenge.createrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746403\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746392\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746393\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746406\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746407\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746397\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746394\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746411\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746408\" Name=\"random.fqdntest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746409\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746410\" Name=\"random.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746356\" Name=\"@\" Type=\"URL\" Address=\"http://www.unittest-seconddomain.dev/\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL
+        Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.466</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4980']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:45:52 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:04:24 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '3920'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest-seconddomain&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
-        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
-        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
-        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
-        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
-        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
-        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
-        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
-        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524856\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524857\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>1.046</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest-seconddomain.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n
+        \     <host HostId=\"746390\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746391\" Name=\"docs\"
+        Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746357\" Name=\"www\" Type=\"CNAME\" Address=\"parkingpage.namecheap.com.\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"CNAME Record\"
+        IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746395\"
+        Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746396\" Name=\"_acme-challenge.createrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746403\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746392\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746393\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746406\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746407\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746397\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746394\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746411\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746408\" Name=\"random.fqdntest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746409\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746410\" Name=\"random.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746356\" Name=\"@\" Type=\"URL\" Address=\"http://www.unittest-seconddomain.dev/\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL
+        Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.345</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4980']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:45:54 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:04:25 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '3920'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'RecordType21=TXT&HostId19=524201&RecordType20=TXT&RecordType23=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&IsDDNSEnabled23=false&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524194&HostId9=524856&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524845&HostId5=524846&HostId6=524853&HostId7=524193&IsDDNSEnabled22=false&MXPref23=10&HostId23=524210&HostId22=524208&HostId21=524204&HostId20=524202&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524195&HostId13=524205&HostId10=524857&HostId11=524847&HostId16=524207&HostId17=524209&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken1&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=&FriendlyName23=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&AssociatedAppTitle23=&HostName12=_acme-challenge.test&HostName13=orig.nameonly.test&HostName10=_acme-challenge.listrecordset&HostName11=_acme-challenge.noop&HostName16=orig.testfqdn&HostName17=orig.testfull&HostName14=orig.nameonly.test&Address1=127.0.0.1&HostName18=random.fqdntest&HostName19=random.fulltest&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&RecordType24=TXT&TTL23=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&HostName24=updated.test&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&AssociatedAppTitle22=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.listrecordset&Address10=challengetoken2&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=updated&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName23=updated.testfull&HostName22=updated.testfqdn&HostName21=updated.test&HostName20=random.test&TTL10=1800&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&IsActive23=true&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&SLD=example-aptise-2&MXPref4=10&Address24=challengetoken&Address23=challengetoken&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524206&AssociatedAppTitle19=&HostId15=524203&HostId18=524200'
+    body: HostId1=746390&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746391&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746357&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746395&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746396&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746403&Address6=challengetoken2&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.deleterecordinset&RecordType6=TXT&HostId7=746392&Address7=challengetoken&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.fqdn&RecordType7=TXT&HostId8=746393&Address8=challengetoken&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.full&RecordType8=TXT&HostId9=746406&Address9=challengetoken1&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.listrecordset&RecordType9=TXT&HostId10=746407&Address10=challengetoken2&MXPref10=10&TTL10=3600&AssociatedAppTitle10=&FriendlyName10=&IsActive10=true&IsDDNSEnabled10=false&HostName10=_acme-challenge.listrecordset&RecordType10=TXT&HostId11=746397&Address11=challengetoken&MXPref11=10&TTL11=3600&AssociatedAppTitle11=&FriendlyName11=&IsActive11=true&IsDDNSEnabled11=false&HostName11=_acme-challenge.noop&RecordType11=TXT&HostId12=746394&Address12=challengetoken&MXPref12=10&TTL12=3600&AssociatedAppTitle12=&FriendlyName12=&IsActive12=true&IsDDNSEnabled12=false&HostName12=_acme-challenge.test&RecordType12=TXT&HostId13=746411&Address13=challengetoken&MXPref13=10&TTL13=3600&AssociatedAppTitle13=&FriendlyName13=&IsActive13=true&IsDDNSEnabled13=false&HostName13=orig.test&RecordType13=TXT&HostId14=746408&Address14=challengetoken&MXPref14=10&TTL14=3600&AssociatedAppTitle14=&FriendlyName14=&IsActive14=true&IsDDNSEnabled14=false&HostName14=random.fqdntest&RecordType14=TXT&HostId15=746409&Address15=challengetoken&MXPref15=10&TTL15=3600&AssociatedAppTitle15=&FriendlyName15=&IsActive15=true&IsDDNSEnabled15=false&HostName15=random.fulltest&RecordType15=TXT&HostId16=746410&Address16=challengetoken&MXPref16=10&TTL16=3600&AssociatedAppTitle16=&FriendlyName16=&IsActive16=true&IsDDNSEnabled16=false&HostName16=random.test&RecordType16=TXT&HostId17=746356&Address17=http%3A%2F%2Fwww.unittest-seconddomain.dev%2F&MXPref17=10&TTL17=1800&AssociatedAppTitle17=URL+Forwarding&FriendlyName17=URL+Record&IsActive17=true&IsDDNSEnabled17=false&HostName17=%40&RecordType17=URL&Address18=challengetoken&TTL18=3600&HostName18=updated.test&RecordType18=TXT&SLD=unittest-seconddomain&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['4285']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '3279'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>1.005</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest-seconddomain.dev\" IsSuccess=\"true\">\r\n      <Warnings
+        />\r\n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>1.101</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['561']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:45:55 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:04:27 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '569'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_provider_when_calling_update_record_should_modify_record_name_specified.yaml
+++ b/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_provider_when_calling_update_record_should_modify_record_name_specified.yaml
@@ -2,499 +2,434 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise-2.com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=unittest-seconddomain.dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
-        \ Status=\"Ok\" ID=\"277442\" DomainName=\"example-aptise-2.com\" OwnerName=\"\
-        jvsandbox2\" IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
-        \n        <CreatedDate>03/26/2018</CreatedDate>\r\n        <ExpiredDate>03/26/2019</ExpiredDate>\r\
-        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
-        \ />\r\n      <Whoisguard Enabled=\"True\">\r\n        <ID>233216</ID>\r\n\
-        \        <ExpiredDate>03/25/2019</ExpiredDate>\r\n        <EmailDetails WhoisGuardEmail=\"\
-        bdf487b65d844ddfafe33163f0e709f0.protect@whoisguard.com\" ForwardedTo=\"namecheap.sandbox.2@2xlp.com\"\
-        \ LastAutoEmailChangeDate=\"\" AutoEmailChangeFrequencyDays=\"0\" />\r\n \
-        \     </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
-        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
-        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
-        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
-        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"23\" EmailType=\"\
-        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
-        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
-        \n      <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\"\
-        >OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n        <Rights\
-        \ Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"nameserver\">OK</Rights>\r\
-        \n        <Rights Type=\"premiumDns\">OK</Rights>\r\n        <Rights Type=\"\
-        dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n    </DomainGetInfoResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.232</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult
+        Status=\"Ok\" ID=\"589668\" DomainName=\"unittest-seconddomain.dev\" OwnerName=\"phassberg2\"
+        IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\n        <CreatedDate>05/20/2020</CreatedDate>\r\n
+        \       <ExpiredDate>05/20/2021</ExpiredDate>\r\n        <NumYears>0</NumYears>\r\n
+        \     </DomainDetails>\r\n      <LockDetails />\r\n      <Whoisguard Enabled=\"True\">\r\n
+        \       <ID>481122</ID>\r\n        <ExpiredDate>05/20/2021</ExpiredDate>\r\n
+        \       <EmailDetails WhoisGuardEmail=\"af9bb0ea7b894617af45bb0fa4809b21.protect@whoisguard.com\"
+        ForwardedTo=\"drdoddo@gmail.com\" LastAutoEmailChangeDate=\"05/20/2020\" AutoEmailChangeFrequencyDays=\"3\"
+        />\r\n      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\n
+        \       <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\n
+        \       <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n        <IsActive>false</IsActive>\r\n
+        \     </PremiumDnsSubscription>\r\n      <DnsDetails ProviderType=\"FREE\"
+        IsUsingOurDNS=\"true\" HostCount=\"18\" EmailType=\"FWD\" DynamicDNSStatus=\"false\"
+        IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\n
+        \       <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\n
+        \     <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\">OK</Rights>\r\n
+        \       <Rights Type=\"eforward\">OK</Rights>\r\n        <Rights Type=\"rlock\">OK</Rights>\r\n
+        \       <Rights Type=\"parkpage\">OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n
+        \       <Rights Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"extend\">OK</Rights>\r\n
+        \       <Rights Type=\"nameserver\">OK</Rights>\r\n        <Rights Type=\"autorenew\">OK</Rights>\r\n
+        \       <Rights Type=\"whoisguard\">OK</Rights>\r\n        <Rights Type=\"premiumDns\">OK</Rights>\r\n
+        \       <Rights Type=\"dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n
+        \   </DomainGetInfoResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.022</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['2034']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:45:55 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:04:27 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '2309'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest-seconddomain&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
-        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
-        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
-        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
-        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
-        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
-        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
-        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
-        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524856\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524857\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>1.043</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest-seconddomain.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n
+        \     <host HostId=\"746390\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746391\" Name=\"docs\"
+        Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746357\" Name=\"www\" Type=\"CNAME\" Address=\"parkingpage.namecheap.com.\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"CNAME Record\"
+        IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746395\"
+        Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746396\" Name=\"_acme-challenge.createrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746403\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746392\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746393\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746406\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746407\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746397\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746394\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746411\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746408\" Name=\"random.fqdntest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746409\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746410\" Name=\"random.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746412\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746356\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest-seconddomain.dev/\" MXPref=\"10\" TTL=\"1800\"
+        AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n
+        \ <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.683</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4980']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:45:58 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:04:30 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '4107'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'RecordType21=TXT&HostId19=524201&RecordType20=TXT&RecordType23=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&IsDDNSEnabled23=false&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524194&HostId9=524856&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524845&HostId5=524846&HostId6=524853&HostId7=524193&IsDDNSEnabled22=false&MXPref23=10&HostId23=524210&HostId22=524208&HostId21=524204&HostId20=524202&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524195&HostId13=524205&HostId10=524857&HostId11=524847&HostId16=524207&HostId17=524209&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken1&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=&FriendlyName23=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&AssociatedAppTitle23=&HostName12=_acme-challenge.test&HostName13=orig.nameonly.test&HostName10=_acme-challenge.listrecordset&HostName11=_acme-challenge.noop&HostName16=orig.testfqdn&HostName17=orig.testfull&HostName14=orig.nameonly.test&Address1=127.0.0.1&HostName18=random.fqdntest&HostName19=random.fulltest&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&RecordType24=TXT&TTL23=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&HostName24=orig.nameonly.test&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&AssociatedAppTitle22=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.listrecordset&Address10=challengetoken2&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=updated&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName23=updated.testfull&HostName22=updated.testfqdn&HostName21=updated.test&HostName20=random.test&TTL10=1800&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&IsActive23=true&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&SLD=example-aptise-2&MXPref4=10&Address24=challengetoken&Address23=challengetoken&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524206&AssociatedAppTitle19=&HostId15=524203&HostId18=524200'
+    body: HostId1=746390&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746391&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746357&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746395&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746396&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746403&Address6=challengetoken2&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.deleterecordinset&RecordType6=TXT&HostId7=746392&Address7=challengetoken&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.fqdn&RecordType7=TXT&HostId8=746393&Address8=challengetoken&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.full&RecordType8=TXT&HostId9=746406&Address9=challengetoken1&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.listrecordset&RecordType9=TXT&HostId10=746407&Address10=challengetoken2&MXPref10=10&TTL10=3600&AssociatedAppTitle10=&FriendlyName10=&IsActive10=true&IsDDNSEnabled10=false&HostName10=_acme-challenge.listrecordset&RecordType10=TXT&HostId11=746397&Address11=challengetoken&MXPref11=10&TTL11=3600&AssociatedAppTitle11=&FriendlyName11=&IsActive11=true&IsDDNSEnabled11=false&HostName11=_acme-challenge.noop&RecordType11=TXT&HostId12=746394&Address12=challengetoken&MXPref12=10&TTL12=3600&AssociatedAppTitle12=&FriendlyName12=&IsActive12=true&IsDDNSEnabled12=false&HostName12=_acme-challenge.test&RecordType12=TXT&HostId13=746411&Address13=challengetoken&MXPref13=10&TTL13=3600&AssociatedAppTitle13=&FriendlyName13=&IsActive13=true&IsDDNSEnabled13=false&HostName13=orig.test&RecordType13=TXT&HostId14=746408&Address14=challengetoken&MXPref14=10&TTL14=3600&AssociatedAppTitle14=&FriendlyName14=&IsActive14=true&IsDDNSEnabled14=false&HostName14=random.fqdntest&RecordType14=TXT&HostId15=746409&Address15=challengetoken&MXPref15=10&TTL15=3600&AssociatedAppTitle15=&FriendlyName15=&IsActive15=true&IsDDNSEnabled15=false&HostName15=random.fulltest&RecordType15=TXT&HostId16=746410&Address16=challengetoken&MXPref16=10&TTL16=3600&AssociatedAppTitle16=&FriendlyName16=&IsActive16=true&IsDDNSEnabled16=false&HostName16=random.test&RecordType16=TXT&HostId17=746412&Address17=challengetoken&MXPref17=10&TTL17=3600&AssociatedAppTitle17=&FriendlyName17=&IsActive17=true&IsDDNSEnabled17=false&HostName17=updated.test&RecordType17=TXT&HostId18=746356&Address18=http%3A%2F%2Fwww.unittest-seconddomain.dev%2F&MXPref18=10&TTL18=1800&AssociatedAppTitle18=URL+Forwarding&FriendlyName18=URL+Record&IsActive18=true&IsDDNSEnabled18=false&HostName18=%40&RecordType18=URL&Address19=challengetoken&TTL19=3600&HostName19=orig.nameonly.test&RecordType19=TXT&SLD=unittest-seconddomain&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['4291']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '3466'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.726</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest-seconddomain.dev\" IsSuccess=\"true\">\r\n      <Warnings
+        />\r\n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.46</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['561']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:45:59 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:04:31 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '568'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest-seconddomain&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
-        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
-        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
-        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
-        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
-        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
-        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
-        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
-        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524856\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524857\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.818</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest-seconddomain.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n
+        \     <host HostId=\"746390\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746391\" Name=\"docs\"
+        Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746357\" Name=\"www\" Type=\"CNAME\" Address=\"parkingpage.namecheap.com.\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"CNAME Record\"
+        IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746395\"
+        Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746396\" Name=\"_acme-challenge.createrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746403\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746392\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746393\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746406\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746407\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746397\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746394\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746413\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746411\" Name=\"orig.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746408\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746409\" Name=\"random.fulltest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746410\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746412\" Name=\"updated.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746356\" Name=\"@\" Type=\"URL\" Address=\"http://www.unittest-seconddomain.dev/\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL
+        Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.383</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4980']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:46:00 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:04:32 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '4300'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest-seconddomain&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
-        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
-        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
-        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
-        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
-        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
-        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
-        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
-        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524856\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524857\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.669</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest-seconddomain.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n
+        \     <host HostId=\"746390\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746391\" Name=\"docs\"
+        Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746357\" Name=\"www\" Type=\"CNAME\" Address=\"parkingpage.namecheap.com.\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"CNAME Record\"
+        IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746395\"
+        Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746396\" Name=\"_acme-challenge.createrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746403\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746392\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746393\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746406\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746407\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746397\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746394\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746413\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746411\" Name=\"orig.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746408\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746409\" Name=\"random.fulltest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746410\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746412\" Name=\"updated.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746356\" Name=\"@\" Type=\"URL\" Address=\"http://www.unittest-seconddomain.dev/\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL
+        Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.412</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4980']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:46:02 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:04:34 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '4300'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'RecordType21=TXT&HostId19=524202&RecordType20=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524194&HostId9=524856&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524845&HostId5=524846&HostId6=524853&HostId7=524193&IsDDNSEnabled22=false&HostId22=524210&HostId21=524208&HostId20=524204&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524195&HostId13=524205&HostId10=524857&HostId11=524847&HostId16=524209&HostId17=524200&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken1&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&HostName12=_acme-challenge.test&HostName13=orig.nameonly.test&HostName10=_acme-challenge.listrecordset&HostName11=_acme-challenge.noop&HostName16=orig.testfull&HostName17=random.fqdntest&HostName14=orig.test&Address1=127.0.0.1&HostName18=random.fulltest&HostName19=random.test&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&AssociatedAppTitle22=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.listrecordset&Address10=challengetoken2&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName22=updated.testfull&HostName21=updated.testfqdn&HostName20=updated.test&TTL10=1800&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.testfqdn&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&SLD=example-aptise-2&MXPref4=10&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524203&AssociatedAppTitle19=&HostId15=524207&HostId18=524201'
+    body: HostId1=746390&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746391&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746357&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746395&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746396&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746403&Address6=challengetoken2&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.deleterecordinset&RecordType6=TXT&HostId7=746392&Address7=challengetoken&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.fqdn&RecordType7=TXT&HostId8=746393&Address8=challengetoken&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.full&RecordType8=TXT&HostId9=746406&Address9=challengetoken1&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.listrecordset&RecordType9=TXT&HostId10=746407&Address10=challengetoken2&MXPref10=10&TTL10=3600&AssociatedAppTitle10=&FriendlyName10=&IsActive10=true&IsDDNSEnabled10=false&HostName10=_acme-challenge.listrecordset&RecordType10=TXT&HostId11=746397&Address11=challengetoken&MXPref11=10&TTL11=3600&AssociatedAppTitle11=&FriendlyName11=&IsActive11=true&IsDDNSEnabled11=false&HostName11=_acme-challenge.noop&RecordType11=TXT&HostId12=746394&Address12=challengetoken&MXPref12=10&TTL12=3600&AssociatedAppTitle12=&FriendlyName12=&IsActive12=true&IsDDNSEnabled12=false&HostName12=_acme-challenge.test&RecordType12=TXT&HostId13=746413&Address13=challengetoken&MXPref13=10&TTL13=3600&AssociatedAppTitle13=&FriendlyName13=&IsActive13=true&IsDDNSEnabled13=false&HostName13=orig.nameonly.test&RecordType13=TXT&HostId14=746411&Address14=challengetoken&MXPref14=10&TTL14=3600&AssociatedAppTitle14=&FriendlyName14=&IsActive14=true&IsDDNSEnabled14=false&HostName14=orig.test&RecordType14=TXT&HostId15=746408&Address15=challengetoken&MXPref15=10&TTL15=3600&AssociatedAppTitle15=&FriendlyName15=&IsActive15=true&IsDDNSEnabled15=false&HostName15=random.fqdntest&RecordType15=TXT&HostId16=746409&Address16=challengetoken&MXPref16=10&TTL16=3600&AssociatedAppTitle16=&FriendlyName16=&IsActive16=true&IsDDNSEnabled16=false&HostName16=random.fulltest&RecordType16=TXT&HostId17=746410&Address17=challengetoken&MXPref17=10&TTL17=3600&AssociatedAppTitle17=&FriendlyName17=&IsActive17=true&IsDDNSEnabled17=false&HostName17=random.test&RecordType17=TXT&HostId18=746412&Address18=challengetoken&MXPref18=10&TTL18=3600&AssociatedAppTitle18=&FriendlyName18=&IsActive18=true&IsDDNSEnabled18=false&HostName18=updated.test&RecordType18=TXT&HostId19=746356&Address19=http%3A%2F%2Fwww.unittest-seconddomain.dev%2F&MXPref19=10&TTL19=1800&AssociatedAppTitle19=URL+Forwarding&FriendlyName19=URL+Record&IsActive19=true&IsDDNSEnabled19=false&HostName19=%40&RecordType19=URL&Address20=updated&TTL20=3600&HostName20=orig.nameonly.test&RecordType20=TXT&SLD=unittest-seconddomain&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['4039']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '3646'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.934</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest-seconddomain.dev\" IsSuccess=\"true\">\r\n      <Warnings
+        />\r\n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>1.03</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['561']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:46:03 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
-    method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
-  response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
-        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
-        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
-        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
-        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
-        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
-        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
-        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
-        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524856\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524857\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524203\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"\
-        orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524200\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\"\
-        \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524202\" Name=\"random.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524204\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524208\" Name=\"\
-        updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.741</ExecutionTime>\r\n</ApiResponse>"}
-    headers:
-      cache-control: [private]
-      content-length: ['4794']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:46:04 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: !!python/unicode 'RecordType21=TXT&HostId19=524202&RecordType20=TXT&RecordType23=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524194&HostId9=524856&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524845&HostId5=524846&HostId6=524853&HostId7=524193&IsDDNSEnabled22=false&HostId22=524210&HostId21=524208&HostId20=524204&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524195&HostId13=524205&HostId10=524857&HostId11=524847&HostId16=524209&HostId17=524200&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken1&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&HostName12=_acme-challenge.test&HostName13=orig.nameonly.test&HostName10=_acme-challenge.listrecordset&HostName11=_acme-challenge.noop&HostName16=orig.testfull&HostName17=random.fqdntest&HostName14=orig.test&Address1=127.0.0.1&HostName18=random.fulltest&HostName19=random.test&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&AssociatedAppTitle22=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.listrecordset&Address10=challengetoken2&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName23=orig.nameonly.test&HostName22=updated.testfull&HostName21=updated.testfqdn&HostName20=updated.test&TTL10=1800&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.testfqdn&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&SLD=example-aptise-2&MXPref4=10&Address23=updated&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524203&AssociatedAppTitle19=&HostId15=524207&HostId18=524201'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['4104']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
-    method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
-  response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.849</ExecutionTime>\r\
-        \n</ApiResponse>"}
-    headers:
-      cache-control: [private]
-      content-length: ['561']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:46:06 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:04:35 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '568'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_provider_when_calling_update_record_with_fqdn_name_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_provider_when_calling_update_record_with_fqdn_name_should_modify_record.yaml
@@ -2,472 +2,547 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise-2.com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=unittest-seconddomain.dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
-        \ Status=\"Ok\" ID=\"277442\" DomainName=\"example-aptise-2.com\" OwnerName=\"\
-        jvsandbox2\" IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
-        \n        <CreatedDate>03/26/2018</CreatedDate>\r\n        <ExpiredDate>03/26/2019</ExpiredDate>\r\
-        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
-        \ />\r\n      <Whoisguard Enabled=\"True\">\r\n        <ID>233216</ID>\r\n\
-        \        <ExpiredDate>03/25/2019</ExpiredDate>\r\n        <EmailDetails WhoisGuardEmail=\"\
-        bdf487b65d844ddfafe33163f0e709f0.protect@whoisguard.com\" ForwardedTo=\"namecheap.sandbox.2@2xlp.com\"\
-        \ LastAutoEmailChangeDate=\"\" AutoEmailChangeFrequencyDays=\"0\" />\r\n \
-        \     </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
-        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
-        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
-        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
-        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"23\" EmailType=\"\
-        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
-        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
-        \n      <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\"\
-        >OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n        <Rights\
-        \ Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"nameserver\">OK</Rights>\r\
-        \n        <Rights Type=\"premiumDns\">OK</Rights>\r\n        <Rights Type=\"\
-        dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n    </DomainGetInfoResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.039</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult
+        Status=\"Ok\" ID=\"589668\" DomainName=\"unittest-seconddomain.dev\" OwnerName=\"phassberg2\"
+        IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\n        <CreatedDate>05/20/2020</CreatedDate>\r\n
+        \       <ExpiredDate>05/20/2021</ExpiredDate>\r\n        <NumYears>0</NumYears>\r\n
+        \     </DomainDetails>\r\n      <LockDetails />\r\n      <Whoisguard Enabled=\"True\">\r\n
+        \       <ID>481122</ID>\r\n        <ExpiredDate>05/20/2021</ExpiredDate>\r\n
+        \       <EmailDetails WhoisGuardEmail=\"af9bb0ea7b894617af45bb0fa4809b21.protect@whoisguard.com\"
+        ForwardedTo=\"drdoddo@gmail.com\" LastAutoEmailChangeDate=\"05/20/2020\" AutoEmailChangeFrequencyDays=\"3\"
+        />\r\n      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\n
+        \       <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\n
+        \       <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n        <IsActive>false</IsActive>\r\n
+        \     </PremiumDnsSubscription>\r\n      <DnsDetails ProviderType=\"FREE\"
+        IsUsingOurDNS=\"true\" HostCount=\"20\" EmailType=\"FWD\" DynamicDNSStatus=\"false\"
+        IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\n
+        \       <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\n
+        \     <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\">OK</Rights>\r\n
+        \       <Rights Type=\"eforward\">OK</Rights>\r\n        <Rights Type=\"rlock\">OK</Rights>\r\n
+        \       <Rights Type=\"parkpage\">OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n
+        \       <Rights Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"extend\">OK</Rights>\r\n
+        \       <Rights Type=\"nameserver\">OK</Rights>\r\n        <Rights Type=\"autorenew\">OK</Rights>\r\n
+        \       <Rights Type=\"whoisguard\">OK</Rights>\r\n        <Rights Type=\"premiumDns\">OK</Rights>\r\n
+        \       <Rights Type=\"dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n
+        \   </DomainGetInfoResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.201</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['2034']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:46:07 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:04:36 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '2309'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest-seconddomain&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
-        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
-        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
-        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
-        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
-        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
-        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
-        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
-        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524856\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524857\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524858\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.689</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest-seconddomain.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n
+        \     <host HostId=\"746390\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746391\" Name=\"docs\"
+        Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746357\" Name=\"www\" Type=\"CNAME\" Address=\"parkingpage.namecheap.com.\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"CNAME Record\"
+        IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746395\"
+        Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746396\" Name=\"_acme-challenge.createrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746403\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746392\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746393\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746406\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746407\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746397\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746394\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746413\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746414\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746411\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746408\" Name=\"random.fqdntest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746409\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746410\" Name=\"random.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746412\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746356\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest-seconddomain.dev/\" MXPref=\"10\" TTL=\"1800\"
+        AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n
+        \ <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.153</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4980']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:46:08 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:04:37 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '4486'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'RecordType21=TXT&HostId19=524201&RecordType20=TXT&RecordType23=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&IsDDNSEnabled23=false&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524194&HostId9=524856&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524845&HostId5=524846&HostId6=524853&HostId7=524193&IsDDNSEnabled22=false&MXPref23=10&HostId23=524210&HostId22=524208&HostId21=524204&HostId20=524202&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524195&HostId13=524205&HostId10=524857&HostId11=524847&HostId16=524207&HostId17=524209&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken1&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=&FriendlyName23=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&AssociatedAppTitle23=&HostName12=_acme-challenge.test&HostName13=orig.nameonly.test&HostName10=_acme-challenge.listrecordset&HostName11=_acme-challenge.noop&HostName16=orig.testfqdn&HostName17=orig.testfull&HostName14=orig.nameonly.test&Address1=127.0.0.1&HostName18=random.fqdntest&HostName19=random.fulltest&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&RecordType24=TXT&TTL23=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&HostName24=orig.testfqdn&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&AssociatedAppTitle22=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.listrecordset&Address10=challengetoken2&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=updated&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName23=updated.testfull&HostName22=updated.testfqdn&HostName21=updated.test&HostName20=random.test&TTL10=1800&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&IsActive23=true&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&SLD=example-aptise-2&MXPref4=10&Address24=challengetoken&Address23=challengetoken&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524858&AssociatedAppTitle19=&HostId15=524203&HostId18=524200'
+    body: HostId1=746390&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746391&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746357&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746395&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746396&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746403&Address6=challengetoken2&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.deleterecordinset&RecordType6=TXT&HostId7=746392&Address7=challengetoken&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.fqdn&RecordType7=TXT&HostId8=746393&Address8=challengetoken&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.full&RecordType8=TXT&HostId9=746406&Address9=challengetoken1&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.listrecordset&RecordType9=TXT&HostId10=746407&Address10=challengetoken2&MXPref10=10&TTL10=3600&AssociatedAppTitle10=&FriendlyName10=&IsActive10=true&IsDDNSEnabled10=false&HostName10=_acme-challenge.listrecordset&RecordType10=TXT&HostId11=746397&Address11=challengetoken&MXPref11=10&TTL11=3600&AssociatedAppTitle11=&FriendlyName11=&IsActive11=true&IsDDNSEnabled11=false&HostName11=_acme-challenge.noop&RecordType11=TXT&HostId12=746394&Address12=challengetoken&MXPref12=10&TTL12=3600&AssociatedAppTitle12=&FriendlyName12=&IsActive12=true&IsDDNSEnabled12=false&HostName12=_acme-challenge.test&RecordType12=TXT&HostId13=746413&Address13=challengetoken&MXPref13=10&TTL13=3600&AssociatedAppTitle13=&FriendlyName13=&IsActive13=true&IsDDNSEnabled13=false&HostName13=orig.nameonly.test&RecordType13=TXT&HostId14=746414&Address14=updated&MXPref14=10&TTL14=3600&AssociatedAppTitle14=&FriendlyName14=&IsActive14=true&IsDDNSEnabled14=false&HostName14=orig.nameonly.test&RecordType14=TXT&HostId15=746411&Address15=challengetoken&MXPref15=10&TTL15=3600&AssociatedAppTitle15=&FriendlyName15=&IsActive15=true&IsDDNSEnabled15=false&HostName15=orig.test&RecordType15=TXT&HostId16=746408&Address16=challengetoken&MXPref16=10&TTL16=3600&AssociatedAppTitle16=&FriendlyName16=&IsActive16=true&IsDDNSEnabled16=false&HostName16=random.fqdntest&RecordType16=TXT&HostId17=746409&Address17=challengetoken&MXPref17=10&TTL17=3600&AssociatedAppTitle17=&FriendlyName17=&IsActive17=true&IsDDNSEnabled17=false&HostName17=random.fulltest&RecordType17=TXT&HostId18=746410&Address18=challengetoken&MXPref18=10&TTL18=3600&AssociatedAppTitle18=&FriendlyName18=&IsActive18=true&IsDDNSEnabled18=false&HostName18=random.test&RecordType18=TXT&HostId19=746412&Address19=challengetoken&MXPref19=10&TTL19=3600&AssociatedAppTitle19=&FriendlyName19=&IsActive19=true&IsDDNSEnabled19=false&HostName19=updated.test&RecordType19=TXT&HostId20=746356&Address20=http%3A%2F%2Fwww.unittest-seconddomain.dev%2F&MXPref20=10&TTL20=1800&AssociatedAppTitle20=URL+Forwarding&FriendlyName20=URL+Record&IsActive20=true&IsDDNSEnabled20=false&HostName20=%40&RecordType20=URL&Address21=challengetoken&TTL21=3600&HostName21=orig.testfqdn&RecordType21=TXT&SLD=unittest-seconddomain&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['4286']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '3828'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>1.003</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest-seconddomain.dev\" IsSuccess=\"true\">\r\n      <Warnings
+        />\r\n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.706</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['561']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:46:10 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:04:38 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '569'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest-seconddomain&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
-        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
-        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
-        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
-        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
-        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
-        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
-        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
-        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524856\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524857\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524858\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.892</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest-seconddomain.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n
+        \     <host HostId=\"746390\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746391\" Name=\"docs\"
+        Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746357\" Name=\"www\" Type=\"CNAME\" Address=\"parkingpage.namecheap.com.\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"CNAME Record\"
+        IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746395\"
+        Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746396\" Name=\"_acme-challenge.createrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746403\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746392\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746393\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746406\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746407\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746397\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746394\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746413\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746414\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746411\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746415\" Name=\"orig.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746408\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746409\" Name=\"random.fulltest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746410\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746412\" Name=\"updated.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746356\" Name=\"@\" Type=\"URL\" Address=\"http://www.unittest-seconddomain.dev/\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL
+        Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.661</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4980']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:46:11 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:04:41 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '4674'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest-seconddomain&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
-        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
-        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
-        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
-        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
-        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
-        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
-        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
-        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524856\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524857\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524858\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.938</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest-seconddomain.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n
+        \     <host HostId=\"746390\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746391\" Name=\"docs\"
+        Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746357\" Name=\"www\" Type=\"CNAME\" Address=\"parkingpage.namecheap.com.\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"CNAME Record\"
+        IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746395\"
+        Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746396\" Name=\"_acme-challenge.createrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746403\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746392\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746393\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746406\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746407\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746397\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746394\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746413\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746414\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746411\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746415\" Name=\"orig.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746408\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746409\" Name=\"random.fulltest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746410\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746412\" Name=\"updated.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746356\" Name=\"@\" Type=\"URL\" Address=\"http://www.unittest-seconddomain.dev/\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL
+        Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.429</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4980']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:46:12 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:04:42 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '4674'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest-seconddomain&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
-        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
-        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
-        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
-        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
-        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
-        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
-        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
-        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524856\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524857\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524858\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.796</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest-seconddomain.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n
+        \     <host HostId=\"746390\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746391\" Name=\"docs\"
+        Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746357\" Name=\"www\" Type=\"CNAME\" Address=\"parkingpage.namecheap.com.\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"CNAME Record\"
+        IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746395\"
+        Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746396\" Name=\"_acme-challenge.createrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746403\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746392\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746393\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746406\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746407\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746397\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746394\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746413\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746414\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746411\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746415\" Name=\"orig.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746408\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746409\" Name=\"random.fulltest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746410\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746412\" Name=\"updated.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746356\" Name=\"@\" Type=\"URL\" Address=\"http://www.unittest-seconddomain.dev/\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL
+        Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.149</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4980']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:46:14 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:04:43 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '4674'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'RecordType21=TXT&HostId19=524201&RecordType20=TXT&RecordType23=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&IsDDNSEnabled23=false&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524194&HostId9=524856&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524845&HostId5=524846&HostId6=524853&HostId7=524193&IsDDNSEnabled22=false&MXPref23=10&HostId23=524210&HostId22=524208&HostId21=524204&HostId20=524202&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524195&HostId13=524205&HostId10=524857&HostId11=524847&HostId16=524207&HostId17=524209&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken1&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=&FriendlyName23=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&AssociatedAppTitle23=&HostName12=_acme-challenge.test&HostName13=orig.nameonly.test&HostName10=_acme-challenge.listrecordset&HostName11=_acme-challenge.noop&HostName16=orig.testfqdn&HostName17=orig.testfull&HostName14=orig.nameonly.test&Address1=127.0.0.1&HostName18=random.fqdntest&HostName19=random.fulltest&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&RecordType24=TXT&TTL23=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&HostName24=updated.testfqdn&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&AssociatedAppTitle22=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.listrecordset&Address10=challengetoken2&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=updated&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName23=updated.testfull&HostName22=updated.testfqdn&HostName21=updated.test&HostName20=random.test&TTL10=1800&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&IsActive23=true&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&SLD=example-aptise-2&MXPref4=10&Address24=challengetoken&Address23=challengetoken&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524858&AssociatedAppTitle19=&HostId15=524203&HostId18=524200'
+    body: HostId1=746390&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746391&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746357&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746395&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746396&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746403&Address6=challengetoken2&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.deleterecordinset&RecordType6=TXT&HostId7=746392&Address7=challengetoken&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.fqdn&RecordType7=TXT&HostId8=746393&Address8=challengetoken&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.full&RecordType8=TXT&HostId9=746406&Address9=challengetoken1&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.listrecordset&RecordType9=TXT&HostId10=746407&Address10=challengetoken2&MXPref10=10&TTL10=3600&AssociatedAppTitle10=&FriendlyName10=&IsActive10=true&IsDDNSEnabled10=false&HostName10=_acme-challenge.listrecordset&RecordType10=TXT&HostId11=746397&Address11=challengetoken&MXPref11=10&TTL11=3600&AssociatedAppTitle11=&FriendlyName11=&IsActive11=true&IsDDNSEnabled11=false&HostName11=_acme-challenge.noop&RecordType11=TXT&HostId12=746394&Address12=challengetoken&MXPref12=10&TTL12=3600&AssociatedAppTitle12=&FriendlyName12=&IsActive12=true&IsDDNSEnabled12=false&HostName12=_acme-challenge.test&RecordType12=TXT&HostId13=746413&Address13=challengetoken&MXPref13=10&TTL13=3600&AssociatedAppTitle13=&FriendlyName13=&IsActive13=true&IsDDNSEnabled13=false&HostName13=orig.nameonly.test&RecordType13=TXT&HostId14=746414&Address14=updated&MXPref14=10&TTL14=3600&AssociatedAppTitle14=&FriendlyName14=&IsActive14=true&IsDDNSEnabled14=false&HostName14=orig.nameonly.test&RecordType14=TXT&HostId15=746411&Address15=challengetoken&MXPref15=10&TTL15=3600&AssociatedAppTitle15=&FriendlyName15=&IsActive15=true&IsDDNSEnabled15=false&HostName15=orig.test&RecordType15=TXT&HostId16=746415&Address16=challengetoken&MXPref16=10&TTL16=3600&AssociatedAppTitle16=&FriendlyName16=&IsActive16=true&IsDDNSEnabled16=false&HostName16=orig.testfqdn&RecordType16=TXT&HostId17=746408&Address17=challengetoken&MXPref17=10&TTL17=3600&AssociatedAppTitle17=&FriendlyName17=&IsActive17=true&IsDDNSEnabled17=false&HostName17=random.fqdntest&RecordType17=TXT&HostId18=746409&Address18=challengetoken&MXPref18=10&TTL18=3600&AssociatedAppTitle18=&FriendlyName18=&IsActive18=true&IsDDNSEnabled18=false&HostName18=random.fulltest&RecordType18=TXT&HostId19=746410&Address19=challengetoken&MXPref19=10&TTL19=3600&AssociatedAppTitle19=&FriendlyName19=&IsActive19=true&IsDDNSEnabled19=false&HostName19=random.test&RecordType19=TXT&HostId20=746412&Address20=challengetoken&MXPref20=10&TTL20=3600&AssociatedAppTitle20=&FriendlyName20=&IsActive20=true&IsDDNSEnabled20=false&HostName20=updated.test&RecordType20=TXT&HostId21=746356&Address21=http%3A%2F%2Fwww.unittest-seconddomain.dev%2F&MXPref21=10&TTL21=1800&AssociatedAppTitle21=URL+Forwarding&FriendlyName21=URL+Record&IsActive21=true&IsDDNSEnabled21=false&HostName21=%40&RecordType21=URL&Address22=challengetoken&TTL22=3600&HostName22=updated.testfqdn&RecordType22=TXT&SLD=unittest-seconddomain&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['4289']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '4013'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.98</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest-seconddomain.dev\" IsSuccess=\"true\">\r\n      <Warnings
+        />\r\n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.662</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['560']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:46:15 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:04:45 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '569'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_provider_when_calling_update_record_with_full_name_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_provider_when_calling_update_record_with_full_name_should_modify_record.yaml
@@ -2,472 +2,567 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise-2.com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=unittest-seconddomain.dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
-        \ Status=\"Ok\" ID=\"277442\" DomainName=\"example-aptise-2.com\" OwnerName=\"\
-        jvsandbox2\" IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
-        \n        <CreatedDate>03/26/2018</CreatedDate>\r\n        <ExpiredDate>03/26/2019</ExpiredDate>\r\
-        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
-        \ />\r\n      <Whoisguard Enabled=\"True\">\r\n        <ID>233216</ID>\r\n\
-        \        <ExpiredDate>03/25/2019</ExpiredDate>\r\n        <EmailDetails WhoisGuardEmail=\"\
-        bdf487b65d844ddfafe33163f0e709f0.protect@whoisguard.com\" ForwardedTo=\"namecheap.sandbox.2@2xlp.com\"\
-        \ LastAutoEmailChangeDate=\"\" AutoEmailChangeFrequencyDays=\"0\" />\r\n \
-        \     </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
-        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
-        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
-        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
-        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"23\" EmailType=\"\
-        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
-        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
-        \n      <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\"\
-        >OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n        <Rights\
-        \ Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"nameserver\">OK</Rights>\r\
-        \n        <Rights Type=\"premiumDns\">OK</Rights>\r\n        <Rights Type=\"\
-        dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n    </DomainGetInfoResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.051</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult
+        Status=\"Ok\" ID=\"589668\" DomainName=\"unittest-seconddomain.dev\" OwnerName=\"phassberg2\"
+        IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\n        <CreatedDate>05/20/2020</CreatedDate>\r\n
+        \       <ExpiredDate>05/20/2021</ExpiredDate>\r\n        <NumYears>0</NumYears>\r\n
+        \     </DomainDetails>\r\n      <LockDetails />\r\n      <Whoisguard Enabled=\"True\">\r\n
+        \       <ID>481122</ID>\r\n        <ExpiredDate>05/20/2021</ExpiredDate>\r\n
+        \       <EmailDetails WhoisGuardEmail=\"af9bb0ea7b894617af45bb0fa4809b21.protect@whoisguard.com\"
+        ForwardedTo=\"drdoddo@gmail.com\" LastAutoEmailChangeDate=\"05/20/2020\" AutoEmailChangeFrequencyDays=\"3\"
+        />\r\n      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\n
+        \       <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\n
+        \       <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n        <IsActive>false</IsActive>\r\n
+        \     </PremiumDnsSubscription>\r\n      <DnsDetails ProviderType=\"FREE\"
+        IsUsingOurDNS=\"true\" HostCount=\"22\" EmailType=\"FWD\" DynamicDNSStatus=\"false\"
+        IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\n
+        \       <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\n
+        \     <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\">OK</Rights>\r\n
+        \       <Rights Type=\"eforward\">OK</Rights>\r\n        <Rights Type=\"rlock\">OK</Rights>\r\n
+        \       <Rights Type=\"parkpage\">OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n
+        \       <Rights Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"extend\">OK</Rights>\r\n
+        \       <Rights Type=\"nameserver\">OK</Rights>\r\n        <Rights Type=\"autorenew\">OK</Rights>\r\n
+        \       <Rights Type=\"whoisguard\">OK</Rights>\r\n        <Rights Type=\"premiumDns\">OK</Rights>\r\n
+        \       <Rights Type=\"dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n
+        \   </DomainGetInfoResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.19</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['2034']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:46:15 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:04:46 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '2308'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest-seconddomain&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
-        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
-        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
-        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
-        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
-        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
-        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
-        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
-        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524856\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524857\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524858\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.686</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest-seconddomain.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n
+        \     <host HostId=\"746390\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746391\" Name=\"docs\"
+        Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746357\" Name=\"www\" Type=\"CNAME\" Address=\"parkingpage.namecheap.com.\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"CNAME Record\"
+        IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746395\"
+        Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746396\" Name=\"_acme-challenge.createrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746403\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746392\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746393\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746406\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746407\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746397\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746394\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746413\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746414\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746411\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746415\" Name=\"orig.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746408\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746409\" Name=\"random.fulltest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746410\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746412\" Name=\"updated.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746416\" Name=\"updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746356\" Name=\"@\" Type=\"URL\"
+        Address=\"http://www.unittest-seconddomain.dev/\" MXPref=\"10\" TTL=\"1800\"
+        AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL Record\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n
+        \ <Server>PHX01SBAPIEXT02</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.442</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4980']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:46:17 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:04:47 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '4865'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'RecordType21=TXT&HostId19=524201&RecordType20=TXT&RecordType23=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&IsDDNSEnabled23=false&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524194&HostId9=524856&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524845&HostId5=524846&HostId6=524853&HostId7=524193&IsDDNSEnabled22=false&MXPref23=10&HostId23=524210&HostId22=524208&HostId21=524204&HostId20=524202&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524195&HostId13=524205&HostId10=524857&HostId11=524847&HostId16=524207&HostId17=524209&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken1&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=&FriendlyName23=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&AssociatedAppTitle23=&HostName12=_acme-challenge.test&HostName13=orig.nameonly.test&HostName10=_acme-challenge.listrecordset&HostName11=_acme-challenge.noop&HostName16=orig.testfqdn&HostName17=orig.testfull&HostName14=orig.nameonly.test&Address1=127.0.0.1&HostName18=random.fqdntest&HostName19=random.fulltest&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&RecordType24=TXT&TTL23=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&HostName24=orig.testfull&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&AssociatedAppTitle22=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.listrecordset&Address10=challengetoken2&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=updated&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName23=updated.testfull&HostName22=updated.testfqdn&HostName21=updated.test&HostName20=random.test&TTL10=1800&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&IsActive23=true&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&SLD=example-aptise-2&MXPref4=10&Address24=challengetoken&Address23=challengetoken&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524858&AssociatedAppTitle19=&HostId15=524203&HostId18=524200'
+    body: HostId1=746390&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746391&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746357&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746395&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746396&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746403&Address6=challengetoken2&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.deleterecordinset&RecordType6=TXT&HostId7=746392&Address7=challengetoken&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.fqdn&RecordType7=TXT&HostId8=746393&Address8=challengetoken&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.full&RecordType8=TXT&HostId9=746406&Address9=challengetoken1&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.listrecordset&RecordType9=TXT&HostId10=746407&Address10=challengetoken2&MXPref10=10&TTL10=3600&AssociatedAppTitle10=&FriendlyName10=&IsActive10=true&IsDDNSEnabled10=false&HostName10=_acme-challenge.listrecordset&RecordType10=TXT&HostId11=746397&Address11=challengetoken&MXPref11=10&TTL11=3600&AssociatedAppTitle11=&FriendlyName11=&IsActive11=true&IsDDNSEnabled11=false&HostName11=_acme-challenge.noop&RecordType11=TXT&HostId12=746394&Address12=challengetoken&MXPref12=10&TTL12=3600&AssociatedAppTitle12=&FriendlyName12=&IsActive12=true&IsDDNSEnabled12=false&HostName12=_acme-challenge.test&RecordType12=TXT&HostId13=746413&Address13=challengetoken&MXPref13=10&TTL13=3600&AssociatedAppTitle13=&FriendlyName13=&IsActive13=true&IsDDNSEnabled13=false&HostName13=orig.nameonly.test&RecordType13=TXT&HostId14=746414&Address14=updated&MXPref14=10&TTL14=3600&AssociatedAppTitle14=&FriendlyName14=&IsActive14=true&IsDDNSEnabled14=false&HostName14=orig.nameonly.test&RecordType14=TXT&HostId15=746411&Address15=challengetoken&MXPref15=10&TTL15=3600&AssociatedAppTitle15=&FriendlyName15=&IsActive15=true&IsDDNSEnabled15=false&HostName15=orig.test&RecordType15=TXT&HostId16=746415&Address16=challengetoken&MXPref16=10&TTL16=3600&AssociatedAppTitle16=&FriendlyName16=&IsActive16=true&IsDDNSEnabled16=false&HostName16=orig.testfqdn&RecordType16=TXT&HostId17=746408&Address17=challengetoken&MXPref17=10&TTL17=3600&AssociatedAppTitle17=&FriendlyName17=&IsActive17=true&IsDDNSEnabled17=false&HostName17=random.fqdntest&RecordType17=TXT&HostId18=746409&Address18=challengetoken&MXPref18=10&TTL18=3600&AssociatedAppTitle18=&FriendlyName18=&IsActive18=true&IsDDNSEnabled18=false&HostName18=random.fulltest&RecordType18=TXT&HostId19=746410&Address19=challengetoken&MXPref19=10&TTL19=3600&AssociatedAppTitle19=&FriendlyName19=&IsActive19=true&IsDDNSEnabled19=false&HostName19=random.test&RecordType19=TXT&HostId20=746412&Address20=challengetoken&MXPref20=10&TTL20=3600&AssociatedAppTitle20=&FriendlyName20=&IsActive20=true&IsDDNSEnabled20=false&HostName20=updated.test&RecordType20=TXT&HostId21=746416&Address21=challengetoken&MXPref21=10&TTL21=3600&AssociatedAppTitle21=&FriendlyName21=&IsActive21=true&IsDDNSEnabled21=false&HostName21=updated.testfqdn&RecordType21=TXT&HostId22=746356&Address22=http%3A%2F%2Fwww.unittest-seconddomain.dev%2F&MXPref22=10&TTL22=1800&AssociatedAppTitle22=URL+Forwarding&FriendlyName22=URL+Record&IsActive22=true&IsDDNSEnabled22=false&HostName22=%40&RecordType22=URL&Address23=challengetoken&TTL23=3600&HostName23=orig.testfull&RecordType23=TXT&SLD=unittest-seconddomain&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['4286']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '4195'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.934</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest-seconddomain.dev\" IsSuccess=\"true\">\r\n      <Warnings
+        />\r\n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.908</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['561']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:46:18 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:04:50 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '569'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest-seconddomain&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
-        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
-        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
-        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
-        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
-        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
-        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
-        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
-        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524856\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524857\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524858\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.616</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest-seconddomain.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n
+        \     <host HostId=\"746390\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746391\" Name=\"docs\"
+        Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746357\" Name=\"www\" Type=\"CNAME\" Address=\"parkingpage.namecheap.com.\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"CNAME Record\"
+        IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746395\"
+        Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746396\" Name=\"_acme-challenge.createrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746403\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746392\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746393\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746406\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746407\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746397\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746394\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746413\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746414\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746411\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746415\" Name=\"orig.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746417\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746408\" Name=\"random.fqdntest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746409\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746410\" Name=\"random.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746412\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746416\" Name=\"updated.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746356\" Name=\"@\" Type=\"URL\" Address=\"http://www.unittest-seconddomain.dev/\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL
+        Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.594</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4980']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:46:20 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:04:51 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '5053'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest-seconddomain&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
-        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
-        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
-        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
-        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
-        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
-        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
-        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
-        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524856\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524857\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524858\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.668</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest-seconddomain.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n
+        \     <host HostId=\"746390\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746391\" Name=\"docs\"
+        Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746357\" Name=\"www\" Type=\"CNAME\" Address=\"parkingpage.namecheap.com.\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"CNAME Record\"
+        IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746395\"
+        Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746396\" Name=\"_acme-challenge.createrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746403\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746392\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746393\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746406\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746407\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746397\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746394\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746413\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746414\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746411\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746415\" Name=\"orig.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746417\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746408\" Name=\"random.fqdntest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746409\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746410\" Name=\"random.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746412\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746416\" Name=\"updated.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746356\" Name=\"@\" Type=\"URL\" Address=\"http://www.unittest-seconddomain.dev/\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL
+        Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.15</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4980']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:46:21 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:04:51 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '5052'
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=unittest-seconddomain&TLD=dev
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
-        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
-        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
-        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
-        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
-        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
-        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
-        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
-        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524856\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524857\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524858\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.723</ExecutionTime>\r\n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult
+        Domain=\"unittest-seconddomain.dev\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n
+        \     <host HostId=\"746390\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746391\" Name=\"docs\"
+        Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746357\" Name=\"www\" Type=\"CNAME\" Address=\"parkingpage.namecheap.com.\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"CNAME Record\"
+        IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746395\"
+        Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746396\" Name=\"_acme-challenge.createrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746403\" Name=\"_acme-challenge.deleterecordinset\" Type=\"TXT\"
+        Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746392\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746393\" Name=\"_acme-challenge.full\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746406\" Name=\"_acme-challenge.listrecordset\" Type=\"TXT\" Address=\"challengetoken1\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746407\" Name=\"_acme-challenge.listrecordset\"
+        Type=\"TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746397\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746394\" Name=\"_acme-challenge.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746413\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746414\" Name=\"orig.nameonly.test\"
+        Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746411\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746415\" Name=\"orig.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746417\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746408\" Name=\"random.fqdntest\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746409\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746410\" Name=\"random.test\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746412\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"
+        MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"
+        IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"746416\" Name=\"updated.testfqdn\"
+        Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"3600\" AssociatedAppTitle=\"\"
+        FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host
+        HostId=\"746356\" Name=\"@\" Type=\"URL\" Address=\"http://www.unittest-seconddomain.dev/\"
+        MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"URL Forwarding\" FriendlyName=\"URL
+        Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n
+        \ </CommandResponse>\r\n  <Server>PHX01SBAPIEXT01</Server>\r\n  <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n
+        \ <ExecutionTime>0.4</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['4980']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:46:22 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:04:53 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '5051'
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode 'RecordType21=TXT&HostId19=524201&RecordType20=TXT&RecordType23=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&IsDDNSEnabled23=false&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524194&HostId9=524856&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524845&HostId5=524846&HostId6=524853&HostId7=524193&IsDDNSEnabled22=false&MXPref23=10&HostId23=524210&HostId22=524208&HostId21=524204&HostId20=524202&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524195&HostId13=524205&HostId10=524857&HostId11=524847&HostId16=524207&HostId17=524209&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken1&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=&FriendlyName23=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&AssociatedAppTitle23=&HostName12=_acme-challenge.test&HostName13=orig.nameonly.test&HostName10=_acme-challenge.listrecordset&HostName11=_acme-challenge.noop&HostName16=orig.testfqdn&HostName17=orig.testfull&HostName14=orig.nameonly.test&Address1=127.0.0.1&HostName18=random.fqdntest&HostName19=random.fulltest&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&RecordType24=TXT&TTL23=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&HostName24=updated.testfull&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&AssociatedAppTitle22=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.listrecordset&Address10=challengetoken2&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=updated&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName23=updated.testfull&HostName22=updated.testfqdn&HostName21=updated.test&HostName20=random.test&TTL10=1800&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&IsActive23=true&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&SLD=example-aptise-2&MXPref4=10&Address24=challengetoken&Address23=challengetoken&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524858&AssociatedAppTitle19=&HostId15=524203&HostId18=524200'
+    body: HostId1=746390&Address1=127.0.0.1&MXPref1=10&TTL1=3600&AssociatedAppTitle1=&FriendlyName1=&IsActive1=true&IsDDNSEnabled1=false&HostName1=localhost&RecordType1=A&HostId2=746391&Address2=docs.example.com.&MXPref2=10&TTL2=3600&AssociatedAppTitle2=&FriendlyName2=&IsActive2=true&IsDDNSEnabled2=false&HostName2=docs&RecordType2=CNAME&HostId3=746357&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL3=1800&AssociatedAppTitle3=&FriendlyName3=CNAME+Record&IsActive3=true&IsDDNSEnabled3=false&HostName3=www&RecordType3=CNAME&HostId4=746395&Address4=challengetoken1&MXPref4=10&TTL4=3600&AssociatedAppTitle4=&FriendlyName4=&IsActive4=true&IsDDNSEnabled4=false&HostName4=_acme-challenge.createrecordset&RecordType4=TXT&HostId5=746396&Address5=challengetoken2&MXPref5=10&TTL5=3600&AssociatedAppTitle5=&FriendlyName5=&IsActive5=true&IsDDNSEnabled5=false&HostName5=_acme-challenge.createrecordset&RecordType5=TXT&HostId6=746403&Address6=challengetoken2&MXPref6=10&TTL6=3600&AssociatedAppTitle6=&FriendlyName6=&IsActive6=true&IsDDNSEnabled6=false&HostName6=_acme-challenge.deleterecordinset&RecordType6=TXT&HostId7=746392&Address7=challengetoken&MXPref7=10&TTL7=3600&AssociatedAppTitle7=&FriendlyName7=&IsActive7=true&IsDDNSEnabled7=false&HostName7=_acme-challenge.fqdn&RecordType7=TXT&HostId8=746393&Address8=challengetoken&MXPref8=10&TTL8=3600&AssociatedAppTitle8=&FriendlyName8=&IsActive8=true&IsDDNSEnabled8=false&HostName8=_acme-challenge.full&RecordType8=TXT&HostId9=746406&Address9=challengetoken1&MXPref9=10&TTL9=3600&AssociatedAppTitle9=&FriendlyName9=&IsActive9=true&IsDDNSEnabled9=false&HostName9=_acme-challenge.listrecordset&RecordType9=TXT&HostId10=746407&Address10=challengetoken2&MXPref10=10&TTL10=3600&AssociatedAppTitle10=&FriendlyName10=&IsActive10=true&IsDDNSEnabled10=false&HostName10=_acme-challenge.listrecordset&RecordType10=TXT&HostId11=746397&Address11=challengetoken&MXPref11=10&TTL11=3600&AssociatedAppTitle11=&FriendlyName11=&IsActive11=true&IsDDNSEnabled11=false&HostName11=_acme-challenge.noop&RecordType11=TXT&HostId12=746394&Address12=challengetoken&MXPref12=10&TTL12=3600&AssociatedAppTitle12=&FriendlyName12=&IsActive12=true&IsDDNSEnabled12=false&HostName12=_acme-challenge.test&RecordType12=TXT&HostId13=746413&Address13=challengetoken&MXPref13=10&TTL13=3600&AssociatedAppTitle13=&FriendlyName13=&IsActive13=true&IsDDNSEnabled13=false&HostName13=orig.nameonly.test&RecordType13=TXT&HostId14=746414&Address14=updated&MXPref14=10&TTL14=3600&AssociatedAppTitle14=&FriendlyName14=&IsActive14=true&IsDDNSEnabled14=false&HostName14=orig.nameonly.test&RecordType14=TXT&HostId15=746411&Address15=challengetoken&MXPref15=10&TTL15=3600&AssociatedAppTitle15=&FriendlyName15=&IsActive15=true&IsDDNSEnabled15=false&HostName15=orig.test&RecordType15=TXT&HostId16=746415&Address16=challengetoken&MXPref16=10&TTL16=3600&AssociatedAppTitle16=&FriendlyName16=&IsActive16=true&IsDDNSEnabled16=false&HostName16=orig.testfqdn&RecordType16=TXT&HostId17=746417&Address17=challengetoken&MXPref17=10&TTL17=3600&AssociatedAppTitle17=&FriendlyName17=&IsActive17=true&IsDDNSEnabled17=false&HostName17=orig.testfull&RecordType17=TXT&HostId18=746408&Address18=challengetoken&MXPref18=10&TTL18=3600&AssociatedAppTitle18=&FriendlyName18=&IsActive18=true&IsDDNSEnabled18=false&HostName18=random.fqdntest&RecordType18=TXT&HostId19=746409&Address19=challengetoken&MXPref19=10&TTL19=3600&AssociatedAppTitle19=&FriendlyName19=&IsActive19=true&IsDDNSEnabled19=false&HostName19=random.fulltest&RecordType19=TXT&HostId20=746410&Address20=challengetoken&MXPref20=10&TTL20=3600&AssociatedAppTitle20=&FriendlyName20=&IsActive20=true&IsDDNSEnabled20=false&HostName20=random.test&RecordType20=TXT&HostId21=746412&Address21=challengetoken&MXPref21=10&TTL21=3600&AssociatedAppTitle21=&FriendlyName21=&IsActive21=true&IsDDNSEnabled21=false&HostName21=updated.test&RecordType21=TXT&HostId22=746416&Address22=challengetoken&MXPref22=10&TTL22=3600&AssociatedAppTitle22=&FriendlyName22=&IsActive22=true&IsDDNSEnabled22=false&HostName22=updated.testfqdn&RecordType22=TXT&HostId23=746356&Address23=http%3A%2F%2Fwww.unittest-seconddomain.dev%2F&MXPref23=10&TTL23=1800&AssociatedAppTitle23=URL+Forwarding&FriendlyName23=URL+Record&IsActive23=true&IsDDNSEnabled23=false&HostName23=%40&RecordType23=URL&Address24=challengetoken&TTL24=3600&HostName24=updated.testfull&RecordType24=TXT&SLD=unittest-seconddomain&TLD=dev
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['4289']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '4380'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
     method: POST
     uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
   response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.923</ExecutionTime>\r\
-        \n</ApiResponse>"}
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ApiResponse Status=\"OK\"
+        xmlns=\"http://api.namecheap.com/xml.response\">\r\n  <Errors />\r\n  <Warnings
+        />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\n
+        \ <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult
+        Domain=\"unittest-seconddomain.dev\" IsSuccess=\"true\">\r\n      <Warnings
+        />\r\n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPIEXT02</Server>\r\n
+        \ <GMTTimeDifference>--4:00</GMTTimeDifference>\r\n  <ExecutionTime>0.602</ExecutionTime>\r\n</ApiResponse>"
     headers:
-      cache-control: [private]
-      content-length: ['561']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:46:23 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 20 May 2020 19:04:54 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Vary:
+      - Accept-Encoding
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      content-length:
+      - '569'
+    status:
+      code: 200
+      message: OK
 version: 1


### PR DESCRIPTION
Creating MX records with namecheap used to crash like this:

```
lexicon  namecheap create peppe.club MX  --name "@" --content "10 smtp.peppe.club"
Remote: 8
To set: 9
Traceback (most recent call last):
  File "/home/petter/git/lexicon/venv/bin/lexicon", line 11, in <module>
    load_entry_point('dns-lexicon==3.3.22', 'console_scripts', 'lexicon')()
  File "/home/petter/git/lexicon/venv/lib/python3.8/site-packages/dns_lexicon-3.3.22-py3.8.egg/lexicon/cli.py", line 117, in main
    results = client.execute()
  File "/home/petter/git/lexicon/venv/lib/python3.8/site-packages/dns_lexicon-3.3.22-py3.8.egg/lexicon/client.py", line 84, in execute
    return self.provider.create_record(record_type, name, content)
  File "/home/petter/git/lexicon/venv/lib/python3.8/site-packages/dns_lexicon-3.3.22-py3.8.egg/lexicon/providers/base.py", line 80, in create_record
    return self._create_record(rtype, name, content)
  File "/home/petter/git/lexicon/venv/lib/python3.8/site-packages/dns_lexicon-3.3.22-py3.8.egg/lexicon/providers/namecheap.py", line 202, in _create_record
    self.client.domains_dns_addHost(self.domain, record)
  File "/home/petter/git/lexicon/venv/lib/python3.8/site-packages/namecheap.py", line 388, in domains_dns_addHost
    self._call("namecheap.domains.dns.setHosts", extra_payload)
  File "/home/petter/git/lexicon/venv/lib/python3.8/site-packages/namecheap.py", line 144, in _call
    xml = self._fetch_xml(payload, extra_payload)
  File "/home/petter/git/lexicon/venv/lib/python3.8/site-packages/namecheap.py", line 137, in _fetch_xml
    raise ApiError(error.attrib['Number'], error.text)
namecheap.ApiError: 2050900 - INVALID_ADDR : ' 10 smtp.peppe.club' should not be an IP/ URL for MX record.(host name: @)
```

Furthermore, listing them did not usually produce the priority field.

With this fix, it works:

```
% PYTHONPATH=. lexicon  namecheap create peppe.club MX  --name "@" --content "10 smtp.peppe.club"
Remote: 8
To set: 9
RESULT
------
True
% PYTHONPATH=. lexicon  namecheap list peppe.club MX
ID     TYPE NAME            CONTENT              TTL 
------ ---- --------------- -------------------- ----
746267 MX   @.peppe.club    10 smtp.peppe.club.  3600

```
