### PR TITLE
Final customizations for hetzner dns api v1.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -39,7 +39,7 @@ lexicon/providers/glesys.py         @hecd
 lexicon/providers/godaddy.py        @adferrand
 lexicon/providers/gratisdns.py      @skeen
 lexicon/providers/henet.py          @hank
-lexicon/providers/hetzner.py        @rembik
+lexicon/providers/hetzner.py        @rembik @cgoIT
 lexicon/providers/hostingde.py      @initit
 lexicon/providers/hover.py          @bkanuka
 lexicon/providers/internetbs.py     @edausq

--- a/lexicon/tests/providers/test_hetzner.py
+++ b/lexicon/tests/providers/test_hetzner.py
@@ -10,7 +10,7 @@ from lexicon.tests.providers.integration_tests import IntegrationTests
 class HetznerProviderTests(TestCase, IntegrationTests):
     """TestCase for Hetzner"""
     provider_name = 'hetzner'
-    domain = 'softwarekollektiv.de'
+    domain = 'hetzner-api-test.de'
 
     def _filter_headers(self):
         return ['Auth-API-Token']

--- a/tests/fixtures/cassettes/hetzner/IntegrationTests/test_provider_authenticate.yaml
+++ b/tests/fixtures/cassettes/hetzner/IntegrationTests/test_provider_authenticate.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -11,39 +11,39 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
     uri: https://dns.hetzner.com/api/v1/zones
   response:
     body:
-      string: '{"zones":[{"id":"xyncsydKx5x44qDZQCzpNM","name":"alt.coop","ttl":300,"registrar":"","legacy_dns_host":"","legacy_ns":["hydrogen.ns.hetzner.com.","helium.ns.hetzner.com.","oxygen.ns.hetzner.com."],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-07
-        01:23:59 +0000 UTC","verified":"2020-04-07 01:53:05.934062806 +0000 UTC m=+578.060435172","modified":"2020-04-08
-        10:38:16.278 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":75},{"id":"JkBqVJDW3PpqefBb274BCZ","name":"softwarekollektiv.de","ttl":86400,"registrar":"","legacy_dns_host":"","legacy_ns":[],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-08
-        18:53:25.589 +0000 UTC","verified":"2020-04-08T18:53:27Z","modified":"2020-04-13
-        15:17:43.767 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":1}],"meta":{"pagination":{"page":1,"per_page":100,"previous_page":1,"next_page":1,"last_page":1,"total_entries":2}}}
+      string: !!python/unicode '{"zones":[{"id":"hetznerapizoneid","name":"hetzner-api-test.de","ttl":3600,"registrar":"","legacy_dns_host":"","legacy_ns":["ns1.first-ns.de.","robotns2.second-ns.de.","robotns3.second-ns.com."],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-07
+        01:24:00 +0000 UTC","verified":"2020-04-07 01:51:26.114056422 +0000 UTC m=+478.240428717","modified":"2020-06-11
+        07:02:20.999 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":9}],"meta":{"pagination":{"page":1,"per_page":100,"previous_page":1,"next_page":1,"last_page":1,"total_entries":12}}}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '1329'
-      Content-Type:
+      content-length:
+      - '7886'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:32:33 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:20:36 GMT
+      transfer-encoding:
+      - chunked
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
-      - '1'
-      X-Kong-Upstream-Latency:
-      - '193'
+      x-kong-proxy-latency:
+      - '2'
+      x-kong-upstream-latency:
+      - '243'
     status:
       code: 200
       message: OK

--- a/tests/fixtures/cassettes/hetzner/IntegrationTests/test_provider_authenticate_with_unmanaged_domain_should_fail.yaml
+++ b/tests/fixtures/cassettes/hetzner/IntegrationTests/test_provider_authenticate_with_unmanaged_domain_should_fail.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -11,39 +11,39 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
     uri: https://dns.hetzner.com/api/v1/zones
   response:
     body:
-      string: '{"zones":[{"id":"xyncsydKx5x44qDZQCzpNM","name":"alt.coop","ttl":300,"registrar":"","legacy_dns_host":"","legacy_ns":["helium.ns.hetzner.com.","oxygen.ns.hetzner.com.","hydrogen.ns.hetzner.com."],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-07
-        01:23:59 +0000 UTC","verified":"2020-04-07 01:53:05.934062806 +0000 UTC m=+578.060435172","modified":"2020-04-08
-        10:38:16.278 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":75},{"id":"JkBqVJDW3PpqefBb274BCZ","name":"softwarekollektiv.de","ttl":86400,"registrar":"","legacy_dns_host":"","legacy_ns":[],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-08
-        18:53:25.589 +0000 UTC","verified":"2020-04-08T18:53:27Z","modified":"2020-04-13
-        15:17:43.767 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":1}],"meta":{"pagination":{"page":1,"per_page":100,"previous_page":1,"next_page":1,"last_page":1,"total_entries":2}}}
+      string: !!python/unicode '{"zones":[{"id":"hetznerapizoneid","name":"hetzner-api-test.de","ttl":3600,"registrar":"","legacy_dns_host":"","legacy_ns":["ns1.first-ns.de.","robotns2.second-ns.de.","robotns3.second-ns.com."],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-07
+        01:24:00 +0000 UTC","verified":"2020-04-07 01:51:26.114056422 +0000 UTC m=+478.240428717","modified":"2020-06-11
+        07:02:20.999 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":9}],"meta":{"pagination":{"page":1,"per_page":100,"previous_page":1,"next_page":1,"last_page":1,"total_entries":12}}}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '1329'
-      Content-Type:
+      content-length:
+      - '7886'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:32:33 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:20:36 GMT
+      transfer-encoding:
+      - chunked
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
+      x-kong-proxy-latency:
       - '1'
-      X-Kong-Upstream-Latency:
-      - '187'
+      x-kong-upstream-latency:
+      - '253'
     status:
       code: 200
       message: OK

--- a/tests/fixtures/cassettes/hetzner/IntegrationTests/test_provider_when_calling_create_record_for_A_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/hetzner/IntegrationTests/test_provider_when_calling_create_record_for_A_with_valid_name_and_content.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -11,44 +11,44 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
     uri: https://dns.hetzner.com/api/v1/zones
   response:
     body:
-      string: '{"zones":[{"id":"xyncsydKx5x44qDZQCzpNM","name":"alt.coop","ttl":300,"registrar":"","legacy_dns_host":"","legacy_ns":["oxygen.ns.hetzner.com.","hydrogen.ns.hetzner.com.","helium.ns.hetzner.com."],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-07
-        01:23:59 +0000 UTC","verified":"2020-04-07 01:53:05.934062806 +0000 UTC m=+578.060435172","modified":"2020-04-08
-        10:38:16.278 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":75},{"id":"JkBqVJDW3PpqefBb274BCZ","name":"softwarekollektiv.de","ttl":86400,"registrar":"","legacy_dns_host":"","legacy_ns":[],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-08
-        18:53:25.589 +0000 UTC","verified":"2020-04-08T18:53:27Z","modified":"2020-04-13
-        15:17:43.767 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":1}],"meta":{"pagination":{"page":1,"per_page":100,"previous_page":1,"next_page":1,"last_page":1,"total_entries":2}}}
+      string: !!python/unicode '{"zones":[{"id":"hetznerapizoneid","name":"hetzner-api-test.de","ttl":3600,"registrar":"","legacy_dns_host":"","legacy_ns":["ns1.first-ns.de.","robotns2.second-ns.de.","robotns3.second-ns.com."],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-07
+        01:24:00 +0000 UTC","verified":"2020-04-07 01:51:26.114056422 +0000 UTC m=+478.240428717","modified":"2020-06-11
+        07:02:20.999 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":9}],"meta":{"pagination":{"page":1,"per_page":100,"previous_page":1,"next_page":1,"last_page":1,"total_entries":12}}}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '1329'
-      Content-Type:
+      content-length:
+      - '7886'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:32:34 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:20:37 GMT
+      transfer-encoding:
+      - chunked
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
-      - '2'
-      X-Kong-Upstream-Latency:
-      - '175'
+      x-kong-proxy-latency:
+      - '1'
+      x-kong-upstream-latency:
+      - '378'
     status:
       code: 200
       message: OK
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -59,43 +59,54 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
-    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=JkBqVJDW3PpqefBb274BCZ
+    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=hetznerapizoneid
   response:
     body:
-      string: '{"records":[{"id":"kPbit4mpJa5pNU6dbFXpp3","type":"SOA","name":"@","value":"ns1.your-server.de.
-        dns.hetzner.com. 2020041570 86400 7200 3600000 3600","zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        15:17:43.061 +0000 UTC","modified":"2020-04-13 20:32:15.569 +0000 UTC"}]}
+      string: !!python/unicode '{"records":[{"id":"9720b5653ca6fd0517ec91a8c6104685","type":"SOA","name":"@","value":"ns1.first-ns.de.
+        dns.hetzner.com. 2020061200 14400 3600 1814400 3600","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:24:42 +0000 UTC","modified":"2020-06-12 08:17:20.817 +0000 UTC"},{"id":"5b378a7097bdb11e6cbb5f58db6bb101","type":"MX","name":"@","value":"10
+        mail.server-zugang.eu.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:12 +0000 UTC","modified":"2020-04-07 01:25:12 +0000 UTC"},{"id":"a26cfdd36217e559c14b305a558f2a3c","type":"AAAA","name":"@","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"7d6f741802597845b97713596e35eaa7","type":"AAAA","name":"*","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"993bafd3e3b110a6a3acde9fe874426a","type":"NS","name":"@","value":"ns1.first-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"cc3e8297060b7bd794fed5fdec3ed91b","type":"NS","name":"@","value":"robotns2.second-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"c4602b1239d9f0747016f551c52b5774","type":"NS","name":"@","value":"robotns3.second-ns.com.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"77ae87e42a04bace81119eb2280c8dca","type":"A","name":"@","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"faff62d59434c666bac4174a1d18a955","type":"A","name":"*","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"}]}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '280'
-      Content-Type:
+      content-length:
+      - '2005'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:32:37 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:20:37 GMT
+      transfer-encoding:
+      - chunked
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
+      x-kong-proxy-latency:
       - '1'
-      X-Kong-Upstream-Latency:
-      - '3273'
+      x-kong-upstream-latency:
+      - '66'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"name": "localhost.softwarekollektiv.de.", "type": "A", "value": "127.0.0.1",
-      "zone_id": "JkBqVJDW3PpqefBb274BCZ", "ttl": 3600}'
+    body: !!python/unicode '{"ttl": 3600, "type": "A", "name": "localhost", "value":
+      "127.0.0.1", "zone_id": "hetznerapizoneid"}'
     headers:
       Accept:
       - '*/*'
@@ -104,38 +115,40 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '128'
+      - '106'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: POST
     uri: https://dns.hetzner.com/api/v1/records
   response:
     body:
-      string: '{"record":{"id":"xbSVZRkvraCx2ZJkB5Stwh","type":"A","name":"localhost.softwarekollektiv.de.","value":"127.0.0.1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:37.644 +0000 UTC","modified":"2020-04-13 20:32:37.644 +0000 UTC"}}
+      string: !!python/unicode '{"record":{"id":"fe6ac2081c630974662caeaa8715d435","type":"A","name":"localhost","value":"127.0.0.1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:37.307 +0000 UTC","modified":"2020-06-12 08:20:37.307 +0000 UTC"}}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '254'
-      Content-Type:
+      content-length:
+      - '242'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:32:40 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:20:38 GMT
+      transfer-encoding:
+      - chunked
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
+      x-kong-proxy-latency:
       - '2'
-      X-Kong-Upstream-Latency:
-      - '2513'
+      x-kong-upstream-latency:
+      - '767'
     status:
       code: 200
       message: OK

--- a/tests/fixtures/cassettes/hetzner/IntegrationTests/test_provider_when_calling_create_record_for_CNAME_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/hetzner/IntegrationTests/test_provider_when_calling_create_record_for_CNAME_with_valid_name_and_content.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -11,44 +11,44 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
     uri: https://dns.hetzner.com/api/v1/zones
   response:
     body:
-      string: '{"zones":[{"id":"xyncsydKx5x44qDZQCzpNM","name":"alt.coop","ttl":300,"registrar":"","legacy_dns_host":"","legacy_ns":["helium.ns.hetzner.com.","oxygen.ns.hetzner.com.","hydrogen.ns.hetzner.com."],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-07
-        01:23:59 +0000 UTC","verified":"2020-04-07 01:53:05.934062806 +0000 UTC m=+578.060435172","modified":"2020-04-08
-        10:38:16.278 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":75},{"id":"JkBqVJDW3PpqefBb274BCZ","name":"softwarekollektiv.de","ttl":86400,"registrar":"","legacy_dns_host":"","legacy_ns":[],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-08
-        18:53:25.589 +0000 UTC","verified":"2020-04-08T18:53:27Z","modified":"2020-04-13
-        15:17:43.767 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":1}],"meta":{"pagination":{"page":1,"per_page":100,"previous_page":1,"next_page":1,"last_page":1,"total_entries":2}}}
+      string: !!python/unicode '{"zones":[{"id":"hetznerapizoneid","name":"hetzner-api-test.de","ttl":3600,"registrar":"","legacy_dns_host":"","legacy_ns":["ns1.first-ns.de.","robotns2.second-ns.de.","robotns3.second-ns.com."],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-07
+        01:24:00 +0000 UTC","verified":"2020-04-07 01:51:26.114056422 +0000 UTC m=+478.240428717","modified":"2020-06-11
+        07:02:20.999 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":9}],"meta":{"pagination":{"page":1,"per_page":100,"previous_page":1,"next_page":1,"last_page":1,"total_entries":12}}}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '1329'
-      Content-Type:
+      content-length:
+      - '7887'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:32:40 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:20:38 GMT
+      transfer-encoding:
+      - chunked
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
+      x-kong-proxy-latency:
       - '1'
-      X-Kong-Upstream-Latency:
-      - '174'
+      x-kong-upstream-latency:
+      - '264'
     status:
       code: 200
       message: OK
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -59,44 +59,55 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
-    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=JkBqVJDW3PpqefBb274BCZ
+    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=hetznerapizoneid
   response:
     body:
-      string: '{"records":[{"id":"kPbit4mpJa5pNU6dbFXpp3","type":"SOA","name":"@","value":"ns1.your-server.de.
-        dns.hetzner.com. 2020041571 86400 7200 3600000 3600","zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        15:17:43.061 +0000 UTC","modified":"2020-04-13 20:32:39.545 +0000 UTC"},{"id":"xbSVZRkvraCx2ZJkB5Stwh","type":"A","name":"localhost.softwarekollektiv.de.","value":"127.0.0.1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:37.644 +0000 UTC","modified":"2020-04-13 20:32:37.644 +0000 UTC"}]}
+      string: !!python/unicode '{"records":[{"id":"9720b5653ca6fd0517ec91a8c6104685","type":"SOA","name":"@","value":"ns1.first-ns.de.
+        dns.hetzner.com. 2020061201 14400 3600 1814400 3600","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:24:42 +0000 UTC","modified":"2020-06-12 08:20:37.415 +0000 UTC"},{"id":"5b378a7097bdb11e6cbb5f58db6bb101","type":"MX","name":"@","value":"10
+        mail.server-zugang.eu.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:12 +0000 UTC","modified":"2020-04-07 01:25:12 +0000 UTC"},{"id":"a26cfdd36217e559c14b305a558f2a3c","type":"AAAA","name":"@","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"7d6f741802597845b97713596e35eaa7","type":"AAAA","name":"*","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"993bafd3e3b110a6a3acde9fe874426a","type":"NS","name":"@","value":"ns1.first-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"cc3e8297060b7bd794fed5fdec3ed91b","type":"NS","name":"@","value":"robotns2.second-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"c4602b1239d9f0747016f551c52b5774","type":"NS","name":"@","value":"robotns3.second-ns.com.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"77ae87e42a04bace81119eb2280c8dca","type":"A","name":"@","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"faff62d59434c666bac4174a1d18a955","type":"A","name":"*","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"fe6ac2081c630974662caeaa8715d435","type":"A","name":"localhost","value":"127.0.0.1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:37.307 +0000 UTC","modified":"2020-06-12 08:20:37.307 +0000 UTC"}]}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '523'
-      Content-Type:
+      content-length:
+      - '2236'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:32:43 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:20:38 GMT
+      transfer-encoding:
+      - chunked
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
-      - '1'
-      X-Kong-Upstream-Latency:
-      - '3075'
+      x-kong-proxy-latency:
+      - '2'
+      x-kong-upstream-latency:
+      - '69'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"name": "docs.softwarekollektiv.de.", "type": "CNAME", "value": "docs.example.com",
-      "zone_id": "JkBqVJDW3PpqefBb274BCZ", "ttl": 3600}'
+    body: !!python/unicode '{"ttl": 3600, "type": "CNAME", "name": "docs", "value":
+      "docs.example.com", "zone_id": "hetznerapizoneid"}'
     headers:
       Accept:
       - '*/*'
@@ -105,38 +116,40 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '134'
+      - '112'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: POST
     uri: https://dns.hetzner.com/api/v1/records
   response:
     body:
-      string: '{"record":{"id":"BotQ9nkmc8HHJpnkDNH9NS","type":"CNAME","name":"docs.softwarekollektiv.de.","value":"docs.example.com","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:43.98 +0000 UTC","modified":"2020-04-13 20:32:43.98 +0000 UTC"}}
+      string: !!python/unicode '{"record":{"id":"8e6b81a856d20f0c1802703b56d1b53d","type":"CNAME","name":"docs","value":"docs.example.com","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:38.743 +0000 UTC","modified":"2020-06-12 08:20:38.743 +0000 UTC"}}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '258'
-      Content-Type:
+      content-length:
+      - '248'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:32:46 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:20:39 GMT
+      transfer-encoding:
+      - chunked
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
+      x-kong-proxy-latency:
       - '2'
-      X-Kong-Upstream-Latency:
-      - '2881'
+      x-kong-upstream-latency:
+      - '779'
     status:
       code: 200
       message: OK

--- a/tests/fixtures/cassettes/hetzner/IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_fqdn_name_and_content.yaml
+++ b/tests/fixtures/cassettes/hetzner/IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_fqdn_name_and_content.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -11,44 +11,44 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
     uri: https://dns.hetzner.com/api/v1/zones
   response:
     body:
-      string: '{"zones":[{"id":"xyncsydKx5x44qDZQCzpNM","name":"alt.coop","ttl":300,"registrar":"","legacy_dns_host":"","legacy_ns":["helium.ns.hetzner.com.","oxygen.ns.hetzner.com.","hydrogen.ns.hetzner.com."],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-07
-        01:23:59 +0000 UTC","verified":"2020-04-07 01:53:05.934062806 +0000 UTC m=+578.060435172","modified":"2020-04-08
-        10:38:16.278 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":75},{"id":"JkBqVJDW3PpqefBb274BCZ","name":"softwarekollektiv.de","ttl":86400,"registrar":"","legacy_dns_host":"","legacy_ns":[],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-08
-        18:53:25.589 +0000 UTC","verified":"2020-04-08T18:53:27Z","modified":"2020-04-13
-        15:17:43.767 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":3}],"meta":{"pagination":{"page":1,"per_page":100,"previous_page":1,"next_page":1,"last_page":1,"total_entries":2}}}
+      string: !!python/unicode '{"zones":[{"id":"hetznerapizoneid","name":"hetzner-api-test.de","ttl":3600,"registrar":"","legacy_dns_host":"","legacy_ns":["ns1.first-ns.de.","robotns2.second-ns.de.","robotns3.second-ns.com."],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-07
+        01:24:00 +0000 UTC","verified":"2020-04-07 01:51:26.114056422 +0000 UTC m=+478.240428717","modified":"2020-06-11
+        07:02:20.999 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":9}],"meta":{"pagination":{"page":1,"per_page":100,"previous_page":1,"next_page":1,"last_page":1,"total_entries":12}}}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '1329'
-      Content-Type:
+      content-length:
+      - '7887'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:32:47 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:20:39 GMT
+      transfer-encoding:
+      - chunked
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
+      x-kong-proxy-latency:
       - '1'
-      X-Kong-Upstream-Latency:
-      - '195'
+      x-kong-upstream-latency:
+      - '235'
     status:
       code: 200
       message: OK
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -59,45 +59,56 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
-    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=JkBqVJDW3PpqefBb274BCZ
+    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=hetznerapizoneid
   response:
     body:
-      string: '{"records":[{"id":"kPbit4mpJa5pNU6dbFXpp3","type":"SOA","name":"@","value":"ns1.your-server.de.
-        dns.hetzner.com. 2020041572 86400 7200 3600000 3600","zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        15:17:43.061 +0000 UTC","modified":"2020-04-13 20:32:46.168 +0000 UTC"},{"id":"xbSVZRkvraCx2ZJkB5Stwh","type":"A","name":"localhost.softwarekollektiv.de.","value":"127.0.0.1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:37.644 +0000 UTC","modified":"2020-04-13 20:32:37.644 +0000 UTC"},{"id":"BotQ9nkmc8HHJpnkDNH9NS","type":"CNAME","name":"docs.softwarekollektiv.de.","value":"docs.example.com","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:43.98 +0000 UTC","modified":"2020-04-13 20:32:43.98 +0000 UTC"}]}
+      string: !!python/unicode '{"records":[{"id":"9720b5653ca6fd0517ec91a8c6104685","type":"SOA","name":"@","value":"ns1.first-ns.de.
+        dns.hetzner.com. 2020061202 14400 3600 1814400 3600","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:24:42 +0000 UTC","modified":"2020-06-12 08:20:39.027 +0000 UTC"},{"id":"5b378a7097bdb11e6cbb5f58db6bb101","type":"MX","name":"@","value":"10
+        mail.server-zugang.eu.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:12 +0000 UTC","modified":"2020-04-07 01:25:12 +0000 UTC"},{"id":"a26cfdd36217e559c14b305a558f2a3c","type":"AAAA","name":"@","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"7d6f741802597845b97713596e35eaa7","type":"AAAA","name":"*","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"993bafd3e3b110a6a3acde9fe874426a","type":"NS","name":"@","value":"ns1.first-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"cc3e8297060b7bd794fed5fdec3ed91b","type":"NS","name":"@","value":"robotns2.second-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"c4602b1239d9f0747016f551c52b5774","type":"NS","name":"@","value":"robotns3.second-ns.com.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"77ae87e42a04bace81119eb2280c8dca","type":"A","name":"@","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"faff62d59434c666bac4174a1d18a955","type":"A","name":"*","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"fe6ac2081c630974662caeaa8715d435","type":"A","name":"localhost","value":"127.0.0.1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:37.307 +0000 UTC","modified":"2020-06-12 08:20:37.307 +0000 UTC"},{"id":"8e6b81a856d20f0c1802703b56d1b53d","type":"CNAME","name":"docs","value":"docs.example.com","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:38.743 +0000 UTC","modified":"2020-06-12 08:20:38.743 +0000 UTC"}]}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '770'
-      Content-Type:
+      content-length:
+      - '2473'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:32:50 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:20:40 GMT
+      transfer-encoding:
+      - chunked
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
+      x-kong-proxy-latency:
       - '2'
-      X-Kong-Upstream-Latency:
-      - '3698'
+      x-kong-upstream-latency:
+      - '73'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"name": "_acme-challenge.fqdn.softwarekollektiv.de.", "type": "TXT", "value":
-      "challengetoken", "zone_id": "JkBqVJDW3PpqefBb274BCZ", "ttl": 3600}'
+    body: !!python/unicode '{"ttl": 3600, "type": "TXT", "name": "_acme-challenge.fqdn",
+      "value": "challengetoken", "zone_id": "hetznerapizoneid"}'
     headers:
       Accept:
       - '*/*'
@@ -106,38 +117,40 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '146'
+      - '124'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: POST
     uri: https://dns.hetzner.com/api/v1/records
   response:
     body:
-      string: '{"record":{"id":"625NbWVVrL96oBE972Si5F","type":"TXT","name":"_acme-challenge.fqdn.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:51.209 +0000 UTC","modified":"2020-04-13 20:32:51.209 +0000 UTC"}}
+      string: !!python/unicode '{"record":{"id":"a5fc9854314c160019d9bd0fcaaf2e2a","type":"TXT","name":"_acme-challenge.fqdn","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:40.141 +0000 UTC","modified":"2020-06-12 08:20:40.141 +0000 UTC"}}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '272'
-      Content-Type:
+      content-length:
+      - '260'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:32:54 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:20:40 GMT
+      transfer-encoding:
+      - chunked
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
-      - '2'
-      X-Kong-Upstream-Latency:
-      - '3584'
+      x-kong-proxy-latency:
+      - '1'
+      x-kong-upstream-latency:
+      - '695'
     status:
       code: 200
       message: OK

--- a/tests/fixtures/cassettes/hetzner/IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_full_name_and_content.yaml
+++ b/tests/fixtures/cassettes/hetzner/IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_full_name_and_content.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -11,44 +11,44 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
     uri: https://dns.hetzner.com/api/v1/zones
   response:
     body:
-      string: '{"zones":[{"id":"xyncsydKx5x44qDZQCzpNM","name":"alt.coop","ttl":300,"registrar":"","legacy_dns_host":"","legacy_ns":["oxygen.ns.hetzner.com.","hydrogen.ns.hetzner.com.","helium.ns.hetzner.com."],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-07
-        01:23:59 +0000 UTC","verified":"2020-04-07 01:53:05.934062806 +0000 UTC m=+578.060435172","modified":"2020-04-08
-        10:38:16.278 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":75},{"id":"JkBqVJDW3PpqefBb274BCZ","name":"softwarekollektiv.de","ttl":86400,"registrar":"","legacy_dns_host":"","legacy_ns":[],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-08
-        18:53:25.589 +0000 UTC","verified":"2020-04-08T18:53:27Z","modified":"2020-04-13
-        15:17:43.767 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":3}],"meta":{"pagination":{"page":1,"per_page":100,"previous_page":1,"next_page":1,"last_page":1,"total_entries":2}}}
+      string: !!python/unicode '{"zones":[{"id":"hetznerapizoneid","name":"hetzner-api-test.de","ttl":3600,"registrar":"","legacy_dns_host":"","legacy_ns":["ns1.first-ns.de.","robotns2.second-ns.de.","robotns3.second-ns.com."],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-07
+        01:24:00 +0000 UTC","verified":"2020-04-07 01:51:26.114056422 +0000 UTC m=+478.240428717","modified":"2020-06-11
+        07:02:20.999 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":9}],"meta":{"pagination":{"page":1,"per_page":100,"previous_page":1,"next_page":1,"last_page":1,"total_entries":12}}}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '1329'
-      Content-Type:
+      content-length:
+      - '7887'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:32:55 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:20:41 GMT
+      transfer-encoding:
+      - chunked
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
+      x-kong-proxy-latency:
       - '1'
-      X-Kong-Upstream-Latency:
-      - '182'
+      x-kong-upstream-latency:
+      - '234'
     status:
       code: 200
       message: OK
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -59,46 +59,57 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
-    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=JkBqVJDW3PpqefBb274BCZ
+    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=hetznerapizoneid
   response:
     body:
-      string: '{"records":[{"id":"kPbit4mpJa5pNU6dbFXpp3","type":"SOA","name":"@","value":"ns1.your-server.de.
-        dns.hetzner.com. 2020041573 86400 7200 3600000 3600","zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        15:17:43.061 +0000 UTC","modified":"2020-04-13 20:32:54.17 +0000 UTC"},{"id":"xbSVZRkvraCx2ZJkB5Stwh","type":"A","name":"localhost.softwarekollektiv.de.","value":"127.0.0.1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:37.644 +0000 UTC","modified":"2020-04-13 20:32:37.644 +0000 UTC"},{"id":"BotQ9nkmc8HHJpnkDNH9NS","type":"CNAME","name":"docs.softwarekollektiv.de.","value":"docs.example.com","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:43.98 +0000 UTC","modified":"2020-04-13 20:32:43.98 +0000 UTC"},{"id":"625NbWVVrL96oBE972Si5F","type":"TXT","name":"_acme-challenge.fqdn.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:51.209 +0000 UTC","modified":"2020-04-13 20:32:51.209 +0000 UTC"}]}
+      string: !!python/unicode '{"records":[{"id":"9720b5653ca6fd0517ec91a8c6104685","type":"SOA","name":"@","value":"ns1.first-ns.de.
+        dns.hetzner.com. 2020061203 14400 3600 1814400 3600","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:24:42 +0000 UTC","modified":"2020-06-12 08:20:40.246 +0000 UTC"},{"id":"5b378a7097bdb11e6cbb5f58db6bb101","type":"MX","name":"@","value":"10
+        mail.server-zugang.eu.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:12 +0000 UTC","modified":"2020-04-07 01:25:12 +0000 UTC"},{"id":"a26cfdd36217e559c14b305a558f2a3c","type":"AAAA","name":"@","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"7d6f741802597845b97713596e35eaa7","type":"AAAA","name":"*","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"993bafd3e3b110a6a3acde9fe874426a","type":"NS","name":"@","value":"ns1.first-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"cc3e8297060b7bd794fed5fdec3ed91b","type":"NS","name":"@","value":"robotns2.second-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"c4602b1239d9f0747016f551c52b5774","type":"NS","name":"@","value":"robotns3.second-ns.com.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"77ae87e42a04bace81119eb2280c8dca","type":"A","name":"@","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"faff62d59434c666bac4174a1d18a955","type":"A","name":"*","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"fe6ac2081c630974662caeaa8715d435","type":"A","name":"localhost","value":"127.0.0.1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:37.307 +0000 UTC","modified":"2020-06-12 08:20:37.307 +0000 UTC"},{"id":"8e6b81a856d20f0c1802703b56d1b53d","type":"CNAME","name":"docs","value":"docs.example.com","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:38.743 +0000 UTC","modified":"2020-06-12 08:20:38.743 +0000 UTC"},{"id":"a5fc9854314c160019d9bd0fcaaf2e2a","type":"TXT","name":"_acme-challenge.fqdn","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:40.141 +0000 UTC","modified":"2020-06-12 08:20:40.141 +0000 UTC"}]}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '1030'
-      Content-Type:
+      content-length:
+      - '2722'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:32:59 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:20:41 GMT
+      transfer-encoding:
+      - chunked
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
-      - '6'
-      X-Kong-Upstream-Latency:
-      - '4038'
+      x-kong-proxy-latency:
+      - '1'
+      x-kong-upstream-latency:
+      - '49'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"name": "_acme-challenge.full.softwarekollektiv.de.", "type": "TXT", "value":
-      "challengetoken", "zone_id": "JkBqVJDW3PpqefBb274BCZ", "ttl": 3600}'
+    body: !!python/unicode '{"ttl": 3600, "type": "TXT", "name": "_acme-challenge.full",
+      "value": "challengetoken", "zone_id": "hetznerapizoneid"}'
     headers:
       Accept:
       - '*/*'
@@ -107,38 +118,40 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '146'
+      - '124'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: POST
     uri: https://dns.hetzner.com/api/v1/records
   response:
     body:
-      string: '{"record":{"id":"oN3QiMz8V6fmJEboVdyxTb","type":"TXT","name":"_acme-challenge.full.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:59.487 +0000 UTC","modified":"2020-04-13 20:32:59.487 +0000 UTC"}}
+      string: !!python/unicode '{"record":{"id":"101296724cdf3710d18ea43a06b39e6c","type":"TXT","name":"_acme-challenge.full","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:41.421 +0000 UTC","modified":"2020-06-12 08:20:41.421 +0000 UTC"}}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '272'
-      Content-Type:
+      content-length:
+      - '260'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:33:03 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:20:42 GMT
+      transfer-encoding:
+      - chunked
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
-      - '1'
-      X-Kong-Upstream-Latency:
-      - '4244'
+      x-kong-proxy-latency:
+      - '2'
+      x-kong-upstream-latency:
+      - '623'
     status:
       code: 200
       message: OK

--- a/tests/fixtures/cassettes/hetzner/IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/hetzner/IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_valid_name_and_content.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -11,44 +11,44 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
     uri: https://dns.hetzner.com/api/v1/zones
   response:
     body:
-      string: '{"zones":[{"id":"xyncsydKx5x44qDZQCzpNM","name":"alt.coop","ttl":300,"registrar":"","legacy_dns_host":"","legacy_ns":["oxygen.ns.hetzner.com.","hydrogen.ns.hetzner.com.","helium.ns.hetzner.com."],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-07
-        01:23:59 +0000 UTC","verified":"2020-04-07 01:53:05.934062806 +0000 UTC m=+578.060435172","modified":"2020-04-08
-        10:38:16.278 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":75},{"id":"JkBqVJDW3PpqefBb274BCZ","name":"softwarekollektiv.de","ttl":86400,"registrar":"","legacy_dns_host":"","legacy_ns":[],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-08
-        18:53:25.589 +0000 UTC","verified":"2020-04-08T18:53:27Z","modified":"2020-04-13
-        15:17:43.767 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":5}],"meta":{"pagination":{"page":1,"per_page":100,"previous_page":1,"next_page":1,"last_page":1,"total_entries":2}}}
+      string: !!python/unicode '{"zones":[{"id":"hetznerapizoneid","name":"hetzner-api-test.de","ttl":3600,"registrar":"","legacy_dns_host":"","legacy_ns":["ns1.first-ns.de.","robotns2.second-ns.de.","robotns3.second-ns.com."],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-07
+        01:24:00 +0000 UTC","verified":"2020-04-07 01:51:26.114056422 +0000 UTC m=+478.240428717","modified":"2020-06-11
+        07:02:20.999 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":9}],"meta":{"pagination":{"page":1,"per_page":100,"previous_page":1,"next_page":1,"last_page":1,"total_entries":12}}}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '1329'
-      Content-Type:
+      content-length:
+      - '7887'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:33:04 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:20:42 GMT
+      transfer-encoding:
+      - chunked
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
+      x-kong-proxy-latency:
       - '1'
-      X-Kong-Upstream-Latency:
-      - '190'
+      x-kong-upstream-latency:
+      - '290'
     status:
       code: 200
       message: OK
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -59,47 +59,58 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
-    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=JkBqVJDW3PpqefBb274BCZ
+    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=hetznerapizoneid
   response:
     body:
-      string: '{"records":[{"id":"kPbit4mpJa5pNU6dbFXpp3","type":"SOA","name":"@","value":"ns1.your-server.de.
-        dns.hetzner.com. 2020041574 86400 7200 3600000 3600","zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        15:17:43.061 +0000 UTC","modified":"2020-04-13 20:33:02.973 +0000 UTC"},{"id":"xbSVZRkvraCx2ZJkB5Stwh","type":"A","name":"localhost.softwarekollektiv.de.","value":"127.0.0.1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:37.644 +0000 UTC","modified":"2020-04-13 20:32:37.644 +0000 UTC"},{"id":"BotQ9nkmc8HHJpnkDNH9NS","type":"CNAME","name":"docs.softwarekollektiv.de.","value":"docs.example.com","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:43.98 +0000 UTC","modified":"2020-04-13 20:32:43.98 +0000 UTC"},{"id":"625NbWVVrL96oBE972Si5F","type":"TXT","name":"_acme-challenge.fqdn.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:51.209 +0000 UTC","modified":"2020-04-13 20:32:51.209 +0000 UTC"},{"id":"oN3QiMz8V6fmJEboVdyxTb","type":"TXT","name":"_acme-challenge.full.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:59.487 +0000 UTC","modified":"2020-04-13 20:32:59.487 +0000 UTC"}]}
+      string: !!python/unicode '{"records":[{"id":"9720b5653ca6fd0517ec91a8c6104685","type":"SOA","name":"@","value":"ns1.first-ns.de.
+        dns.hetzner.com. 2020061204 14400 3600 1814400 3600","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:24:42 +0000 UTC","modified":"2020-06-12 08:20:41.509 +0000 UTC"},{"id":"5b378a7097bdb11e6cbb5f58db6bb101","type":"MX","name":"@","value":"10
+        mail.server-zugang.eu.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:12 +0000 UTC","modified":"2020-04-07 01:25:12 +0000 UTC"},{"id":"a26cfdd36217e559c14b305a558f2a3c","type":"AAAA","name":"@","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"7d6f741802597845b97713596e35eaa7","type":"AAAA","name":"*","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"993bafd3e3b110a6a3acde9fe874426a","type":"NS","name":"@","value":"ns1.first-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"cc3e8297060b7bd794fed5fdec3ed91b","type":"NS","name":"@","value":"robotns2.second-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"c4602b1239d9f0747016f551c52b5774","type":"NS","name":"@","value":"robotns3.second-ns.com.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"77ae87e42a04bace81119eb2280c8dca","type":"A","name":"@","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"faff62d59434c666bac4174a1d18a955","type":"A","name":"*","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"fe6ac2081c630974662caeaa8715d435","type":"A","name":"localhost","value":"127.0.0.1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:37.307 +0000 UTC","modified":"2020-06-12 08:20:37.307 +0000 UTC"},{"id":"8e6b81a856d20f0c1802703b56d1b53d","type":"CNAME","name":"docs","value":"docs.example.com","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:38.743 +0000 UTC","modified":"2020-06-12 08:20:38.743 +0000 UTC"},{"id":"a5fc9854314c160019d9bd0fcaaf2e2a","type":"TXT","name":"_acme-challenge.fqdn","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:40.141 +0000 UTC","modified":"2020-06-12 08:20:40.141 +0000 UTC"},{"id":"101296724cdf3710d18ea43a06b39e6c","type":"TXT","name":"_acme-challenge.full","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:41.421 +0000 UTC","modified":"2020-06-12 08:20:41.421 +0000 UTC"}]}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '1292'
-      Content-Type:
+      content-length:
+      - '2971'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:33:07 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:20:43 GMT
+      transfer-encoding:
+      - chunked
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
+      x-kong-proxy-latency:
       - '1'
-      X-Kong-Upstream-Latency:
-      - '3615'
+      x-kong-upstream-latency:
+      - '694'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"name": "_acme-challenge.test.softwarekollektiv.de.", "type": "TXT", "value":
-      "challengetoken", "zone_id": "JkBqVJDW3PpqefBb274BCZ", "ttl": 3600}'
+    body: !!python/unicode '{"ttl": 3600, "type": "TXT", "name": "_acme-challenge.test",
+      "value": "challengetoken", "zone_id": "hetznerapizoneid"}'
     headers:
       Accept:
       - '*/*'
@@ -108,38 +119,40 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '146'
+      - '124'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: POST
     uri: https://dns.hetzner.com/api/v1/records
   response:
     body:
-      string: '{"record":{"id":"Ko6JBd4bUcHhNnoraHNoFR","type":"TXT","name":"_acme-challenge.test.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:08.017 +0000 UTC","modified":"2020-04-13 20:33:08.017 +0000 UTC"}}
+      string: !!python/unicode '{"record":{"id":"1c06fee6923324bc2727916d2157b3d8","type":"TXT","name":"_acme-challenge.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:43.363 +0000 UTC","modified":"2020-06-12 08:20:43.363 +0000 UTC"}}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '272'
-      Content-Type:
+      content-length:
+      - '260'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:33:10 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:20:43 GMT
+      transfer-encoding:
+      - chunked
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
-      - '0'
-      X-Kong-Upstream-Latency:
-      - '2965'
+      x-kong-proxy-latency:
+      - '1'
+      x-kong-upstream-latency:
+      - '597'
     status:
       code: 200
       message: OK

--- a/tests/fixtures/cassettes/hetzner/IntegrationTests/test_provider_when_calling_create_record_multiple_times_should_create_record_set.yaml
+++ b/tests/fixtures/cassettes/hetzner/IntegrationTests/test_provider_when_calling_create_record_multiple_times_should_create_record_set.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -11,44 +11,44 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
     uri: https://dns.hetzner.com/api/v1/zones
   response:
     body:
-      string: '{"zones":[{"id":"xyncsydKx5x44qDZQCzpNM","name":"alt.coop","ttl":300,"registrar":"","legacy_dns_host":"","legacy_ns":["hydrogen.ns.hetzner.com.","helium.ns.hetzner.com.","oxygen.ns.hetzner.com."],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-07
-        01:23:59 +0000 UTC","verified":"2020-04-07 01:53:05.934062806 +0000 UTC m=+578.060435172","modified":"2020-04-08
-        10:38:16.278 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":75},{"id":"JkBqVJDW3PpqefBb274BCZ","name":"softwarekollektiv.de","ttl":86400,"registrar":"","legacy_dns_host":"","legacy_ns":[],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-08
-        18:53:25.589 +0000 UTC","verified":"2020-04-08T18:53:27Z","modified":"2020-04-13
-        15:17:43.767 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":5}],"meta":{"pagination":{"page":1,"per_page":100,"previous_page":1,"next_page":1,"last_page":1,"total_entries":2}}}
+      string: !!python/unicode '{"zones":[{"id":"hetznerapizoneid","name":"hetzner-api-test.de","ttl":3600,"registrar":"","legacy_dns_host":"","legacy_ns":["ns1.first-ns.de.","robotns2.second-ns.de.","robotns3.second-ns.com."],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-07
+        01:24:00 +0000 UTC","verified":"2020-04-07 01:51:26.114056422 +0000 UTC m=+478.240428717","modified":"2020-06-11
+        07:02:20.999 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":9}],"meta":{"pagination":{"page":1,"per_page":100,"previous_page":1,"next_page":1,"last_page":1,"total_entries":12}}}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '1329'
-      Content-Type:
+      content-length:
+      - '7887'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:33:11 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:20:44 GMT
+      transfer-encoding:
+      - chunked
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
-      - '1'
-      X-Kong-Upstream-Latency:
-      - '179'
+      x-kong-proxy-latency:
+      - '2'
+      x-kong-upstream-latency:
+      - '221'
     status:
       code: 200
       message: OK
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -59,49 +59,59 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
-    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=JkBqVJDW3PpqefBb274BCZ
+    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=hetznerapizoneid
   response:
     body:
-      string: '{"records":[{"id":"kPbit4mpJa5pNU6dbFXpp3","type":"SOA","name":"@","value":"ns1.your-server.de.
-        dns.hetzner.com. 2020041575 86400 7200 3600000 3600","zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        15:17:43.061 +0000 UTC","modified":"2020-04-13 20:33:10.274 +0000 UTC"},{"id":"xbSVZRkvraCx2ZJkB5Stwh","type":"A","name":"localhost.softwarekollektiv.de.","value":"127.0.0.1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:37.644 +0000 UTC","modified":"2020-04-13 20:32:37.644 +0000 UTC"},{"id":"BotQ9nkmc8HHJpnkDNH9NS","type":"CNAME","name":"docs.softwarekollektiv.de.","value":"docs.example.com","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:43.98 +0000 UTC","modified":"2020-04-13 20:32:43.98 +0000 UTC"},{"id":"625NbWVVrL96oBE972Si5F","type":"TXT","name":"_acme-challenge.fqdn.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:51.209 +0000 UTC","modified":"2020-04-13 20:32:51.209 +0000 UTC"},{"id":"oN3QiMz8V6fmJEboVdyxTb","type":"TXT","name":"_acme-challenge.full.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:59.487 +0000 UTC","modified":"2020-04-13 20:32:59.487 +0000 UTC"},{"id":"Ko6JBd4bUcHhNnoraHNoFR","type":"TXT","name":"_acme-challenge.test.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:08.017 +0000 UTC","modified":"2020-04-13 20:33:08.017 +0000 UTC"}]}
+      string: !!python/unicode '{"records":[{"id":"9720b5653ca6fd0517ec91a8c6104685","type":"SOA","name":"@","value":"ns1.first-ns.de.
+        dns.hetzner.com. 2020061205 14400 3600 1814400 3600","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:24:42 +0000 UTC","modified":"2020-06-12 08:20:43.461 +0000 UTC"},{"id":"5b378a7097bdb11e6cbb5f58db6bb101","type":"MX","name":"@","value":"10
+        mail.server-zugang.eu.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:12 +0000 UTC","modified":"2020-04-07 01:25:12 +0000 UTC"},{"id":"a26cfdd36217e559c14b305a558f2a3c","type":"AAAA","name":"@","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"7d6f741802597845b97713596e35eaa7","type":"AAAA","name":"*","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"993bafd3e3b110a6a3acde9fe874426a","type":"NS","name":"@","value":"ns1.first-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"cc3e8297060b7bd794fed5fdec3ed91b","type":"NS","name":"@","value":"robotns2.second-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"c4602b1239d9f0747016f551c52b5774","type":"NS","name":"@","value":"robotns3.second-ns.com.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"77ae87e42a04bace81119eb2280c8dca","type":"A","name":"@","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"faff62d59434c666bac4174a1d18a955","type":"A","name":"*","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"fe6ac2081c630974662caeaa8715d435","type":"A","name":"localhost","value":"127.0.0.1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:37.307 +0000 UTC","modified":"2020-06-12 08:20:37.307 +0000 UTC"},{"id":"8e6b81a856d20f0c1802703b56d1b53d","type":"CNAME","name":"docs","value":"docs.example.com","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:38.743 +0000 UTC","modified":"2020-06-12 08:20:38.743 +0000 UTC"},{"id":"a5fc9854314c160019d9bd0fcaaf2e2a","type":"TXT","name":"_acme-challenge.fqdn","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:40.141 +0000 UTC","modified":"2020-06-12 08:20:40.141 +0000 UTC"},{"id":"101296724cdf3710d18ea43a06b39e6c","type":"TXT","name":"_acme-challenge.full","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:41.421 +0000 UTC","modified":"2020-06-12 08:20:41.421 +0000 UTC"},{"id":"1c06fee6923324bc2727916d2157b3d8","type":"TXT","name":"_acme-challenge.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:43.363 +0000 UTC","modified":"2020-06-12 08:20:43.363 +0000 UTC"}]}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '1553'
-      Content-Type:
+      content-length:
+      - '3220'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:33:17 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:20:44 GMT
+      transfer-encoding:
+      - chunked
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
-      - '2'
-      X-Kong-Upstream-Latency:
-      - '6315'
+      x-kong-proxy-latency:
+      - '1'
+      x-kong-upstream-latency:
+      - '70'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"name": "_acme-challenge.createrecordset.softwarekollektiv.de.", "type":
-      "TXT", "value": "challengetoken1", "zone_id": "JkBqVJDW3PpqefBb274BCZ", "ttl":
-      3600}'
+    body: !!python/unicode '{"ttl": 3600, "type": "TXT", "name": "_acme-challenge.createrecordset",
+      "value": "challengetoken1", "zone_id": "hetznerapizoneid"}'
     headers:
       Accept:
       - '*/*'
@@ -110,43 +120,45 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '158'
+      - '136'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: POST
     uri: https://dns.hetzner.com/api/v1/records
   response:
     body:
-      string: '{"record":{"id":"beBTaU99WWcg3j3CT6nWgg","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:18.136 +0000 UTC","modified":"2020-04-13 20:33:18.136 +0000 UTC"}}
+      string: !!python/unicode '{"record":{"id":"97dcfc7f529a65b944a11554e15dcdfb","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:44.557 +0000 UTC","modified":"2020-06-12 08:20:44.557 +0000 UTC"}}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '284'
-      Content-Type:
+      content-length:
+      - '272'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:33:21 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:20:45 GMT
+      transfer-encoding:
+      - chunked
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
+      x-kong-proxy-latency:
       - '1'
-      X-Kong-Upstream-Latency:
-      - '3839'
+      x-kong-upstream-latency:
+      - '657'
     status:
       code: 200
       message: OK
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -157,50 +169,60 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
-    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=JkBqVJDW3PpqefBb274BCZ
+    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=hetznerapizoneid
   response:
     body:
-      string: '{"records":[{"id":"kPbit4mpJa5pNU6dbFXpp3","type":"SOA","name":"@","value":"ns1.your-server.de.
-        dns.hetzner.com. 2020041576 86400 7200 3600000 3600","zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        15:17:43.061 +0000 UTC","modified":"2020-04-13 20:33:21.31 +0000 UTC"},{"id":"xbSVZRkvraCx2ZJkB5Stwh","type":"A","name":"localhost.softwarekollektiv.de.","value":"127.0.0.1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:37.644 +0000 UTC","modified":"2020-04-13 20:32:37.644 +0000 UTC"},{"id":"BotQ9nkmc8HHJpnkDNH9NS","type":"CNAME","name":"docs.softwarekollektiv.de.","value":"docs.example.com","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:43.98 +0000 UTC","modified":"2020-04-13 20:32:43.98 +0000 UTC"},{"id":"625NbWVVrL96oBE972Si5F","type":"TXT","name":"_acme-challenge.fqdn.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:51.209 +0000 UTC","modified":"2020-04-13 20:32:51.209 +0000 UTC"},{"id":"oN3QiMz8V6fmJEboVdyxTb","type":"TXT","name":"_acme-challenge.full.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:59.487 +0000 UTC","modified":"2020-04-13 20:32:59.487 +0000 UTC"},{"id":"Ko6JBd4bUcHhNnoraHNoFR","type":"TXT","name":"_acme-challenge.test.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:08.017 +0000 UTC","modified":"2020-04-13 20:33:08.017 +0000 UTC"},{"id":"beBTaU99WWcg3j3CT6nWgg","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:18.136 +0000 UTC","modified":"2020-04-13 20:33:18.136 +0000 UTC"}]}
+      string: !!python/unicode '{"records":[{"id":"9720b5653ca6fd0517ec91a8c6104685","type":"SOA","name":"@","value":"ns1.first-ns.de.
+        dns.hetzner.com. 2020061206 14400 3600 1814400 3600","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:24:42 +0000 UTC","modified":"2020-06-12 08:20:44.65 +0000 UTC"},{"id":"5b378a7097bdb11e6cbb5f58db6bb101","type":"MX","name":"@","value":"10
+        mail.server-zugang.eu.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:12 +0000 UTC","modified":"2020-04-07 01:25:12 +0000 UTC"},{"id":"a26cfdd36217e559c14b305a558f2a3c","type":"AAAA","name":"@","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"7d6f741802597845b97713596e35eaa7","type":"AAAA","name":"*","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"993bafd3e3b110a6a3acde9fe874426a","type":"NS","name":"@","value":"ns1.first-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"cc3e8297060b7bd794fed5fdec3ed91b","type":"NS","name":"@","value":"robotns2.second-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"c4602b1239d9f0747016f551c52b5774","type":"NS","name":"@","value":"robotns3.second-ns.com.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"77ae87e42a04bace81119eb2280c8dca","type":"A","name":"@","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"faff62d59434c666bac4174a1d18a955","type":"A","name":"*","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"fe6ac2081c630974662caeaa8715d435","type":"A","name":"localhost","value":"127.0.0.1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:37.307 +0000 UTC","modified":"2020-06-12 08:20:37.307 +0000 UTC"},{"id":"8e6b81a856d20f0c1802703b56d1b53d","type":"CNAME","name":"docs","value":"docs.example.com","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:38.743 +0000 UTC","modified":"2020-06-12 08:20:38.743 +0000 UTC"},{"id":"a5fc9854314c160019d9bd0fcaaf2e2a","type":"TXT","name":"_acme-challenge.fqdn","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:40.141 +0000 UTC","modified":"2020-06-12 08:20:40.141 +0000 UTC"},{"id":"101296724cdf3710d18ea43a06b39e6c","type":"TXT","name":"_acme-challenge.full","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:41.421 +0000 UTC","modified":"2020-06-12 08:20:41.421 +0000 UTC"},{"id":"1c06fee6923324bc2727916d2157b3d8","type":"TXT","name":"_acme-challenge.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:43.363 +0000 UTC","modified":"2020-06-12 08:20:43.363 +0000 UTC"},{"id":"97dcfc7f529a65b944a11554e15dcdfb","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:44.557 +0000 UTC","modified":"2020-06-12 08:20:44.557 +0000 UTC"}]}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '1825'
-      Content-Type:
+      content-length:
+      - '3480'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:33:25 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:20:45 GMT
+      transfer-encoding:
+      - chunked
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
-      - '1'
-      X-Kong-Upstream-Latency:
-      - '3618'
+      x-kong-proxy-latency:
+      - '2'
+      x-kong-upstream-latency:
+      - '71'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"name": "_acme-challenge.createrecordset.softwarekollektiv.de.", "type":
-      "TXT", "value": "challengetoken2", "zone_id": "JkBqVJDW3PpqefBb274BCZ", "ttl":
-      3600}'
+    body: !!python/unicode '{"ttl": 3600, "type": "TXT", "name": "_acme-challenge.createrecordset",
+      "value": "challengetoken2", "zone_id": "hetznerapizoneid"}'
     headers:
       Accept:
       - '*/*'
@@ -209,38 +231,40 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '158'
+      - '136'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: POST
     uri: https://dns.hetzner.com/api/v1/records
   response:
     body:
-      string: '{"record":{"id":"jM2j9P6TLSAGNPbBiwjKPj","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:25.929 +0000 UTC","modified":"2020-04-13 20:33:25.929 +0000 UTC"}}
+      string: !!python/unicode '{"record":{"id":"880d3713398b9301dda21a611cbd9ab0","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:45.499 +0000 UTC","modified":"2020-06-12 08:20:45.499 +0000 UTC"}}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '284'
-      Content-Type:
+      content-length:
+      - '272'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:33:29 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:20:46 GMT
+      transfer-encoding:
+      - chunked
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
+      x-kong-proxy-latency:
       - '1'
-      X-Kong-Upstream-Latency:
-      - '3483'
+      x-kong-upstream-latency:
+      - '645'
     status:
       code: 200
       message: OK

--- a/tests/fixtures/cassettes/hetzner/IntegrationTests/test_provider_when_calling_create_record_with_duplicate_records_should_be_noop.yaml
+++ b/tests/fixtures/cassettes/hetzner/IntegrationTests/test_provider_when_calling_create_record_with_duplicate_records_should_be_noop.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -11,44 +11,44 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
     uri: https://dns.hetzner.com/api/v1/zones
   response:
     body:
-      string: '{"zones":[{"id":"xyncsydKx5x44qDZQCzpNM","name":"alt.coop","ttl":300,"registrar":"","legacy_dns_host":"","legacy_ns":["oxygen.ns.hetzner.com.","hydrogen.ns.hetzner.com.","helium.ns.hetzner.com."],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-07
-        01:23:59 +0000 UTC","verified":"2020-04-07 01:53:05.934062806 +0000 UTC m=+578.060435172","modified":"2020-04-08
-        10:38:16.278 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":75},{"id":"JkBqVJDW3PpqefBb274BCZ","name":"softwarekollektiv.de","ttl":86400,"registrar":"","legacy_dns_host":"","legacy_ns":[],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-08
-        18:53:25.589 +0000 UTC","verified":"2020-04-08T18:53:27Z","modified":"2020-04-13
-        15:17:43.767 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":7}],"meta":{"pagination":{"page":1,"per_page":100,"previous_page":1,"next_page":1,"last_page":1,"total_entries":2}}}
+      string: !!python/unicode '{"zones":[{"id":"hetznerapizoneid","name":"hetzner-api-test.de","ttl":3600,"registrar":"","legacy_dns_host":"","legacy_ns":["ns1.first-ns.de.","robotns2.second-ns.de.","robotns3.second-ns.com."],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-07
+        01:24:00 +0000 UTC","verified":"2020-04-07 01:51:26.114056422 +0000 UTC m=+478.240428717","modified":"2020-06-11
+        07:02:20.999 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":9}],"meta":{"pagination":{"page":1,"per_page":100,"previous_page":1,"next_page":1,"last_page":1,"total_entries":12}}}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '1329'
-      Content-Type:
+      content-length:
+      - '7887'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:33:29 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:20:46 GMT
+      transfer-encoding:
+      - chunked
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
-      - '2'
-      X-Kong-Upstream-Latency:
-      - '178'
+      x-kong-proxy-latency:
+      - '1'
+      x-kong-upstream-latency:
+      - '230'
     status:
       code: 200
       message: OK
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -59,50 +59,61 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
-    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=JkBqVJDW3PpqefBb274BCZ
+    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=hetznerapizoneid
   response:
     body:
-      string: '{"records":[{"id":"kPbit4mpJa5pNU6dbFXpp3","type":"SOA","name":"@","value":"ns1.your-server.de.
-        dns.hetzner.com. 2020041577 86400 7200 3600000 3600","zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        15:17:43.061 +0000 UTC","modified":"2020-04-13 20:33:28.671 +0000 UTC"},{"id":"xbSVZRkvraCx2ZJkB5Stwh","type":"A","name":"localhost.softwarekollektiv.de.","value":"127.0.0.1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:37.644 +0000 UTC","modified":"2020-04-13 20:32:37.644 +0000 UTC"},{"id":"BotQ9nkmc8HHJpnkDNH9NS","type":"CNAME","name":"docs.softwarekollektiv.de.","value":"docs.example.com","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:43.98 +0000 UTC","modified":"2020-04-13 20:32:43.98 +0000 UTC"},{"id":"625NbWVVrL96oBE972Si5F","type":"TXT","name":"_acme-challenge.fqdn.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:51.209 +0000 UTC","modified":"2020-04-13 20:32:51.209 +0000 UTC"},{"id":"oN3QiMz8V6fmJEboVdyxTb","type":"TXT","name":"_acme-challenge.full.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:59.487 +0000 UTC","modified":"2020-04-13 20:32:59.487 +0000 UTC"},{"id":"Ko6JBd4bUcHhNnoraHNoFR","type":"TXT","name":"_acme-challenge.test.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:08.017 +0000 UTC","modified":"2020-04-13 20:33:08.017 +0000 UTC"},{"id":"beBTaU99WWcg3j3CT6nWgg","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:18.136 +0000 UTC","modified":"2020-04-13 20:33:18.136 +0000 UTC"},{"id":"jM2j9P6TLSAGNPbBiwjKPj","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:25.929 +0000 UTC","modified":"2020-04-13 20:33:25.929 +0000 UTC"}]}
+      string: !!python/unicode '{"records":[{"id":"9720b5653ca6fd0517ec91a8c6104685","type":"SOA","name":"@","value":"ns1.first-ns.de.
+        dns.hetzner.com. 2020061207 14400 3600 1814400 3600","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:24:42 +0000 UTC","modified":"2020-06-12 08:20:45.608 +0000 UTC"},{"id":"5b378a7097bdb11e6cbb5f58db6bb101","type":"MX","name":"@","value":"10
+        mail.server-zugang.eu.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:12 +0000 UTC","modified":"2020-04-07 01:25:12 +0000 UTC"},{"id":"a26cfdd36217e559c14b305a558f2a3c","type":"AAAA","name":"@","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"7d6f741802597845b97713596e35eaa7","type":"AAAA","name":"*","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"993bafd3e3b110a6a3acde9fe874426a","type":"NS","name":"@","value":"ns1.first-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"cc3e8297060b7bd794fed5fdec3ed91b","type":"NS","name":"@","value":"robotns2.second-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"c4602b1239d9f0747016f551c52b5774","type":"NS","name":"@","value":"robotns3.second-ns.com.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"77ae87e42a04bace81119eb2280c8dca","type":"A","name":"@","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"faff62d59434c666bac4174a1d18a955","type":"A","name":"*","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"fe6ac2081c630974662caeaa8715d435","type":"A","name":"localhost","value":"127.0.0.1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:37.307 +0000 UTC","modified":"2020-06-12 08:20:37.307 +0000 UTC"},{"id":"8e6b81a856d20f0c1802703b56d1b53d","type":"CNAME","name":"docs","value":"docs.example.com","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:38.743 +0000 UTC","modified":"2020-06-12 08:20:38.743 +0000 UTC"},{"id":"a5fc9854314c160019d9bd0fcaaf2e2a","type":"TXT","name":"_acme-challenge.fqdn","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:40.141 +0000 UTC","modified":"2020-06-12 08:20:40.141 +0000 UTC"},{"id":"101296724cdf3710d18ea43a06b39e6c","type":"TXT","name":"_acme-challenge.full","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:41.421 +0000 UTC","modified":"2020-06-12 08:20:41.421 +0000 UTC"},{"id":"1c06fee6923324bc2727916d2157b3d8","type":"TXT","name":"_acme-challenge.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:43.363 +0000 UTC","modified":"2020-06-12 08:20:43.363 +0000 UTC"},{"id":"97dcfc7f529a65b944a11554e15dcdfb","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:44.557 +0000 UTC","modified":"2020-06-12 08:20:44.557 +0000 UTC"},{"id":"880d3713398b9301dda21a611cbd9ab0","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:45.499 +0000 UTC","modified":"2020-06-12 08:20:45.499 +0000 UTC"}]}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Type:
+      content-length:
+      - '3742'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:33:33 GMT
-      Transfer-Encoding:
+      date:
+      - Fri, 12 Jun 2020 08:20:46 GMT
+      transfer-encoding:
       - chunked
-      Vary:
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
+      x-kong-proxy-latency:
       - '1'
-      X-Kong-Upstream-Latency:
-      - '3615'
+      x-kong-upstream-latency:
+      - '68'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"name": "_acme-challenge.noop.softwarekollektiv.de.", "type": "TXT", "value":
-      "challengetoken", "zone_id": "JkBqVJDW3PpqefBb274BCZ", "ttl": 3600}'
+    body: !!python/unicode '{"ttl": 3600, "type": "TXT", "name": "_acme-challenge.noop",
+      "value": "challengetoken", "zone_id": "hetznerapizoneid"}'
     headers:
       Accept:
       - '*/*'
@@ -111,43 +122,45 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '146'
+      - '124'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: POST
     uri: https://dns.hetzner.com/api/v1/records
   response:
     body:
-      string: '{"record":{"id":"Ubdw2SbjGbBHHPVTYPwGPC","type":"TXT","name":"_acme-challenge.noop.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:33.653 +0000 UTC","modified":"2020-04-13 20:33:33.653 +0000 UTC"}}
+      string: !!python/unicode '{"record":{"id":"f794c3584778621edfa903a30a993f9b","type":"TXT","name":"_acme-challenge.noop","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:46.766 +0000 UTC","modified":"2020-06-12 08:20:46.766 +0000 UTC"}}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '272'
-      Content-Type:
+      content-length:
+      - '260'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:33:37 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:20:47 GMT
+      transfer-encoding:
+      - chunked
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
+      x-kong-proxy-latency:
       - '1'
-      X-Kong-Upstream-Latency:
-      - '3457'
+      x-kong-upstream-latency:
+      - '664'
     status:
       code: 200
       message: OK
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -158,50 +171,61 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
-    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=JkBqVJDW3PpqefBb274BCZ
+    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=hetznerapizoneid
   response:
     body:
-      string: '{"records":[{"id":"kPbit4mpJa5pNU6dbFXpp3","type":"SOA","name":"@","value":"ns1.your-server.de.
-        dns.hetzner.com. 2020041578 86400 7200 3600000 3600","zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        15:17:43.061 +0000 UTC","modified":"2020-04-13 20:33:36.369 +0000 UTC"},{"id":"xbSVZRkvraCx2ZJkB5Stwh","type":"A","name":"localhost.softwarekollektiv.de.","value":"127.0.0.1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:37.644 +0000 UTC","modified":"2020-04-13 20:32:37.644 +0000 UTC"},{"id":"BotQ9nkmc8HHJpnkDNH9NS","type":"CNAME","name":"docs.softwarekollektiv.de.","value":"docs.example.com","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:43.98 +0000 UTC","modified":"2020-04-13 20:32:43.98 +0000 UTC"},{"id":"625NbWVVrL96oBE972Si5F","type":"TXT","name":"_acme-challenge.fqdn.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:51.209 +0000 UTC","modified":"2020-04-13 20:32:51.209 +0000 UTC"},{"id":"oN3QiMz8V6fmJEboVdyxTb","type":"TXT","name":"_acme-challenge.full.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:59.487 +0000 UTC","modified":"2020-04-13 20:32:59.487 +0000 UTC"},{"id":"Ko6JBd4bUcHhNnoraHNoFR","type":"TXT","name":"_acme-challenge.test.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:08.017 +0000 UTC","modified":"2020-04-13 20:33:08.017 +0000 UTC"},{"id":"beBTaU99WWcg3j3CT6nWgg","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:18.136 +0000 UTC","modified":"2020-04-13 20:33:18.136 +0000 UTC"},{"id":"jM2j9P6TLSAGNPbBiwjKPj","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:25.929 +0000 UTC","modified":"2020-04-13 20:33:25.929 +0000 UTC"},{"id":"Ubdw2SbjGbBHHPVTYPwGPC","type":"TXT","name":"_acme-challenge.noop.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:33.653 +0000 UTC","modified":"2020-04-13 20:33:33.653 +0000 UTC"}]}
+      string: !!python/unicode '{"records":[{"id":"9720b5653ca6fd0517ec91a8c6104685","type":"SOA","name":"@","value":"ns1.first-ns.de.
+        dns.hetzner.com. 2020061208 14400 3600 1814400 3600","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:24:42 +0000 UTC","modified":"2020-06-12 08:20:46.89 +0000 UTC"},{"id":"5b378a7097bdb11e6cbb5f58db6bb101","type":"MX","name":"@","value":"10
+        mail.server-zugang.eu.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:12 +0000 UTC","modified":"2020-04-07 01:25:12 +0000 UTC"},{"id":"a26cfdd36217e559c14b305a558f2a3c","type":"AAAA","name":"@","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"7d6f741802597845b97713596e35eaa7","type":"AAAA","name":"*","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"993bafd3e3b110a6a3acde9fe874426a","type":"NS","name":"@","value":"ns1.first-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"cc3e8297060b7bd794fed5fdec3ed91b","type":"NS","name":"@","value":"robotns2.second-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"c4602b1239d9f0747016f551c52b5774","type":"NS","name":"@","value":"robotns3.second-ns.com.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"77ae87e42a04bace81119eb2280c8dca","type":"A","name":"@","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"faff62d59434c666bac4174a1d18a955","type":"A","name":"*","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"fe6ac2081c630974662caeaa8715d435","type":"A","name":"localhost","value":"127.0.0.1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:37.307 +0000 UTC","modified":"2020-06-12 08:20:37.307 +0000 UTC"},{"id":"8e6b81a856d20f0c1802703b56d1b53d","type":"CNAME","name":"docs","value":"docs.example.com","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:38.743 +0000 UTC","modified":"2020-06-12 08:20:38.743 +0000 UTC"},{"id":"a5fc9854314c160019d9bd0fcaaf2e2a","type":"TXT","name":"_acme-challenge.fqdn","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:40.141 +0000 UTC","modified":"2020-06-12 08:20:40.141 +0000 UTC"},{"id":"101296724cdf3710d18ea43a06b39e6c","type":"TXT","name":"_acme-challenge.full","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:41.421 +0000 UTC","modified":"2020-06-12 08:20:41.421 +0000 UTC"},{"id":"1c06fee6923324bc2727916d2157b3d8","type":"TXT","name":"_acme-challenge.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:43.363 +0000 UTC","modified":"2020-06-12 08:20:43.363 +0000 UTC"},{"id":"97dcfc7f529a65b944a11554e15dcdfb","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:44.557 +0000 UTC","modified":"2020-06-12 08:20:44.557 +0000 UTC"},{"id":"880d3713398b9301dda21a611cbd9ab0","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:45.499 +0000 UTC","modified":"2020-06-12 08:20:45.499 +0000 UTC"},{"id":"f794c3584778621edfa903a30a993f9b","type":"TXT","name":"_acme-challenge.noop","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:46.766 +0000 UTC","modified":"2020-06-12 08:20:46.766 +0000 UTC"}]}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Type:
+      content-length:
+      - '3990'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:33:40 GMT
-      Transfer-Encoding:
+      date:
+      - Fri, 12 Jun 2020 08:20:47 GMT
+      transfer-encoding:
       - chunked
-      Vary:
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
+      x-kong-proxy-latency:
       - '1'
-      X-Kong-Upstream-Latency:
-      - '3343'
+      x-kong-upstream-latency:
+      - '70'
     status:
       code: 200
       message: OK
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -212,45 +236,56 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
-    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=JkBqVJDW3PpqefBb274BCZ
+    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=hetznerapizoneid
   response:
     body:
-      string: '{"records":[{"id":"kPbit4mpJa5pNU6dbFXpp3","type":"SOA","name":"@","value":"ns1.your-server.de.
-        dns.hetzner.com. 2020041578 86400 7200 3600000 3600","zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        15:17:43.061 +0000 UTC","modified":"2020-04-13 20:33:36.369 +0000 UTC"},{"id":"xbSVZRkvraCx2ZJkB5Stwh","type":"A","name":"localhost.softwarekollektiv.de.","value":"127.0.0.1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:37.644 +0000 UTC","modified":"2020-04-13 20:32:37.644 +0000 UTC"},{"id":"BotQ9nkmc8HHJpnkDNH9NS","type":"CNAME","name":"docs.softwarekollektiv.de.","value":"docs.example.com","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:43.98 +0000 UTC","modified":"2020-04-13 20:32:43.98 +0000 UTC"},{"id":"625NbWVVrL96oBE972Si5F","type":"TXT","name":"_acme-challenge.fqdn.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:51.209 +0000 UTC","modified":"2020-04-13 20:32:51.209 +0000 UTC"},{"id":"oN3QiMz8V6fmJEboVdyxTb","type":"TXT","name":"_acme-challenge.full.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:59.487 +0000 UTC","modified":"2020-04-13 20:32:59.487 +0000 UTC"},{"id":"Ko6JBd4bUcHhNnoraHNoFR","type":"TXT","name":"_acme-challenge.test.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:08.017 +0000 UTC","modified":"2020-04-13 20:33:08.017 +0000 UTC"},{"id":"beBTaU99WWcg3j3CT6nWgg","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:18.136 +0000 UTC","modified":"2020-04-13 20:33:18.136 +0000 UTC"},{"id":"jM2j9P6TLSAGNPbBiwjKPj","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:25.929 +0000 UTC","modified":"2020-04-13 20:33:25.929 +0000 UTC"},{"id":"Ubdw2SbjGbBHHPVTYPwGPC","type":"TXT","name":"_acme-challenge.noop.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:33.653 +0000 UTC","modified":"2020-04-13 20:33:33.653 +0000 UTC"}]}
+      string: !!python/unicode '{"records":[{"id":"9720b5653ca6fd0517ec91a8c6104685","type":"SOA","name":"@","value":"ns1.first-ns.de.
+        dns.hetzner.com. 2020061208 14400 3600 1814400 3600","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:24:42 +0000 UTC","modified":"2020-06-12 08:20:46.89 +0000 UTC"},{"id":"5b378a7097bdb11e6cbb5f58db6bb101","type":"MX","name":"@","value":"10
+        mail.server-zugang.eu.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:12 +0000 UTC","modified":"2020-04-07 01:25:12 +0000 UTC"},{"id":"a26cfdd36217e559c14b305a558f2a3c","type":"AAAA","name":"@","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"7d6f741802597845b97713596e35eaa7","type":"AAAA","name":"*","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"993bafd3e3b110a6a3acde9fe874426a","type":"NS","name":"@","value":"ns1.first-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"cc3e8297060b7bd794fed5fdec3ed91b","type":"NS","name":"@","value":"robotns2.second-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"c4602b1239d9f0747016f551c52b5774","type":"NS","name":"@","value":"robotns3.second-ns.com.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"77ae87e42a04bace81119eb2280c8dca","type":"A","name":"@","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"faff62d59434c666bac4174a1d18a955","type":"A","name":"*","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"fe6ac2081c630974662caeaa8715d435","type":"A","name":"localhost","value":"127.0.0.1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:37.307 +0000 UTC","modified":"2020-06-12 08:20:37.307 +0000 UTC"},{"id":"8e6b81a856d20f0c1802703b56d1b53d","type":"CNAME","name":"docs","value":"docs.example.com","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:38.743 +0000 UTC","modified":"2020-06-12 08:20:38.743 +0000 UTC"},{"id":"a5fc9854314c160019d9bd0fcaaf2e2a","type":"TXT","name":"_acme-challenge.fqdn","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:40.141 +0000 UTC","modified":"2020-06-12 08:20:40.141 +0000 UTC"},{"id":"101296724cdf3710d18ea43a06b39e6c","type":"TXT","name":"_acme-challenge.full","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:41.421 +0000 UTC","modified":"2020-06-12 08:20:41.421 +0000 UTC"},{"id":"1c06fee6923324bc2727916d2157b3d8","type":"TXT","name":"_acme-challenge.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:43.363 +0000 UTC","modified":"2020-06-12 08:20:43.363 +0000 UTC"},{"id":"97dcfc7f529a65b944a11554e15dcdfb","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:44.557 +0000 UTC","modified":"2020-06-12 08:20:44.557 +0000 UTC"},{"id":"880d3713398b9301dda21a611cbd9ab0","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:45.499 +0000 UTC","modified":"2020-06-12 08:20:45.499 +0000 UTC"},{"id":"f794c3584778621edfa903a30a993f9b","type":"TXT","name":"_acme-challenge.noop","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:46.766 +0000 UTC","modified":"2020-06-12 08:20:46.766 +0000 UTC"}]}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Type:
+      content-length:
+      - '3990'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:33:44 GMT
-      Transfer-Encoding:
+      date:
+      - Fri, 12 Jun 2020 08:20:47 GMT
+      transfer-encoding:
       - chunked
-      Vary:
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
+      x-kong-proxy-latency:
       - '2'
-      X-Kong-Upstream-Latency:
-      - '3317'
+      x-kong-upstream-latency:
+      - '73'
     status:
       code: 200
       message: OK

--- a/tests/fixtures/cassettes/hetzner/IntegrationTests/test_provider_when_calling_delete_record_by_filter_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/hetzner/IntegrationTests/test_provider_when_calling_delete_record_by_filter_should_remove_record.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -11,44 +11,44 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
     uri: https://dns.hetzner.com/api/v1/zones
   response:
     body:
-      string: '{"zones":[{"id":"xyncsydKx5x44qDZQCzpNM","name":"alt.coop","ttl":300,"registrar":"","legacy_dns_host":"","legacy_ns":["helium.ns.hetzner.com.","oxygen.ns.hetzner.com.","hydrogen.ns.hetzner.com."],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-07
-        01:23:59 +0000 UTC","verified":"2020-04-07 01:53:05.934062806 +0000 UTC m=+578.060435172","modified":"2020-04-08
-        10:38:16.278 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":75},{"id":"JkBqVJDW3PpqefBb274BCZ","name":"softwarekollektiv.de","ttl":86400,"registrar":"","legacy_dns_host":"","legacy_ns":[],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-08
-        18:53:25.589 +0000 UTC","verified":"2020-04-08T18:53:27Z","modified":"2020-04-13
-        15:17:43.767 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":9}],"meta":{"pagination":{"page":1,"per_page":100,"previous_page":1,"next_page":1,"last_page":1,"total_entries":2}}}
+      string: !!python/unicode '{"zones":[{"id":"hetznerapizoneid","name":"hetzner-api-test.de","ttl":3600,"registrar":"","legacy_dns_host":"","legacy_ns":["ns1.first-ns.de.","robotns2.second-ns.de.","robotns3.second-ns.com."],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-07
+        01:24:00 +0000 UTC","verified":"2020-04-07 01:51:26.114056422 +0000 UTC m=+478.240428717","modified":"2020-06-11
+        07:02:20.999 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":9}],"meta":{"pagination":{"page":1,"per_page":100,"previous_page":1,"next_page":1,"last_page":1,"total_entries":12}}}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '1329'
-      Content-Type:
+      content-length:
+      - '7887'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:33:44 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:20:48 GMT
+      transfer-encoding:
+      - chunked
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
+      x-kong-proxy-latency:
       - '2'
-      X-Kong-Upstream-Latency:
-      - '202'
+      x-kong-upstream-latency:
+      - '222'
     status:
       code: 200
       message: OK
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -59,51 +59,62 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
-    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=JkBqVJDW3PpqefBb274BCZ
+    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=hetznerapizoneid
   response:
     body:
-      string: '{"records":[{"id":"kPbit4mpJa5pNU6dbFXpp3","type":"SOA","name":"@","value":"ns1.your-server.de.
-        dns.hetzner.com. 2020041578 86400 7200 3600000 3600","zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        15:17:43.061 +0000 UTC","modified":"2020-04-13 20:33:36.369 +0000 UTC"},{"id":"xbSVZRkvraCx2ZJkB5Stwh","type":"A","name":"localhost.softwarekollektiv.de.","value":"127.0.0.1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:37.644 +0000 UTC","modified":"2020-04-13 20:32:37.644 +0000 UTC"},{"id":"BotQ9nkmc8HHJpnkDNH9NS","type":"CNAME","name":"docs.softwarekollektiv.de.","value":"docs.example.com","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:43.98 +0000 UTC","modified":"2020-04-13 20:32:43.98 +0000 UTC"},{"id":"625NbWVVrL96oBE972Si5F","type":"TXT","name":"_acme-challenge.fqdn.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:51.209 +0000 UTC","modified":"2020-04-13 20:32:51.209 +0000 UTC"},{"id":"oN3QiMz8V6fmJEboVdyxTb","type":"TXT","name":"_acme-challenge.full.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:59.487 +0000 UTC","modified":"2020-04-13 20:32:59.487 +0000 UTC"},{"id":"Ko6JBd4bUcHhNnoraHNoFR","type":"TXT","name":"_acme-challenge.test.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:08.017 +0000 UTC","modified":"2020-04-13 20:33:08.017 +0000 UTC"},{"id":"beBTaU99WWcg3j3CT6nWgg","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:18.136 +0000 UTC","modified":"2020-04-13 20:33:18.136 +0000 UTC"},{"id":"jM2j9P6TLSAGNPbBiwjKPj","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:25.929 +0000 UTC","modified":"2020-04-13 20:33:25.929 +0000 UTC"},{"id":"Ubdw2SbjGbBHHPVTYPwGPC","type":"TXT","name":"_acme-challenge.noop.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:33.653 +0000 UTC","modified":"2020-04-13 20:33:33.653 +0000 UTC"}]}
+      string: !!python/unicode '{"records":[{"id":"9720b5653ca6fd0517ec91a8c6104685","type":"SOA","name":"@","value":"ns1.first-ns.de.
+        dns.hetzner.com. 2020061208 14400 3600 1814400 3600","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:24:42 +0000 UTC","modified":"2020-06-12 08:20:46.89 +0000 UTC"},{"id":"5b378a7097bdb11e6cbb5f58db6bb101","type":"MX","name":"@","value":"10
+        mail.server-zugang.eu.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:12 +0000 UTC","modified":"2020-04-07 01:25:12 +0000 UTC"},{"id":"a26cfdd36217e559c14b305a558f2a3c","type":"AAAA","name":"@","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"7d6f741802597845b97713596e35eaa7","type":"AAAA","name":"*","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"993bafd3e3b110a6a3acde9fe874426a","type":"NS","name":"@","value":"ns1.first-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"cc3e8297060b7bd794fed5fdec3ed91b","type":"NS","name":"@","value":"robotns2.second-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"c4602b1239d9f0747016f551c52b5774","type":"NS","name":"@","value":"robotns3.second-ns.com.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"77ae87e42a04bace81119eb2280c8dca","type":"A","name":"@","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"faff62d59434c666bac4174a1d18a955","type":"A","name":"*","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"fe6ac2081c630974662caeaa8715d435","type":"A","name":"localhost","value":"127.0.0.1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:37.307 +0000 UTC","modified":"2020-06-12 08:20:37.307 +0000 UTC"},{"id":"8e6b81a856d20f0c1802703b56d1b53d","type":"CNAME","name":"docs","value":"docs.example.com","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:38.743 +0000 UTC","modified":"2020-06-12 08:20:38.743 +0000 UTC"},{"id":"a5fc9854314c160019d9bd0fcaaf2e2a","type":"TXT","name":"_acme-challenge.fqdn","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:40.141 +0000 UTC","modified":"2020-06-12 08:20:40.141 +0000 UTC"},{"id":"101296724cdf3710d18ea43a06b39e6c","type":"TXT","name":"_acme-challenge.full","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:41.421 +0000 UTC","modified":"2020-06-12 08:20:41.421 +0000 UTC"},{"id":"1c06fee6923324bc2727916d2157b3d8","type":"TXT","name":"_acme-challenge.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:43.363 +0000 UTC","modified":"2020-06-12 08:20:43.363 +0000 UTC"},{"id":"97dcfc7f529a65b944a11554e15dcdfb","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:44.557 +0000 UTC","modified":"2020-06-12 08:20:44.557 +0000 UTC"},{"id":"880d3713398b9301dda21a611cbd9ab0","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:45.499 +0000 UTC","modified":"2020-06-12 08:20:45.499 +0000 UTC"},{"id":"f794c3584778621edfa903a30a993f9b","type":"TXT","name":"_acme-challenge.noop","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:46.766 +0000 UTC","modified":"2020-06-12 08:20:46.766 +0000 UTC"}]}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Type:
+      content-length:
+      - '3990'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:33:48 GMT
-      Transfer-Encoding:
+      date:
+      - Fri, 12 Jun 2020 08:20:48 GMT
+      transfer-encoding:
       - chunked
-      Vary:
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
-      - '2'
-      X-Kong-Upstream-Latency:
-      - '3557'
+      x-kong-proxy-latency:
+      - '1'
+      x-kong-upstream-latency:
+      - '70'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"name": "delete.testfilt.softwarekollektiv.de.", "type": "TXT", "value":
-      "challengetoken", "zone_id": "JkBqVJDW3PpqefBb274BCZ", "ttl": 3600}'
+    body: !!python/unicode '{"ttl": 3600, "type": "TXT", "name": "delete.testfilt",
+      "value": "challengetoken", "zone_id": "hetznerapizoneid"}'
     headers:
       Accept:
       - '*/*'
@@ -112,43 +123,45 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '141'
+      - '119'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: POST
     uri: https://dns.hetzner.com/api/v1/records
   response:
     body:
-      string: '{"record":{"id":"idaCUXpirsXskU6PDBRxek","type":"TXT","name":"delete.testfilt.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:48.262 +0000 UTC","modified":"2020-04-13 20:33:48.262 +0000 UTC"}}
+      string: !!python/unicode '{"record":{"id":"65436254f1ccb94a67392b8e1642fd55","type":"TXT","name":"delete.testfilt","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:48.39 +0000 UTC","modified":"2020-06-12 08:20:48.39 +0000 UTC"}}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '267'
-      Content-Type:
+      content-length:
+      - '253'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:33:51 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:20:49 GMT
+      transfer-encoding:
+      - chunked
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
-      - '2'
-      X-Kong-Upstream-Latency:
-      - '3617'
+      x-kong-proxy-latency:
+      - '1'
+      x-kong-upstream-latency:
+      - '676'
     status:
       code: 200
       message: OK
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -159,51 +172,62 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
-    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=JkBqVJDW3PpqefBb274BCZ
+    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=hetznerapizoneid
   response:
     body:
-      string: '{"records":[{"id":"kPbit4mpJa5pNU6dbFXpp3","type":"SOA","name":"@","value":"ns1.your-server.de.
-        dns.hetzner.com. 2020041579 86400 7200 3600000 3600","zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        15:17:43.061 +0000 UTC","modified":"2020-04-13 20:33:51.346 +0000 UTC"},{"id":"xbSVZRkvraCx2ZJkB5Stwh","type":"A","name":"localhost.softwarekollektiv.de.","value":"127.0.0.1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:37.644 +0000 UTC","modified":"2020-04-13 20:32:37.644 +0000 UTC"},{"id":"BotQ9nkmc8HHJpnkDNH9NS","type":"CNAME","name":"docs.softwarekollektiv.de.","value":"docs.example.com","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:43.98 +0000 UTC","modified":"2020-04-13 20:32:43.98 +0000 UTC"},{"id":"625NbWVVrL96oBE972Si5F","type":"TXT","name":"_acme-challenge.fqdn.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:51.209 +0000 UTC","modified":"2020-04-13 20:32:51.209 +0000 UTC"},{"id":"oN3QiMz8V6fmJEboVdyxTb","type":"TXT","name":"_acme-challenge.full.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:59.487 +0000 UTC","modified":"2020-04-13 20:32:59.487 +0000 UTC"},{"id":"Ko6JBd4bUcHhNnoraHNoFR","type":"TXT","name":"_acme-challenge.test.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:08.017 +0000 UTC","modified":"2020-04-13 20:33:08.017 +0000 UTC"},{"id":"beBTaU99WWcg3j3CT6nWgg","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:18.136 +0000 UTC","modified":"2020-04-13 20:33:18.136 +0000 UTC"},{"id":"jM2j9P6TLSAGNPbBiwjKPj","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:25.929 +0000 UTC","modified":"2020-04-13 20:33:25.929 +0000 UTC"},{"id":"Ubdw2SbjGbBHHPVTYPwGPC","type":"TXT","name":"_acme-challenge.noop.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:33.653 +0000 UTC","modified":"2020-04-13 20:33:33.653 +0000 UTC"},{"id":"idaCUXpirsXskU6PDBRxek","type":"TXT","name":"delete.testfilt.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:48.262 +0000 UTC","modified":"2020-04-13 20:33:48.262 +0000 UTC"}]}
+      string: !!python/unicode '{"records":[{"id":"9720b5653ca6fd0517ec91a8c6104685","type":"SOA","name":"@","value":"ns1.first-ns.de.
+        dns.hetzner.com. 2020061209 14400 3600 1814400 3600","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:24:42 +0000 UTC","modified":"2020-06-12 08:20:48.497 +0000 UTC"},{"id":"5b378a7097bdb11e6cbb5f58db6bb101","type":"MX","name":"@","value":"10
+        mail.server-zugang.eu.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:12 +0000 UTC","modified":"2020-04-07 01:25:12 +0000 UTC"},{"id":"a26cfdd36217e559c14b305a558f2a3c","type":"AAAA","name":"@","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"7d6f741802597845b97713596e35eaa7","type":"AAAA","name":"*","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"993bafd3e3b110a6a3acde9fe874426a","type":"NS","name":"@","value":"ns1.first-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"cc3e8297060b7bd794fed5fdec3ed91b","type":"NS","name":"@","value":"robotns2.second-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"c4602b1239d9f0747016f551c52b5774","type":"NS","name":"@","value":"robotns3.second-ns.com.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"77ae87e42a04bace81119eb2280c8dca","type":"A","name":"@","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"faff62d59434c666bac4174a1d18a955","type":"A","name":"*","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"fe6ac2081c630974662caeaa8715d435","type":"A","name":"localhost","value":"127.0.0.1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:37.307 +0000 UTC","modified":"2020-06-12 08:20:37.307 +0000 UTC"},{"id":"8e6b81a856d20f0c1802703b56d1b53d","type":"CNAME","name":"docs","value":"docs.example.com","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:38.743 +0000 UTC","modified":"2020-06-12 08:20:38.743 +0000 UTC"},{"id":"a5fc9854314c160019d9bd0fcaaf2e2a","type":"TXT","name":"_acme-challenge.fqdn","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:40.141 +0000 UTC","modified":"2020-06-12 08:20:40.141 +0000 UTC"},{"id":"101296724cdf3710d18ea43a06b39e6c","type":"TXT","name":"_acme-challenge.full","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:41.421 +0000 UTC","modified":"2020-06-12 08:20:41.421 +0000 UTC"},{"id":"1c06fee6923324bc2727916d2157b3d8","type":"TXT","name":"_acme-challenge.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:43.363 +0000 UTC","modified":"2020-06-12 08:20:43.363 +0000 UTC"},{"id":"97dcfc7f529a65b944a11554e15dcdfb","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:44.557 +0000 UTC","modified":"2020-06-12 08:20:44.557 +0000 UTC"},{"id":"880d3713398b9301dda21a611cbd9ab0","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:45.499 +0000 UTC","modified":"2020-06-12 08:20:45.499 +0000 UTC"},{"id":"f794c3584778621edfa903a30a993f9b","type":"TXT","name":"_acme-challenge.noop","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:46.766 +0000 UTC","modified":"2020-06-12 08:20:46.766 +0000 UTC"},{"id":"65436254f1ccb94a67392b8e1642fd55","type":"TXT","name":"delete.testfilt","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:48.39 +0000 UTC","modified":"2020-06-12 08:20:48.39 +0000 UTC"}]}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Type:
+      content-length:
+      - '4233'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:33:54 GMT
-      Transfer-Encoding:
+      date:
+      - Fri, 12 Jun 2020 08:20:49 GMT
+      transfer-encoding:
       - chunked
-      Vary:
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
+      x-kong-proxy-latency:
       - '1'
-      X-Kong-Upstream-Latency:
-      - '3007'
+      x-kong-upstream-latency:
+      - '100'
     status:
       code: 200
       message: OK
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -214,40 +238,40 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: DELETE
-    uri: https://dns.hetzner.com/api/v1/records/idaCUXpirsXskU6PDBRxek
+    uri: https://dns.hetzner.com/api/v1/records/65436254f1ccb94a67392b8e1642fd55
   response:
     body:
-      string: '{"error":{}}
+      string: !!python/unicode '{"error":{}}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
+      content-length:
       - '13'
-      Content-Type:
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:33:55 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:20:49 GMT
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
+      x-kong-proxy-latency:
       - '1'
-      X-Kong-Upstream-Latency:
-      - '158'
+      x-kong-upstream-latency:
+      - '571'
     status:
       code: 200
       message: OK
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -258,45 +282,56 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
-    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=JkBqVJDW3PpqefBb274BCZ
+    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=hetznerapizoneid
   response:
     body:
-      string: '{"records":[{"id":"kPbit4mpJa5pNU6dbFXpp3","type":"SOA","name":"@","value":"ns1.your-server.de.
-        dns.hetzner.com. 2020041579 86400 7200 3600000 3600","zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        15:17:43.061 +0000 UTC","modified":"2020-04-13 20:33:51.346 +0000 UTC"},{"id":"xbSVZRkvraCx2ZJkB5Stwh","type":"A","name":"localhost.softwarekollektiv.de.","value":"127.0.0.1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:37.644 +0000 UTC","modified":"2020-04-13 20:32:37.644 +0000 UTC"},{"id":"BotQ9nkmc8HHJpnkDNH9NS","type":"CNAME","name":"docs.softwarekollektiv.de.","value":"docs.example.com","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:43.98 +0000 UTC","modified":"2020-04-13 20:32:43.98 +0000 UTC"},{"id":"625NbWVVrL96oBE972Si5F","type":"TXT","name":"_acme-challenge.fqdn.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:51.209 +0000 UTC","modified":"2020-04-13 20:32:51.209 +0000 UTC"},{"id":"oN3QiMz8V6fmJEboVdyxTb","type":"TXT","name":"_acme-challenge.full.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:59.487 +0000 UTC","modified":"2020-04-13 20:32:59.487 +0000 UTC"},{"id":"Ko6JBd4bUcHhNnoraHNoFR","type":"TXT","name":"_acme-challenge.test.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:08.017 +0000 UTC","modified":"2020-04-13 20:33:08.017 +0000 UTC"},{"id":"beBTaU99WWcg3j3CT6nWgg","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:18.136 +0000 UTC","modified":"2020-04-13 20:33:18.136 +0000 UTC"},{"id":"jM2j9P6TLSAGNPbBiwjKPj","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:25.929 +0000 UTC","modified":"2020-04-13 20:33:25.929 +0000 UTC"},{"id":"Ubdw2SbjGbBHHPVTYPwGPC","type":"TXT","name":"_acme-challenge.noop.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:33.653 +0000 UTC","modified":"2020-04-13 20:33:33.653 +0000 UTC"}]}
+      string: !!python/unicode '{"records":[{"id":"9720b5653ca6fd0517ec91a8c6104685","type":"SOA","name":"@","value":"ns1.first-ns.de.
+        dns.hetzner.com. 2020061210 14400 3600 1814400 3600","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:24:42 +0000 UTC","modified":"2020-06-12 08:20:49.465 +0000 UTC"},{"id":"5b378a7097bdb11e6cbb5f58db6bb101","type":"MX","name":"@","value":"10
+        mail.server-zugang.eu.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:12 +0000 UTC","modified":"2020-04-07 01:25:12 +0000 UTC"},{"id":"a26cfdd36217e559c14b305a558f2a3c","type":"AAAA","name":"@","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"7d6f741802597845b97713596e35eaa7","type":"AAAA","name":"*","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"993bafd3e3b110a6a3acde9fe874426a","type":"NS","name":"@","value":"ns1.first-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"cc3e8297060b7bd794fed5fdec3ed91b","type":"NS","name":"@","value":"robotns2.second-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"c4602b1239d9f0747016f551c52b5774","type":"NS","name":"@","value":"robotns3.second-ns.com.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"77ae87e42a04bace81119eb2280c8dca","type":"A","name":"@","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"faff62d59434c666bac4174a1d18a955","type":"A","name":"*","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"fe6ac2081c630974662caeaa8715d435","type":"A","name":"localhost","value":"127.0.0.1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:37.307 +0000 UTC","modified":"2020-06-12 08:20:37.307 +0000 UTC"},{"id":"8e6b81a856d20f0c1802703b56d1b53d","type":"CNAME","name":"docs","value":"docs.example.com","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:38.743 +0000 UTC","modified":"2020-06-12 08:20:38.743 +0000 UTC"},{"id":"a5fc9854314c160019d9bd0fcaaf2e2a","type":"TXT","name":"_acme-challenge.fqdn","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:40.141 +0000 UTC","modified":"2020-06-12 08:20:40.141 +0000 UTC"},{"id":"101296724cdf3710d18ea43a06b39e6c","type":"TXT","name":"_acme-challenge.full","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:41.421 +0000 UTC","modified":"2020-06-12 08:20:41.421 +0000 UTC"},{"id":"1c06fee6923324bc2727916d2157b3d8","type":"TXT","name":"_acme-challenge.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:43.363 +0000 UTC","modified":"2020-06-12 08:20:43.363 +0000 UTC"},{"id":"97dcfc7f529a65b944a11554e15dcdfb","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:44.557 +0000 UTC","modified":"2020-06-12 08:20:44.557 +0000 UTC"},{"id":"880d3713398b9301dda21a611cbd9ab0","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:45.499 +0000 UTC","modified":"2020-06-12 08:20:45.499 +0000 UTC"},{"id":"f794c3584778621edfa903a30a993f9b","type":"TXT","name":"_acme-challenge.noop","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:46.766 +0000 UTC","modified":"2020-06-12 08:20:46.766 +0000 UTC"}]}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Type:
+      content-length:
+      - '3991'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:33:58 GMT
-      Transfer-Encoding:
+      date:
+      - Fri, 12 Jun 2020 08:20:50 GMT
+      transfer-encoding:
       - chunked
-      Vary:
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
-      - '1'
-      X-Kong-Upstream-Latency:
-      - '2649'
+      x-kong-proxy-latency:
+      - '2'
+      x-kong-upstream-latency:
+      - '68'
     status:
       code: 200
       message: OK

--- a/tests/fixtures/cassettes/hetzner/IntegrationTests/test_provider_when_calling_delete_record_by_filter_with_fqdn_name_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/hetzner/IntegrationTests/test_provider_when_calling_delete_record_by_filter_with_fqdn_name_should_remove_record.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -11,44 +11,44 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
     uri: https://dns.hetzner.com/api/v1/zones
   response:
     body:
-      string: '{"zones":[{"id":"xyncsydKx5x44qDZQCzpNM","name":"alt.coop","ttl":300,"registrar":"","legacy_dns_host":"","legacy_ns":["oxygen.ns.hetzner.com.","hydrogen.ns.hetzner.com.","helium.ns.hetzner.com."],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-07
-        01:23:59 +0000 UTC","verified":"2020-04-07 01:53:05.934062806 +0000 UTC m=+578.060435172","modified":"2020-04-08
-        10:38:16.278 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":75},{"id":"JkBqVJDW3PpqefBb274BCZ","name":"softwarekollektiv.de","ttl":86400,"registrar":"","legacy_dns_host":"","legacy_ns":[],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-08
-        18:53:25.589 +0000 UTC","verified":"2020-04-08T18:53:27Z","modified":"2020-04-13
-        15:17:43.767 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":9}],"meta":{"pagination":{"page":1,"per_page":100,"previous_page":1,"next_page":1,"last_page":1,"total_entries":2}}}
+      string: !!python/unicode '{"zones":[{"id":"hetznerapizoneid","name":"hetzner-api-test.de","ttl":3600,"registrar":"","legacy_dns_host":"","legacy_ns":["ns1.first-ns.de.","robotns2.second-ns.de.","robotns3.second-ns.com."],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-07
+        01:24:00 +0000 UTC","verified":"2020-04-07 01:51:26.114056422 +0000 UTC m=+478.240428717","modified":"2020-06-11
+        07:02:20.999 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":9}],"meta":{"pagination":{"page":1,"per_page":100,"previous_page":1,"next_page":1,"last_page":1,"total_entries":12}}}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '1329'
-      Content-Type:
+      content-length:
+      - '7887'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:33:58 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:20:50 GMT
+      transfer-encoding:
+      - chunked
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
+      x-kong-proxy-latency:
       - '1'
-      X-Kong-Upstream-Latency:
-      - '193'
+      x-kong-upstream-latency:
+      - '343'
     status:
       code: 200
       message: OK
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -59,51 +59,62 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
-    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=JkBqVJDW3PpqefBb274BCZ
+    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=hetznerapizoneid
   response:
     body:
-      string: '{"records":[{"id":"kPbit4mpJa5pNU6dbFXpp3","type":"SOA","name":"@","value":"ns1.your-server.de.
-        dns.hetzner.com. 2020041579 86400 7200 3600000 3600","zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        15:17:43.061 +0000 UTC","modified":"2020-04-13 20:33:51.346 +0000 UTC"},{"id":"xbSVZRkvraCx2ZJkB5Stwh","type":"A","name":"localhost.softwarekollektiv.de.","value":"127.0.0.1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:37.644 +0000 UTC","modified":"2020-04-13 20:32:37.644 +0000 UTC"},{"id":"BotQ9nkmc8HHJpnkDNH9NS","type":"CNAME","name":"docs.softwarekollektiv.de.","value":"docs.example.com","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:43.98 +0000 UTC","modified":"2020-04-13 20:32:43.98 +0000 UTC"},{"id":"625NbWVVrL96oBE972Si5F","type":"TXT","name":"_acme-challenge.fqdn.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:51.209 +0000 UTC","modified":"2020-04-13 20:32:51.209 +0000 UTC"},{"id":"oN3QiMz8V6fmJEboVdyxTb","type":"TXT","name":"_acme-challenge.full.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:59.487 +0000 UTC","modified":"2020-04-13 20:32:59.487 +0000 UTC"},{"id":"Ko6JBd4bUcHhNnoraHNoFR","type":"TXT","name":"_acme-challenge.test.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:08.017 +0000 UTC","modified":"2020-04-13 20:33:08.017 +0000 UTC"},{"id":"beBTaU99WWcg3j3CT6nWgg","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:18.136 +0000 UTC","modified":"2020-04-13 20:33:18.136 +0000 UTC"},{"id":"jM2j9P6TLSAGNPbBiwjKPj","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:25.929 +0000 UTC","modified":"2020-04-13 20:33:25.929 +0000 UTC"},{"id":"Ubdw2SbjGbBHHPVTYPwGPC","type":"TXT","name":"_acme-challenge.noop.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:33.653 +0000 UTC","modified":"2020-04-13 20:33:33.653 +0000 UTC"}]}
+      string: !!python/unicode '{"records":[{"id":"9720b5653ca6fd0517ec91a8c6104685","type":"SOA","name":"@","value":"ns1.first-ns.de.
+        dns.hetzner.com. 2020061210 14400 3600 1814400 3600","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:24:42 +0000 UTC","modified":"2020-06-12 08:20:49.465 +0000 UTC"},{"id":"5b378a7097bdb11e6cbb5f58db6bb101","type":"MX","name":"@","value":"10
+        mail.server-zugang.eu.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:12 +0000 UTC","modified":"2020-04-07 01:25:12 +0000 UTC"},{"id":"a26cfdd36217e559c14b305a558f2a3c","type":"AAAA","name":"@","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"7d6f741802597845b97713596e35eaa7","type":"AAAA","name":"*","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"993bafd3e3b110a6a3acde9fe874426a","type":"NS","name":"@","value":"ns1.first-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"cc3e8297060b7bd794fed5fdec3ed91b","type":"NS","name":"@","value":"robotns2.second-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"c4602b1239d9f0747016f551c52b5774","type":"NS","name":"@","value":"robotns3.second-ns.com.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"77ae87e42a04bace81119eb2280c8dca","type":"A","name":"@","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"faff62d59434c666bac4174a1d18a955","type":"A","name":"*","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"fe6ac2081c630974662caeaa8715d435","type":"A","name":"localhost","value":"127.0.0.1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:37.307 +0000 UTC","modified":"2020-06-12 08:20:37.307 +0000 UTC"},{"id":"8e6b81a856d20f0c1802703b56d1b53d","type":"CNAME","name":"docs","value":"docs.example.com","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:38.743 +0000 UTC","modified":"2020-06-12 08:20:38.743 +0000 UTC"},{"id":"a5fc9854314c160019d9bd0fcaaf2e2a","type":"TXT","name":"_acme-challenge.fqdn","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:40.141 +0000 UTC","modified":"2020-06-12 08:20:40.141 +0000 UTC"},{"id":"101296724cdf3710d18ea43a06b39e6c","type":"TXT","name":"_acme-challenge.full","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:41.421 +0000 UTC","modified":"2020-06-12 08:20:41.421 +0000 UTC"},{"id":"1c06fee6923324bc2727916d2157b3d8","type":"TXT","name":"_acme-challenge.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:43.363 +0000 UTC","modified":"2020-06-12 08:20:43.363 +0000 UTC"},{"id":"97dcfc7f529a65b944a11554e15dcdfb","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:44.557 +0000 UTC","modified":"2020-06-12 08:20:44.557 +0000 UTC"},{"id":"880d3713398b9301dda21a611cbd9ab0","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:45.499 +0000 UTC","modified":"2020-06-12 08:20:45.499 +0000 UTC"},{"id":"f794c3584778621edfa903a30a993f9b","type":"TXT","name":"_acme-challenge.noop","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:46.766 +0000 UTC","modified":"2020-06-12 08:20:46.766 +0000 UTC"}]}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Type:
+      content-length:
+      - '3991'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:34:01 GMT
-      Transfer-Encoding:
+      date:
+      - Fri, 12 Jun 2020 08:20:50 GMT
+      transfer-encoding:
       - chunked
-      Vary:
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
+      x-kong-proxy-latency:
       - '1'
-      X-Kong-Upstream-Latency:
-      - '2823'
+      x-kong-upstream-latency:
+      - '68'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"name": "delete.testfqdn.softwarekollektiv.de.", "type": "TXT", "value":
-      "challengetoken", "zone_id": "JkBqVJDW3PpqefBb274BCZ", "ttl": 3600}'
+    body: !!python/unicode '{"ttl": 3600, "type": "TXT", "name": "delete.testfqdn",
+      "value": "challengetoken", "zone_id": "hetznerapizoneid"}'
     headers:
       Accept:
       - '*/*'
@@ -112,43 +123,45 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '141'
+      - '119'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: POST
     uri: https://dns.hetzner.com/api/v1/records
   response:
     body:
-      string: '{"record":{"id":"SLiEse2srxBDUgRSVamMSR","type":"TXT","name":"delete.testfqdn.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:34:01.715 +0000 UTC","modified":"2020-04-13 20:34:01.715 +0000 UTC"}}
+      string: !!python/unicode '{"record":{"id":"411ba27cd056b2e66f2948b3b5293c80","type":"TXT","name":"delete.testfqdn","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:50.859 +0000 UTC","modified":"2020-06-12 08:20:50.859 +0000 UTC"}}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '267'
-      Content-Type:
+      content-length:
+      - '255'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:34:04 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:20:51 GMT
+      transfer-encoding:
+      - chunked
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
-      - '2'
-      X-Kong-Upstream-Latency:
-      - '3169'
+      x-kong-proxy-latency:
+      - '1'
+      x-kong-upstream-latency:
+      - '540'
     status:
       code: 200
       message: OK
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -159,51 +172,62 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
-    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=JkBqVJDW3PpqefBb274BCZ
+    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=hetznerapizoneid
   response:
     body:
-      string: '{"records":[{"id":"kPbit4mpJa5pNU6dbFXpp3","type":"SOA","name":"@","value":"ns1.your-server.de.
-        dns.hetzner.com. 2020041580 86400 7200 3600000 3600","zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        15:17:43.061 +0000 UTC","modified":"2020-04-13 20:34:04.373 +0000 UTC"},{"id":"xbSVZRkvraCx2ZJkB5Stwh","type":"A","name":"localhost.softwarekollektiv.de.","value":"127.0.0.1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:37.644 +0000 UTC","modified":"2020-04-13 20:32:37.644 +0000 UTC"},{"id":"BotQ9nkmc8HHJpnkDNH9NS","type":"CNAME","name":"docs.softwarekollektiv.de.","value":"docs.example.com","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:43.98 +0000 UTC","modified":"2020-04-13 20:32:43.98 +0000 UTC"},{"id":"625NbWVVrL96oBE972Si5F","type":"TXT","name":"_acme-challenge.fqdn.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:51.209 +0000 UTC","modified":"2020-04-13 20:32:51.209 +0000 UTC"},{"id":"oN3QiMz8V6fmJEboVdyxTb","type":"TXT","name":"_acme-challenge.full.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:59.487 +0000 UTC","modified":"2020-04-13 20:32:59.487 +0000 UTC"},{"id":"Ko6JBd4bUcHhNnoraHNoFR","type":"TXT","name":"_acme-challenge.test.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:08.017 +0000 UTC","modified":"2020-04-13 20:33:08.017 +0000 UTC"},{"id":"beBTaU99WWcg3j3CT6nWgg","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:18.136 +0000 UTC","modified":"2020-04-13 20:33:18.136 +0000 UTC"},{"id":"jM2j9P6TLSAGNPbBiwjKPj","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:25.929 +0000 UTC","modified":"2020-04-13 20:33:25.929 +0000 UTC"},{"id":"Ubdw2SbjGbBHHPVTYPwGPC","type":"TXT","name":"_acme-challenge.noop.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:33.653 +0000 UTC","modified":"2020-04-13 20:33:33.653 +0000 UTC"},{"id":"SLiEse2srxBDUgRSVamMSR","type":"TXT","name":"delete.testfqdn.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:34:01.715 +0000 UTC","modified":"2020-04-13 20:34:01.715 +0000 UTC"}]}
+      string: !!python/unicode '{"records":[{"id":"9720b5653ca6fd0517ec91a8c6104685","type":"SOA","name":"@","value":"ns1.first-ns.de.
+        dns.hetzner.com. 2020061211 14400 3600 1814400 3600","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:24:42 +0000 UTC","modified":"2020-06-12 08:20:50.934 +0000 UTC"},{"id":"5b378a7097bdb11e6cbb5f58db6bb101","type":"MX","name":"@","value":"10
+        mail.server-zugang.eu.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:12 +0000 UTC","modified":"2020-04-07 01:25:12 +0000 UTC"},{"id":"a26cfdd36217e559c14b305a558f2a3c","type":"AAAA","name":"@","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"7d6f741802597845b97713596e35eaa7","type":"AAAA","name":"*","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"993bafd3e3b110a6a3acde9fe874426a","type":"NS","name":"@","value":"ns1.first-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"cc3e8297060b7bd794fed5fdec3ed91b","type":"NS","name":"@","value":"robotns2.second-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"c4602b1239d9f0747016f551c52b5774","type":"NS","name":"@","value":"robotns3.second-ns.com.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"77ae87e42a04bace81119eb2280c8dca","type":"A","name":"@","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"faff62d59434c666bac4174a1d18a955","type":"A","name":"*","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"fe6ac2081c630974662caeaa8715d435","type":"A","name":"localhost","value":"127.0.0.1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:37.307 +0000 UTC","modified":"2020-06-12 08:20:37.307 +0000 UTC"},{"id":"8e6b81a856d20f0c1802703b56d1b53d","type":"CNAME","name":"docs","value":"docs.example.com","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:38.743 +0000 UTC","modified":"2020-06-12 08:20:38.743 +0000 UTC"},{"id":"a5fc9854314c160019d9bd0fcaaf2e2a","type":"TXT","name":"_acme-challenge.fqdn","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:40.141 +0000 UTC","modified":"2020-06-12 08:20:40.141 +0000 UTC"},{"id":"101296724cdf3710d18ea43a06b39e6c","type":"TXT","name":"_acme-challenge.full","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:41.421 +0000 UTC","modified":"2020-06-12 08:20:41.421 +0000 UTC"},{"id":"1c06fee6923324bc2727916d2157b3d8","type":"TXT","name":"_acme-challenge.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:43.363 +0000 UTC","modified":"2020-06-12 08:20:43.363 +0000 UTC"},{"id":"97dcfc7f529a65b944a11554e15dcdfb","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:44.557 +0000 UTC","modified":"2020-06-12 08:20:44.557 +0000 UTC"},{"id":"880d3713398b9301dda21a611cbd9ab0","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:45.499 +0000 UTC","modified":"2020-06-12 08:20:45.499 +0000 UTC"},{"id":"f794c3584778621edfa903a30a993f9b","type":"TXT","name":"_acme-challenge.noop","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:46.766 +0000 UTC","modified":"2020-06-12 08:20:46.766 +0000 UTC"},{"id":"411ba27cd056b2e66f2948b3b5293c80","type":"TXT","name":"delete.testfqdn","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:50.859 +0000 UTC","modified":"2020-06-12 08:20:50.859 +0000 UTC"}]}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Type:
+      content-length:
+      - '4235'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:34:07 GMT
-      Transfer-Encoding:
+      date:
+      - Fri, 12 Jun 2020 08:20:51 GMT
+      transfer-encoding:
       - chunked
-      Vary:
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
-      - '2'
-      X-Kong-Upstream-Latency:
-      - '2664'
+      x-kong-proxy-latency:
+      - '1'
+      x-kong-upstream-latency:
+      - '65'
     status:
       code: 200
       message: OK
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -214,40 +238,40 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: DELETE
-    uri: https://dns.hetzner.com/api/v1/records/SLiEse2srxBDUgRSVamMSR
+    uri: https://dns.hetzner.com/api/v1/records/411ba27cd056b2e66f2948b3b5293c80
   response:
     body:
-      string: '{"error":{}}
+      string: !!python/unicode '{"error":{}}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
+      content-length:
       - '13'
-      Content-Type:
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:34:08 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:20:52 GMT
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
-      - '1'
-      X-Kong-Upstream-Latency:
-      - '185'
+      x-kong-proxy-latency:
+      - '2'
+      x-kong-upstream-latency:
+      - '657'
     status:
       code: 200
       message: OK
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -258,45 +282,56 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
-    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=JkBqVJDW3PpqefBb274BCZ
+    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=hetznerapizoneid
   response:
     body:
-      string: '{"records":[{"id":"kPbit4mpJa5pNU6dbFXpp3","type":"SOA","name":"@","value":"ns1.your-server.de.
-        dns.hetzner.com. 2020041580 86400 7200 3600000 3600","zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        15:17:43.061 +0000 UTC","modified":"2020-04-13 20:34:04.373 +0000 UTC"},{"id":"xbSVZRkvraCx2ZJkB5Stwh","type":"A","name":"localhost.softwarekollektiv.de.","value":"127.0.0.1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:37.644 +0000 UTC","modified":"2020-04-13 20:32:37.644 +0000 UTC"},{"id":"BotQ9nkmc8HHJpnkDNH9NS","type":"CNAME","name":"docs.softwarekollektiv.de.","value":"docs.example.com","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:43.98 +0000 UTC","modified":"2020-04-13 20:32:43.98 +0000 UTC"},{"id":"625NbWVVrL96oBE972Si5F","type":"TXT","name":"_acme-challenge.fqdn.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:51.209 +0000 UTC","modified":"2020-04-13 20:32:51.209 +0000 UTC"},{"id":"oN3QiMz8V6fmJEboVdyxTb","type":"TXT","name":"_acme-challenge.full.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:59.487 +0000 UTC","modified":"2020-04-13 20:32:59.487 +0000 UTC"},{"id":"Ko6JBd4bUcHhNnoraHNoFR","type":"TXT","name":"_acme-challenge.test.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:08.017 +0000 UTC","modified":"2020-04-13 20:33:08.017 +0000 UTC"},{"id":"beBTaU99WWcg3j3CT6nWgg","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:18.136 +0000 UTC","modified":"2020-04-13 20:33:18.136 +0000 UTC"},{"id":"jM2j9P6TLSAGNPbBiwjKPj","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:25.929 +0000 UTC","modified":"2020-04-13 20:33:25.929 +0000 UTC"},{"id":"Ubdw2SbjGbBHHPVTYPwGPC","type":"TXT","name":"_acme-challenge.noop.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:33.653 +0000 UTC","modified":"2020-04-13 20:33:33.653 +0000 UTC"}]}
+      string: !!python/unicode '{"records":[{"id":"9720b5653ca6fd0517ec91a8c6104685","type":"SOA","name":"@","value":"ns1.first-ns.de.
+        dns.hetzner.com. 2020061212 14400 3600 1814400 3600","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:24:42 +0000 UTC","modified":"2020-06-12 08:20:51.797 +0000 UTC"},{"id":"5b378a7097bdb11e6cbb5f58db6bb101","type":"MX","name":"@","value":"10
+        mail.server-zugang.eu.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:12 +0000 UTC","modified":"2020-04-07 01:25:12 +0000 UTC"},{"id":"a26cfdd36217e559c14b305a558f2a3c","type":"AAAA","name":"@","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"7d6f741802597845b97713596e35eaa7","type":"AAAA","name":"*","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"993bafd3e3b110a6a3acde9fe874426a","type":"NS","name":"@","value":"ns1.first-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"cc3e8297060b7bd794fed5fdec3ed91b","type":"NS","name":"@","value":"robotns2.second-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"c4602b1239d9f0747016f551c52b5774","type":"NS","name":"@","value":"robotns3.second-ns.com.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"77ae87e42a04bace81119eb2280c8dca","type":"A","name":"@","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"faff62d59434c666bac4174a1d18a955","type":"A","name":"*","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"fe6ac2081c630974662caeaa8715d435","type":"A","name":"localhost","value":"127.0.0.1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:37.307 +0000 UTC","modified":"2020-06-12 08:20:37.307 +0000 UTC"},{"id":"8e6b81a856d20f0c1802703b56d1b53d","type":"CNAME","name":"docs","value":"docs.example.com","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:38.743 +0000 UTC","modified":"2020-06-12 08:20:38.743 +0000 UTC"},{"id":"a5fc9854314c160019d9bd0fcaaf2e2a","type":"TXT","name":"_acme-challenge.fqdn","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:40.141 +0000 UTC","modified":"2020-06-12 08:20:40.141 +0000 UTC"},{"id":"101296724cdf3710d18ea43a06b39e6c","type":"TXT","name":"_acme-challenge.full","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:41.421 +0000 UTC","modified":"2020-06-12 08:20:41.421 +0000 UTC"},{"id":"1c06fee6923324bc2727916d2157b3d8","type":"TXT","name":"_acme-challenge.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:43.363 +0000 UTC","modified":"2020-06-12 08:20:43.363 +0000 UTC"},{"id":"97dcfc7f529a65b944a11554e15dcdfb","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:44.557 +0000 UTC","modified":"2020-06-12 08:20:44.557 +0000 UTC"},{"id":"880d3713398b9301dda21a611cbd9ab0","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:45.499 +0000 UTC","modified":"2020-06-12 08:20:45.499 +0000 UTC"},{"id":"f794c3584778621edfa903a30a993f9b","type":"TXT","name":"_acme-challenge.noop","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:46.766 +0000 UTC","modified":"2020-06-12 08:20:46.766 +0000 UTC"}]}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Type:
+      content-length:
+      - '3991'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:34:11 GMT
-      Transfer-Encoding:
+      date:
+      - Fri, 12 Jun 2020 08:20:52 GMT
+      transfer-encoding:
       - chunked
-      Vary:
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
-      - '2'
-      X-Kong-Upstream-Latency:
-      - '3282'
+      x-kong-proxy-latency:
+      - '1'
+      x-kong-upstream-latency:
+      - '69'
     status:
       code: 200
       message: OK

--- a/tests/fixtures/cassettes/hetzner/IntegrationTests/test_provider_when_calling_delete_record_by_filter_with_full_name_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/hetzner/IntegrationTests/test_provider_when_calling_delete_record_by_filter_with_full_name_should_remove_record.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -11,44 +11,44 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
     uri: https://dns.hetzner.com/api/v1/zones
   response:
     body:
-      string: '{"zones":[{"id":"xyncsydKx5x44qDZQCzpNM","name":"alt.coop","ttl":300,"registrar":"","legacy_dns_host":"","legacy_ns":["hydrogen.ns.hetzner.com.","helium.ns.hetzner.com.","oxygen.ns.hetzner.com."],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-07
-        01:23:59 +0000 UTC","verified":"2020-04-07 01:53:05.934062806 +0000 UTC m=+578.060435172","modified":"2020-04-08
-        10:38:16.278 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":75},{"id":"JkBqVJDW3PpqefBb274BCZ","name":"softwarekollektiv.de","ttl":86400,"registrar":"","legacy_dns_host":"","legacy_ns":[],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-08
-        18:53:25.589 +0000 UTC","verified":"2020-04-08T18:53:27Z","modified":"2020-04-13
-        15:17:43.767 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":9}],"meta":{"pagination":{"page":1,"per_page":100,"previous_page":1,"next_page":1,"last_page":1,"total_entries":2}}}
+      string: !!python/unicode '{"zones":[{"id":"hetznerapizoneid","name":"hetzner-api-test.de","ttl":3600,"registrar":"","legacy_dns_host":"","legacy_ns":["ns1.first-ns.de.","robotns2.second-ns.de.","robotns3.second-ns.com."],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-07
+        01:24:00 +0000 UTC","verified":"2020-04-07 01:51:26.114056422 +0000 UTC m=+478.240428717","modified":"2020-06-11
+        07:02:20.999 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":9}],"meta":{"pagination":{"page":1,"per_page":100,"previous_page":1,"next_page":1,"last_page":1,"total_entries":12}}}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '1329'
-      Content-Type:
+      content-length:
+      - '7887'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:34:11 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:20:52 GMT
+      transfer-encoding:
+      - chunked
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
+      x-kong-proxy-latency:
       - '1'
-      X-Kong-Upstream-Latency:
-      - '195'
+      x-kong-upstream-latency:
+      - '224'
     status:
       code: 200
       message: OK
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -59,51 +59,62 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
-    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=JkBqVJDW3PpqefBb274BCZ
+    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=hetznerapizoneid
   response:
     body:
-      string: '{"records":[{"id":"kPbit4mpJa5pNU6dbFXpp3","type":"SOA","name":"@","value":"ns1.your-server.de.
-        dns.hetzner.com. 2020041580 86400 7200 3600000 3600","zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        15:17:43.061 +0000 UTC","modified":"2020-04-13 20:34:04.373 +0000 UTC"},{"id":"xbSVZRkvraCx2ZJkB5Stwh","type":"A","name":"localhost.softwarekollektiv.de.","value":"127.0.0.1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:37.644 +0000 UTC","modified":"2020-04-13 20:32:37.644 +0000 UTC"},{"id":"BotQ9nkmc8HHJpnkDNH9NS","type":"CNAME","name":"docs.softwarekollektiv.de.","value":"docs.example.com","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:43.98 +0000 UTC","modified":"2020-04-13 20:32:43.98 +0000 UTC"},{"id":"625NbWVVrL96oBE972Si5F","type":"TXT","name":"_acme-challenge.fqdn.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:51.209 +0000 UTC","modified":"2020-04-13 20:32:51.209 +0000 UTC"},{"id":"oN3QiMz8V6fmJEboVdyxTb","type":"TXT","name":"_acme-challenge.full.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:59.487 +0000 UTC","modified":"2020-04-13 20:32:59.487 +0000 UTC"},{"id":"Ko6JBd4bUcHhNnoraHNoFR","type":"TXT","name":"_acme-challenge.test.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:08.017 +0000 UTC","modified":"2020-04-13 20:33:08.017 +0000 UTC"},{"id":"beBTaU99WWcg3j3CT6nWgg","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:18.136 +0000 UTC","modified":"2020-04-13 20:33:18.136 +0000 UTC"},{"id":"jM2j9P6TLSAGNPbBiwjKPj","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:25.929 +0000 UTC","modified":"2020-04-13 20:33:25.929 +0000 UTC"},{"id":"Ubdw2SbjGbBHHPVTYPwGPC","type":"TXT","name":"_acme-challenge.noop.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:33.653 +0000 UTC","modified":"2020-04-13 20:33:33.653 +0000 UTC"}]}
+      string: !!python/unicode '{"records":[{"id":"9720b5653ca6fd0517ec91a8c6104685","type":"SOA","name":"@","value":"ns1.first-ns.de.
+        dns.hetzner.com. 2020061212 14400 3600 1814400 3600","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:24:42 +0000 UTC","modified":"2020-06-12 08:20:51.797 +0000 UTC"},{"id":"5b378a7097bdb11e6cbb5f58db6bb101","type":"MX","name":"@","value":"10
+        mail.server-zugang.eu.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:12 +0000 UTC","modified":"2020-04-07 01:25:12 +0000 UTC"},{"id":"a26cfdd36217e559c14b305a558f2a3c","type":"AAAA","name":"@","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"7d6f741802597845b97713596e35eaa7","type":"AAAA","name":"*","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"993bafd3e3b110a6a3acde9fe874426a","type":"NS","name":"@","value":"ns1.first-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"cc3e8297060b7bd794fed5fdec3ed91b","type":"NS","name":"@","value":"robotns2.second-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"c4602b1239d9f0747016f551c52b5774","type":"NS","name":"@","value":"robotns3.second-ns.com.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"77ae87e42a04bace81119eb2280c8dca","type":"A","name":"@","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"faff62d59434c666bac4174a1d18a955","type":"A","name":"*","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"fe6ac2081c630974662caeaa8715d435","type":"A","name":"localhost","value":"127.0.0.1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:37.307 +0000 UTC","modified":"2020-06-12 08:20:37.307 +0000 UTC"},{"id":"8e6b81a856d20f0c1802703b56d1b53d","type":"CNAME","name":"docs","value":"docs.example.com","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:38.743 +0000 UTC","modified":"2020-06-12 08:20:38.743 +0000 UTC"},{"id":"a5fc9854314c160019d9bd0fcaaf2e2a","type":"TXT","name":"_acme-challenge.fqdn","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:40.141 +0000 UTC","modified":"2020-06-12 08:20:40.141 +0000 UTC"},{"id":"101296724cdf3710d18ea43a06b39e6c","type":"TXT","name":"_acme-challenge.full","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:41.421 +0000 UTC","modified":"2020-06-12 08:20:41.421 +0000 UTC"},{"id":"1c06fee6923324bc2727916d2157b3d8","type":"TXT","name":"_acme-challenge.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:43.363 +0000 UTC","modified":"2020-06-12 08:20:43.363 +0000 UTC"},{"id":"97dcfc7f529a65b944a11554e15dcdfb","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:44.557 +0000 UTC","modified":"2020-06-12 08:20:44.557 +0000 UTC"},{"id":"880d3713398b9301dda21a611cbd9ab0","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:45.499 +0000 UTC","modified":"2020-06-12 08:20:45.499 +0000 UTC"},{"id":"f794c3584778621edfa903a30a993f9b","type":"TXT","name":"_acme-challenge.noop","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:46.766 +0000 UTC","modified":"2020-06-12 08:20:46.766 +0000 UTC"}]}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Type:
+      content-length:
+      - '3991'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:34:16 GMT
-      Transfer-Encoding:
+      date:
+      - Fri, 12 Jun 2020 08:20:52 GMT
+      transfer-encoding:
       - chunked
-      Vary:
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
+      x-kong-proxy-latency:
       - '1'
-      X-Kong-Upstream-Latency:
-      - '4558'
+      x-kong-upstream-latency:
+      - '70'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"name": "delete.testfull.softwarekollektiv.de.", "type": "TXT", "value":
-      "challengetoken", "zone_id": "JkBqVJDW3PpqefBb274BCZ", "ttl": 3600}'
+    body: !!python/unicode '{"ttl": 3600, "type": "TXT", "name": "delete.testfull",
+      "value": "challengetoken", "zone_id": "hetznerapizoneid"}'
     headers:
       Accept:
       - '*/*'
@@ -112,43 +123,45 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '141'
+      - '119'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: POST
     uri: https://dns.hetzner.com/api/v1/records
   response:
     body:
-      string: '{"record":{"id":"3aR4otm4QVhQYbdKoi4XUc","type":"TXT","name":"delete.testfull.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:34:16.947 +0000 UTC","modified":"2020-04-13 20:34:16.947 +0000 UTC"}}
+      string: !!python/unicode '{"record":{"id":"ebb40bb53e3247b36f3958cb554aee3c","type":"TXT","name":"delete.testfull","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:53.125 +0000 UTC","modified":"2020-06-12 08:20:53.125 +0000 UTC"}}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '267'
-      Content-Type:
+      content-length:
+      - '255'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:34:20 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:20:53 GMT
+      transfer-encoding:
+      - chunked
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
+      x-kong-proxy-latency:
       - '1'
-      X-Kong-Upstream-Latency:
-      - '3308'
+      x-kong-upstream-latency:
+      - '634'
     status:
       code: 200
       message: OK
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -159,51 +172,62 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
-    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=JkBqVJDW3PpqefBb274BCZ
+    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=hetznerapizoneid
   response:
     body:
-      string: '{"records":[{"id":"kPbit4mpJa5pNU6dbFXpp3","type":"SOA","name":"@","value":"ns1.your-server.de.
-        dns.hetzner.com. 2020041581 86400 7200 3600000 3600","zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        15:17:43.061 +0000 UTC","modified":"2020-04-13 20:34:19.653 +0000 UTC"},{"id":"xbSVZRkvraCx2ZJkB5Stwh","type":"A","name":"localhost.softwarekollektiv.de.","value":"127.0.0.1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:37.644 +0000 UTC","modified":"2020-04-13 20:32:37.644 +0000 UTC"},{"id":"BotQ9nkmc8HHJpnkDNH9NS","type":"CNAME","name":"docs.softwarekollektiv.de.","value":"docs.example.com","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:43.98 +0000 UTC","modified":"2020-04-13 20:32:43.98 +0000 UTC"},{"id":"625NbWVVrL96oBE972Si5F","type":"TXT","name":"_acme-challenge.fqdn.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:51.209 +0000 UTC","modified":"2020-04-13 20:32:51.209 +0000 UTC"},{"id":"oN3QiMz8V6fmJEboVdyxTb","type":"TXT","name":"_acme-challenge.full.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:59.487 +0000 UTC","modified":"2020-04-13 20:32:59.487 +0000 UTC"},{"id":"Ko6JBd4bUcHhNnoraHNoFR","type":"TXT","name":"_acme-challenge.test.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:08.017 +0000 UTC","modified":"2020-04-13 20:33:08.017 +0000 UTC"},{"id":"beBTaU99WWcg3j3CT6nWgg","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:18.136 +0000 UTC","modified":"2020-04-13 20:33:18.136 +0000 UTC"},{"id":"jM2j9P6TLSAGNPbBiwjKPj","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:25.929 +0000 UTC","modified":"2020-04-13 20:33:25.929 +0000 UTC"},{"id":"Ubdw2SbjGbBHHPVTYPwGPC","type":"TXT","name":"_acme-challenge.noop.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:33.653 +0000 UTC","modified":"2020-04-13 20:33:33.653 +0000 UTC"},{"id":"3aR4otm4QVhQYbdKoi4XUc","type":"TXT","name":"delete.testfull.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:34:16.947 +0000 UTC","modified":"2020-04-13 20:34:16.947 +0000 UTC"}]}
+      string: !!python/unicode '{"records":[{"id":"9720b5653ca6fd0517ec91a8c6104685","type":"SOA","name":"@","value":"ns1.first-ns.de.
+        dns.hetzner.com. 2020061213 14400 3600 1814400 3600","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:24:42 +0000 UTC","modified":"2020-06-12 08:20:53.234 +0000 UTC"},{"id":"5b378a7097bdb11e6cbb5f58db6bb101","type":"MX","name":"@","value":"10
+        mail.server-zugang.eu.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:12 +0000 UTC","modified":"2020-04-07 01:25:12 +0000 UTC"},{"id":"a26cfdd36217e559c14b305a558f2a3c","type":"AAAA","name":"@","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"7d6f741802597845b97713596e35eaa7","type":"AAAA","name":"*","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"993bafd3e3b110a6a3acde9fe874426a","type":"NS","name":"@","value":"ns1.first-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"cc3e8297060b7bd794fed5fdec3ed91b","type":"NS","name":"@","value":"robotns2.second-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"c4602b1239d9f0747016f551c52b5774","type":"NS","name":"@","value":"robotns3.second-ns.com.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"77ae87e42a04bace81119eb2280c8dca","type":"A","name":"@","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"faff62d59434c666bac4174a1d18a955","type":"A","name":"*","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"fe6ac2081c630974662caeaa8715d435","type":"A","name":"localhost","value":"127.0.0.1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:37.307 +0000 UTC","modified":"2020-06-12 08:20:37.307 +0000 UTC"},{"id":"8e6b81a856d20f0c1802703b56d1b53d","type":"CNAME","name":"docs","value":"docs.example.com","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:38.743 +0000 UTC","modified":"2020-06-12 08:20:38.743 +0000 UTC"},{"id":"a5fc9854314c160019d9bd0fcaaf2e2a","type":"TXT","name":"_acme-challenge.fqdn","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:40.141 +0000 UTC","modified":"2020-06-12 08:20:40.141 +0000 UTC"},{"id":"101296724cdf3710d18ea43a06b39e6c","type":"TXT","name":"_acme-challenge.full","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:41.421 +0000 UTC","modified":"2020-06-12 08:20:41.421 +0000 UTC"},{"id":"1c06fee6923324bc2727916d2157b3d8","type":"TXT","name":"_acme-challenge.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:43.363 +0000 UTC","modified":"2020-06-12 08:20:43.363 +0000 UTC"},{"id":"97dcfc7f529a65b944a11554e15dcdfb","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:44.557 +0000 UTC","modified":"2020-06-12 08:20:44.557 +0000 UTC"},{"id":"880d3713398b9301dda21a611cbd9ab0","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:45.499 +0000 UTC","modified":"2020-06-12 08:20:45.499 +0000 UTC"},{"id":"f794c3584778621edfa903a30a993f9b","type":"TXT","name":"_acme-challenge.noop","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:46.766 +0000 UTC","modified":"2020-06-12 08:20:46.766 +0000 UTC"},{"id":"ebb40bb53e3247b36f3958cb554aee3c","type":"TXT","name":"delete.testfull","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:53.125 +0000 UTC","modified":"2020-06-12 08:20:53.125 +0000 UTC"}]}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Type:
+      content-length:
+      - '4235'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:34:24 GMT
-      Transfer-Encoding:
+      date:
+      - Fri, 12 Jun 2020 08:20:53 GMT
+      transfer-encoding:
       - chunked
-      Vary:
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
+      x-kong-proxy-latency:
       - '1'
-      X-Kong-Upstream-Latency:
-      - '4475'
+      x-kong-upstream-latency:
+      - '75'
     status:
       code: 200
       message: OK
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -214,40 +238,40 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: DELETE
-    uri: https://dns.hetzner.com/api/v1/records/3aR4otm4QVhQYbdKoi4XUc
+    uri: https://dns.hetzner.com/api/v1/records/ebb40bb53e3247b36f3958cb554aee3c
   response:
     body:
-      string: '{"error":{}}
+      string: !!python/unicode '{"error":{}}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
+      content-length:
       - '13'
-      Content-Type:
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:34:25 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:20:54 GMT
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
-      - '1'
-      X-Kong-Upstream-Latency:
-      - '251'
+      x-kong-proxy-latency:
+      - '2'
+      x-kong-upstream-latency:
+      - '691'
     status:
       code: 200
       message: OK
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -258,45 +282,56 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
-    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=JkBqVJDW3PpqefBb274BCZ
+    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=hetznerapizoneid
   response:
     body:
-      string: '{"records":[{"id":"kPbit4mpJa5pNU6dbFXpp3","type":"SOA","name":"@","value":"ns1.your-server.de.
-        dns.hetzner.com. 2020041581 86400 7200 3600000 3600","zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        15:17:43.061 +0000 UTC","modified":"2020-04-13 20:34:19.653 +0000 UTC"},{"id":"xbSVZRkvraCx2ZJkB5Stwh","type":"A","name":"localhost.softwarekollektiv.de.","value":"127.0.0.1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:37.644 +0000 UTC","modified":"2020-04-13 20:32:37.644 +0000 UTC"},{"id":"BotQ9nkmc8HHJpnkDNH9NS","type":"CNAME","name":"docs.softwarekollektiv.de.","value":"docs.example.com","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:43.98 +0000 UTC","modified":"2020-04-13 20:32:43.98 +0000 UTC"},{"id":"625NbWVVrL96oBE972Si5F","type":"TXT","name":"_acme-challenge.fqdn.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:51.209 +0000 UTC","modified":"2020-04-13 20:32:51.209 +0000 UTC"},{"id":"oN3QiMz8V6fmJEboVdyxTb","type":"TXT","name":"_acme-challenge.full.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:59.487 +0000 UTC","modified":"2020-04-13 20:32:59.487 +0000 UTC"},{"id":"Ko6JBd4bUcHhNnoraHNoFR","type":"TXT","name":"_acme-challenge.test.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:08.017 +0000 UTC","modified":"2020-04-13 20:33:08.017 +0000 UTC"},{"id":"beBTaU99WWcg3j3CT6nWgg","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:18.136 +0000 UTC","modified":"2020-04-13 20:33:18.136 +0000 UTC"},{"id":"jM2j9P6TLSAGNPbBiwjKPj","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:25.929 +0000 UTC","modified":"2020-04-13 20:33:25.929 +0000 UTC"},{"id":"Ubdw2SbjGbBHHPVTYPwGPC","type":"TXT","name":"_acme-challenge.noop.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:33.653 +0000 UTC","modified":"2020-04-13 20:33:33.653 +0000 UTC"}]}
+      string: !!python/unicode '{"records":[{"id":"9720b5653ca6fd0517ec91a8c6104685","type":"SOA","name":"@","value":"ns1.first-ns.de.
+        dns.hetzner.com. 2020061214 14400 3600 1814400 3600","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:24:42 +0000 UTC","modified":"2020-06-12 08:20:54.175 +0000 UTC"},{"id":"5b378a7097bdb11e6cbb5f58db6bb101","type":"MX","name":"@","value":"10
+        mail.server-zugang.eu.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:12 +0000 UTC","modified":"2020-04-07 01:25:12 +0000 UTC"},{"id":"a26cfdd36217e559c14b305a558f2a3c","type":"AAAA","name":"@","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"7d6f741802597845b97713596e35eaa7","type":"AAAA","name":"*","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"993bafd3e3b110a6a3acde9fe874426a","type":"NS","name":"@","value":"ns1.first-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"cc3e8297060b7bd794fed5fdec3ed91b","type":"NS","name":"@","value":"robotns2.second-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"c4602b1239d9f0747016f551c52b5774","type":"NS","name":"@","value":"robotns3.second-ns.com.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"77ae87e42a04bace81119eb2280c8dca","type":"A","name":"@","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"faff62d59434c666bac4174a1d18a955","type":"A","name":"*","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"fe6ac2081c630974662caeaa8715d435","type":"A","name":"localhost","value":"127.0.0.1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:37.307 +0000 UTC","modified":"2020-06-12 08:20:37.307 +0000 UTC"},{"id":"8e6b81a856d20f0c1802703b56d1b53d","type":"CNAME","name":"docs","value":"docs.example.com","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:38.743 +0000 UTC","modified":"2020-06-12 08:20:38.743 +0000 UTC"},{"id":"a5fc9854314c160019d9bd0fcaaf2e2a","type":"TXT","name":"_acme-challenge.fqdn","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:40.141 +0000 UTC","modified":"2020-06-12 08:20:40.141 +0000 UTC"},{"id":"101296724cdf3710d18ea43a06b39e6c","type":"TXT","name":"_acme-challenge.full","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:41.421 +0000 UTC","modified":"2020-06-12 08:20:41.421 +0000 UTC"},{"id":"1c06fee6923324bc2727916d2157b3d8","type":"TXT","name":"_acme-challenge.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:43.363 +0000 UTC","modified":"2020-06-12 08:20:43.363 +0000 UTC"},{"id":"97dcfc7f529a65b944a11554e15dcdfb","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:44.557 +0000 UTC","modified":"2020-06-12 08:20:44.557 +0000 UTC"},{"id":"880d3713398b9301dda21a611cbd9ab0","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:45.499 +0000 UTC","modified":"2020-06-12 08:20:45.499 +0000 UTC"},{"id":"f794c3584778621edfa903a30a993f9b","type":"TXT","name":"_acme-challenge.noop","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:46.766 +0000 UTC","modified":"2020-06-12 08:20:46.766 +0000 UTC"}]}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Type:
+      content-length:
+      - '3991'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:34:29 GMT
-      Transfer-Encoding:
+      date:
+      - Fri, 12 Jun 2020 08:20:54 GMT
+      transfer-encoding:
       - chunked
-      Vary:
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
-      - '1'
-      X-Kong-Upstream-Latency:
-      - '3530'
+      x-kong-proxy-latency:
+      - '2'
+      x-kong-upstream-latency:
+      - '102'
     status:
       code: 200
       message: OK

--- a/tests/fixtures/cassettes/hetzner/IntegrationTests/test_provider_when_calling_delete_record_by_identifier_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/hetzner/IntegrationTests/test_provider_when_calling_delete_record_by_identifier_should_remove_record.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -11,44 +11,44 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
     uri: https://dns.hetzner.com/api/v1/zones
   response:
     body:
-      string: '{"zones":[{"id":"xyncsydKx5x44qDZQCzpNM","name":"alt.coop","ttl":300,"registrar":"","legacy_dns_host":"","legacy_ns":["oxygen.ns.hetzner.com.","hydrogen.ns.hetzner.com.","helium.ns.hetzner.com."],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-07
-        01:23:59 +0000 UTC","verified":"2020-04-07 01:53:05.934062806 +0000 UTC m=+578.060435172","modified":"2020-04-08
-        10:38:16.278 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":75},{"id":"JkBqVJDW3PpqefBb274BCZ","name":"softwarekollektiv.de","ttl":86400,"registrar":"","legacy_dns_host":"","legacy_ns":[],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-08
-        18:53:25.589 +0000 UTC","verified":"2020-04-08T18:53:27Z","modified":"2020-04-13
-        15:17:43.767 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":9}],"meta":{"pagination":{"page":1,"per_page":100,"previous_page":1,"next_page":1,"last_page":1,"total_entries":2}}}
+      string: !!python/unicode '{"zones":[{"id":"hetznerapizoneid","name":"hetzner-api-test.de","ttl":3600,"registrar":"","legacy_dns_host":"","legacy_ns":["ns1.first-ns.de.","robotns2.second-ns.de.","robotns3.second-ns.com."],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-07
+        01:24:00 +0000 UTC","verified":"2020-04-07 01:51:26.114056422 +0000 UTC m=+478.240428717","modified":"2020-06-11
+        07:02:20.999 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":9}],"meta":{"pagination":{"page":1,"per_page":100,"previous_page":1,"next_page":1,"last_page":1,"total_entries":12}}}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '1329'
-      Content-Type:
+      content-length:
+      - '7887'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:34:29 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:20:55 GMT
+      transfer-encoding:
+      - chunked
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
+      x-kong-proxy-latency:
       - '1'
-      X-Kong-Upstream-Latency:
-      - '176'
+      x-kong-upstream-latency:
+      - '243'
     status:
       code: 200
       message: OK
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -59,51 +59,62 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
-    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=JkBqVJDW3PpqefBb274BCZ
+    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=hetznerapizoneid
   response:
     body:
-      string: '{"records":[{"id":"95PQwU7m2utSVVy6KCawvK","type":"SOA","name":"@","value":"ns1.your-server.de.
-        dns.hetzner.com. 2020041581 86400 7200 3600000 3600","zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        15:17:43.061 +0000 UTC","modified":"2020-04-13 20:34:19.653 +0000 UTC"},{"id":"GfYFqPkZgim24vTVrsfcZX","type":"A","name":"localhost.softwarekollektiv.de.","value":"127.0.0.1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:37.644 +0000 UTC","modified":"2020-04-13 20:32:37.644 +0000 UTC"},{"id":"Mg4uWPMaEaYduBgTa5TPPc","type":"CNAME","name":"docs.softwarekollektiv.de.","value":"docs.example.com","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:43.98 +0000 UTC","modified":"2020-04-13 20:32:43.98 +0000 UTC"},{"id":"rUeFkcZBgee7SHSDeV6Ck","type":"TXT","name":"_acme-challenge.fqdn.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:51.209 +0000 UTC","modified":"2020-04-13 20:32:51.209 +0000 UTC"},{"id":"ZyqnjNabiDrtZT6Uwzu56n","type":"TXT","name":"_acme-challenge.full.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:59.487 +0000 UTC","modified":"2020-04-13 20:32:59.487 +0000 UTC"},{"id":"FfdcR67Vnw5A7SHXWX7Hxg","type":"TXT","name":"_acme-challenge.test.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:08.017 +0000 UTC","modified":"2020-04-13 20:33:08.017 +0000 UTC"},{"id":"5sV8XVC5vgc8LWes8RfvcW","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:18.136 +0000 UTC","modified":"2020-04-13 20:33:18.136 +0000 UTC"},{"id":"XAoFz3naor3FrDtkWVNhYn","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:25.929 +0000 UTC","modified":"2020-04-13 20:33:25.929 +0000 UTC"},{"id":"hdKaNwzzkQqayWeYbvYPbB","type":"TXT","name":"_acme-challenge.noop.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:33.653 +0000 UTC","modified":"2020-04-13 20:33:33.653 +0000 UTC"}]}
+      string: !!python/unicode '{"records":[{"id":"9720b5653ca6fd0517ec91a8c6104685","type":"SOA","name":"@","value":"ns1.first-ns.de.
+        dns.hetzner.com. 2020061214 14400 3600 1814400 3600","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:24:42 +0000 UTC","modified":"2020-06-12 08:20:54.175 +0000 UTC"},{"id":"5b378a7097bdb11e6cbb5f58db6bb101","type":"MX","name":"@","value":"10
+        mail.server-zugang.eu.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:12 +0000 UTC","modified":"2020-04-07 01:25:12 +0000 UTC"},{"id":"a26cfdd36217e559c14b305a558f2a3c","type":"AAAA","name":"@","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"7d6f741802597845b97713596e35eaa7","type":"AAAA","name":"*","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"993bafd3e3b110a6a3acde9fe874426a","type":"NS","name":"@","value":"ns1.first-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"cc3e8297060b7bd794fed5fdec3ed91b","type":"NS","name":"@","value":"robotns2.second-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"c4602b1239d9f0747016f551c52b5774","type":"NS","name":"@","value":"robotns3.second-ns.com.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"77ae87e42a04bace81119eb2280c8dca","type":"A","name":"@","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"faff62d59434c666bac4174a1d18a955","type":"A","name":"*","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"fe6ac2081c630974662caeaa8715d435","type":"A","name":"localhost","value":"127.0.0.1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:37.307 +0000 UTC","modified":"2020-06-12 08:20:37.307 +0000 UTC"},{"id":"8e6b81a856d20f0c1802703b56d1b53d","type":"CNAME","name":"docs","value":"docs.example.com","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:38.743 +0000 UTC","modified":"2020-06-12 08:20:38.743 +0000 UTC"},{"id":"a5fc9854314c160019d9bd0fcaaf2e2a","type":"TXT","name":"_acme-challenge.fqdn","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:40.141 +0000 UTC","modified":"2020-06-12 08:20:40.141 +0000 UTC"},{"id":"101296724cdf3710d18ea43a06b39e6c","type":"TXT","name":"_acme-challenge.full","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:41.421 +0000 UTC","modified":"2020-06-12 08:20:41.421 +0000 UTC"},{"id":"1c06fee6923324bc2727916d2157b3d8","type":"TXT","name":"_acme-challenge.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:43.363 +0000 UTC","modified":"2020-06-12 08:20:43.363 +0000 UTC"},{"id":"97dcfc7f529a65b944a11554e15dcdfb","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:44.557 +0000 UTC","modified":"2020-06-12 08:20:44.557 +0000 UTC"},{"id":"880d3713398b9301dda21a611cbd9ab0","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:45.499 +0000 UTC","modified":"2020-06-12 08:20:45.499 +0000 UTC"},{"id":"f794c3584778621edfa903a30a993f9b","type":"TXT","name":"_acme-challenge.noop","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:46.766 +0000 UTC","modified":"2020-06-12 08:20:46.766 +0000 UTC"}]}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Type:
+      content-length:
+      - '3991'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:34:32 GMT
-      Transfer-Encoding:
+      date:
+      - Fri, 12 Jun 2020 08:20:55 GMT
+      transfer-encoding:
       - chunked
-      Vary:
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
+      x-kong-proxy-latency:
       - '1'
-      X-Kong-Upstream-Latency:
-      - '3288'
+      x-kong-upstream-latency:
+      - '73'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"name": "delete.testid.softwarekollektiv.de.", "type": "TXT", "value":
-      "challengetoken", "zone_id": "JkBqVJDW3PpqefBb274BCZ", "ttl": 3600}'
+    body: !!python/unicode '{"ttl": 3600, "type": "TXT", "name": "delete.testid",
+      "value": "challengetoken", "zone_id": "hetznerapizoneid"}'
     headers:
       Accept:
       - '*/*'
@@ -112,43 +123,45 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '139'
+      - '117'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: POST
     uri: https://dns.hetzner.com/api/v1/records
   response:
     body:
-      string: '{"record":{"id":"29yv5V7uKozZTVwQbuYa3g","type":"TXT","name":"delete.testid.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:34:33.185 +0000 UTC","modified":"2020-04-13 20:34:33.185 +0000 UTC"}}
+      string: !!python/unicode '{"record":{"id":"69ab5d906a7fa7959f2112870a3b7acd","type":"TXT","name":"delete.testid","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:55.592 +0000 UTC","modified":"2020-06-12 08:20:55.592 +0000 UTC"}}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '265'
-      Content-Type:
+      content-length:
+      - '253'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:34:36 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:20:56 GMT
+      transfer-encoding:
+      - chunked
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
-      - '2'
-      X-Kong-Upstream-Latency:
-      - '3529'
+      x-kong-proxy-latency:
+      - '1'
+      x-kong-upstream-latency:
+      - '659'
     status:
       code: 200
       message: OK
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -159,51 +172,62 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
-    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=JkBqVJDW3PpqefBb274BCZ
+    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=hetznerapizoneid
   response:
     body:
-      string: '{"records":[{"id":"95PQwU7m2utSVVy6KCawvK","type":"SOA","name":"@","value":"ns1.your-server.de.
-        dns.hetzner.com. 2020041582 86400 7200 3600000 3600","zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        15:17:43.061 +0000 UTC","modified":"2020-04-13 20:34:36.046 +0000 UTC"},{"id":"GfYFqPkZgim24vTVrsfcZX","type":"A","name":"localhost.softwarekollektiv.de.","value":"127.0.0.1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:37.644 +0000 UTC","modified":"2020-04-13 20:32:37.644 +0000 UTC"},{"id":"Mg4uWPMaEaYduBgTa5TPPc","type":"CNAME","name":"docs.softwarekollektiv.de.","value":"docs.example.com","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:43.98 +0000 UTC","modified":"2020-04-13 20:32:43.98 +0000 UTC"},{"id":"rUeFkcZBgee7SHSDeV6Ck","type":"TXT","name":"_acme-challenge.fqdn.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:51.209 +0000 UTC","modified":"2020-04-13 20:32:51.209 +0000 UTC"},{"id":"ZyqnjNabiDrtZT6Uwzu56n","type":"TXT","name":"_acme-challenge.full.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:59.487 +0000 UTC","modified":"2020-04-13 20:32:59.487 +0000 UTC"},{"id":"FfdcR67Vnw5A7SHXWX7Hxg","type":"TXT","name":"_acme-challenge.test.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:08.017 +0000 UTC","modified":"2020-04-13 20:33:08.017 +0000 UTC"},{"id":"5sV8XVC5vgc8LWes8RfvcW","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:18.136 +0000 UTC","modified":"2020-04-13 20:33:18.136 +0000 UTC"},{"id":"XAoFz3naor3FrDtkWVNhYn","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:25.929 +0000 UTC","modified":"2020-04-13 20:33:25.929 +0000 UTC"},{"id":"hdKaNwzzkQqayWeYbvYPbB","type":"TXT","name":"_acme-challenge.noop.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:33.653 +0000 UTC","modified":"2020-04-13 20:33:33.653 +0000 UTC"},{"id":"29yv5V7uKozZTVwQbuYa3g","type":"TXT","name":"delete.testid.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:34:33.185 +0000 UTC","modified":"2020-04-13 20:34:33.185 +0000 UTC"}]}
+      string: !!python/unicode '{"records":[{"id":"9720b5653ca6fd0517ec91a8c6104685","type":"SOA","name":"@","value":"ns1.first-ns.de.
+        dns.hetzner.com. 2020061215 14400 3600 1814400 3600","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:24:42 +0000 UTC","modified":"2020-06-12 08:20:55.702 +0000 UTC"},{"id":"5b378a7097bdb11e6cbb5f58db6bb101","type":"MX","name":"@","value":"10
+        mail.server-zugang.eu.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:12 +0000 UTC","modified":"2020-04-07 01:25:12 +0000 UTC"},{"id":"a26cfdd36217e559c14b305a558f2a3c","type":"AAAA","name":"@","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"7d6f741802597845b97713596e35eaa7","type":"AAAA","name":"*","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"993bafd3e3b110a6a3acde9fe874426a","type":"NS","name":"@","value":"ns1.first-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"cc3e8297060b7bd794fed5fdec3ed91b","type":"NS","name":"@","value":"robotns2.second-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"c4602b1239d9f0747016f551c52b5774","type":"NS","name":"@","value":"robotns3.second-ns.com.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"77ae87e42a04bace81119eb2280c8dca","type":"A","name":"@","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"faff62d59434c666bac4174a1d18a955","type":"A","name":"*","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"fe6ac2081c630974662caeaa8715d435","type":"A","name":"localhost","value":"127.0.0.1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:37.307 +0000 UTC","modified":"2020-06-12 08:20:37.307 +0000 UTC"},{"id":"8e6b81a856d20f0c1802703b56d1b53d","type":"CNAME","name":"docs","value":"docs.example.com","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:38.743 +0000 UTC","modified":"2020-06-12 08:20:38.743 +0000 UTC"},{"id":"a5fc9854314c160019d9bd0fcaaf2e2a","type":"TXT","name":"_acme-challenge.fqdn","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:40.141 +0000 UTC","modified":"2020-06-12 08:20:40.141 +0000 UTC"},{"id":"101296724cdf3710d18ea43a06b39e6c","type":"TXT","name":"_acme-challenge.full","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:41.421 +0000 UTC","modified":"2020-06-12 08:20:41.421 +0000 UTC"},{"id":"1c06fee6923324bc2727916d2157b3d8","type":"TXT","name":"_acme-challenge.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:43.363 +0000 UTC","modified":"2020-06-12 08:20:43.363 +0000 UTC"},{"id":"97dcfc7f529a65b944a11554e15dcdfb","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:44.557 +0000 UTC","modified":"2020-06-12 08:20:44.557 +0000 UTC"},{"id":"880d3713398b9301dda21a611cbd9ab0","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:45.499 +0000 UTC","modified":"2020-06-12 08:20:45.499 +0000 UTC"},{"id":"f794c3584778621edfa903a30a993f9b","type":"TXT","name":"_acme-challenge.noop","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:46.766 +0000 UTC","modified":"2020-06-12 08:20:46.766 +0000 UTC"},{"id":"69ab5d906a7fa7959f2112870a3b7acd","type":"TXT","name":"delete.testid","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:55.592 +0000 UTC","modified":"2020-06-12 08:20:55.592 +0000 UTC"}]}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Type:
+      content-length:
+      - '4233'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:34:40 GMT
-      Transfer-Encoding:
+      date:
+      - Fri, 12 Jun 2020 08:20:56 GMT
+      transfer-encoding:
       - chunked
-      Vary:
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
-      - '1'
-      X-Kong-Upstream-Latency:
-      - '3280'
+      x-kong-proxy-latency:
+      - '2'
+      x-kong-upstream-latency:
+      - '109'
     status:
       code: 200
       message: OK
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -214,40 +238,40 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: DELETE
-    uri: https://dns.hetzner.com/api/v1/records/29yv5V7uKozZTVwQbuYa3g
+    uri: https://dns.hetzner.com/api/v1/records/69ab5d906a7fa7959f2112870a3b7acd
   response:
     body:
-      string: '{"error":{}}
+      string: !!python/unicode '{"error":{}}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
+      content-length:
       - '13'
-      Content-Type:
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:34:40 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:20:57 GMT
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
-      - '2'
-      X-Kong-Upstream-Latency:
-      - '226'
+      x-kong-proxy-latency:
+      - '1'
+      x-kong-upstream-latency:
+      - '581'
     status:
       code: 200
       message: OK
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -258,45 +282,56 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
-    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=JkBqVJDW3PpqefBb274BCZ
+    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=hetznerapizoneid
   response:
     body:
-      string: '{"records":[{"id":"95PQwU7m2utSVVy6KCawvK","type":"SOA","name":"@","value":"ns1.your-server.de.
-        dns.hetzner.com. 2020041582 86400 7200 3600000 3600","zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        15:17:43.061 +0000 UTC","modified":"2020-04-13 20:34:36.046 +0000 UTC"},{"id":"GfYFqPkZgim24vTVrsfcZX","type":"A","name":"localhost.softwarekollektiv.de.","value":"127.0.0.1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:37.644 +0000 UTC","modified":"2020-04-13 20:32:37.644 +0000 UTC"},{"id":"Mg4uWPMaEaYduBgTa5TPPc","type":"CNAME","name":"docs.softwarekollektiv.de.","value":"docs.example.com","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:43.98 +0000 UTC","modified":"2020-04-13 20:32:43.98 +0000 UTC"},{"id":"rUeFkcZBgee7SHSDeV6Ck","type":"TXT","name":"_acme-challenge.fqdn.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:51.209 +0000 UTC","modified":"2020-04-13 20:32:51.209 +0000 UTC"},{"id":"ZyqnjNabiDrtZT6Uwzu56n","type":"TXT","name":"_acme-challenge.full.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:59.487 +0000 UTC","modified":"2020-04-13 20:32:59.487 +0000 UTC"},{"id":"FfdcR67Vnw5A7SHXWX7Hxg","type":"TXT","name":"_acme-challenge.test.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:08.017 +0000 UTC","modified":"2020-04-13 20:33:08.017 +0000 UTC"},{"id":"5sV8XVC5vgc8LWes8RfvcW","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:18.136 +0000 UTC","modified":"2020-04-13 20:33:18.136 +0000 UTC"},{"id":"XAoFz3naor3FrDtkWVNhYn","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:25.929 +0000 UTC","modified":"2020-04-13 20:33:25.929 +0000 UTC"},{"id":"hdKaNwzzkQqayWeYbvYPbB","type":"TXT","name":"_acme-challenge.noop.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:33.653 +0000 UTC","modified":"2020-04-13 20:33:33.653 +0000 UTC"}]}
+      string: !!python/unicode '{"records":[{"id":"9720b5653ca6fd0517ec91a8c6104685","type":"SOA","name":"@","value":"ns1.first-ns.de.
+        dns.hetzner.com. 2020061216 14400 3600 1814400 3600","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:24:42 +0000 UTC","modified":"2020-06-12 08:20:56.661 +0000 UTC"},{"id":"5b378a7097bdb11e6cbb5f58db6bb101","type":"MX","name":"@","value":"10
+        mail.server-zugang.eu.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:12 +0000 UTC","modified":"2020-04-07 01:25:12 +0000 UTC"},{"id":"a26cfdd36217e559c14b305a558f2a3c","type":"AAAA","name":"@","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"7d6f741802597845b97713596e35eaa7","type":"AAAA","name":"*","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"993bafd3e3b110a6a3acde9fe874426a","type":"NS","name":"@","value":"ns1.first-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"cc3e8297060b7bd794fed5fdec3ed91b","type":"NS","name":"@","value":"robotns2.second-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"c4602b1239d9f0747016f551c52b5774","type":"NS","name":"@","value":"robotns3.second-ns.com.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"77ae87e42a04bace81119eb2280c8dca","type":"A","name":"@","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"faff62d59434c666bac4174a1d18a955","type":"A","name":"*","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"fe6ac2081c630974662caeaa8715d435","type":"A","name":"localhost","value":"127.0.0.1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:37.307 +0000 UTC","modified":"2020-06-12 08:20:37.307 +0000 UTC"},{"id":"8e6b81a856d20f0c1802703b56d1b53d","type":"CNAME","name":"docs","value":"docs.example.com","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:38.743 +0000 UTC","modified":"2020-06-12 08:20:38.743 +0000 UTC"},{"id":"a5fc9854314c160019d9bd0fcaaf2e2a","type":"TXT","name":"_acme-challenge.fqdn","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:40.141 +0000 UTC","modified":"2020-06-12 08:20:40.141 +0000 UTC"},{"id":"101296724cdf3710d18ea43a06b39e6c","type":"TXT","name":"_acme-challenge.full","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:41.421 +0000 UTC","modified":"2020-06-12 08:20:41.421 +0000 UTC"},{"id":"1c06fee6923324bc2727916d2157b3d8","type":"TXT","name":"_acme-challenge.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:43.363 +0000 UTC","modified":"2020-06-12 08:20:43.363 +0000 UTC"},{"id":"97dcfc7f529a65b944a11554e15dcdfb","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:44.557 +0000 UTC","modified":"2020-06-12 08:20:44.557 +0000 UTC"},{"id":"880d3713398b9301dda21a611cbd9ab0","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:45.499 +0000 UTC","modified":"2020-06-12 08:20:45.499 +0000 UTC"},{"id":"f794c3584778621edfa903a30a993f9b","type":"TXT","name":"_acme-challenge.noop","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:46.766 +0000 UTC","modified":"2020-06-12 08:20:46.766 +0000 UTC"}]}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Type:
+      content-length:
+      - '3991'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:34:44 GMT
-      Transfer-Encoding:
+      date:
+      - Fri, 12 Jun 2020 08:20:57 GMT
+      transfer-encoding:
       - chunked
-      Vary:
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
-      - '4'
-      X-Kong-Upstream-Latency:
-      - '3680'
+      x-kong-proxy-latency:
+      - '1'
+      x-kong-upstream-latency:
+      - '71'
     status:
       code: 200
       message: OK

--- a/tests/fixtures/cassettes/hetzner/IntegrationTests/test_provider_when_calling_delete_record_with_record_set_by_content_should_leave_others_untouched.yaml
+++ b/tests/fixtures/cassettes/hetzner/IntegrationTests/test_provider_when_calling_delete_record_with_record_set_by_content_should_leave_others_untouched.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -11,44 +11,44 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
     uri: https://dns.hetzner.com/api/v1/zones
   response:
     body:
-      string: '{"zones":[{"id":"xyncsydKx5x44qDZQCzpNM","name":"alt.coop","ttl":300,"registrar":"","legacy_dns_host":"","legacy_ns":["hydrogen.ns.hetzner.com.","helium.ns.hetzner.com.","oxygen.ns.hetzner.com."],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-07
-        01:23:59 +0000 UTC","verified":"2020-04-07 01:53:05.934062806 +0000 UTC m=+578.060435172","modified":"2020-04-08
-        10:38:16.278 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":75},{"id":"JkBqVJDW3PpqefBb274BCZ","name":"softwarekollektiv.de","ttl":86400,"registrar":"","legacy_dns_host":"","legacy_ns":[],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-08
-        18:53:25.589 +0000 UTC","verified":"2020-04-08T18:53:27Z","modified":"2020-04-13
-        15:17:43.767 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":9}],"meta":{"pagination":{"page":1,"per_page":100,"previous_page":1,"next_page":1,"last_page":1,"total_entries":2}}}
+      string: !!python/unicode '{"zones":[{"id":"hetznerapizoneid","name":"hetzner-api-test.de","ttl":3600,"registrar":"","legacy_dns_host":"","legacy_ns":["ns1.first-ns.de.","robotns2.second-ns.de.","robotns3.second-ns.com."],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-07
+        01:24:00 +0000 UTC","verified":"2020-04-07 01:51:26.114056422 +0000 UTC m=+478.240428717","modified":"2020-06-11
+        07:02:20.999 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":9}],"meta":{"pagination":{"page":1,"per_page":100,"previous_page":1,"next_page":1,"last_page":1,"total_entries":12}}}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '1329'
-      Content-Type:
+      content-length:
+      - '7887'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:34:44 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:20:57 GMT
+      transfer-encoding:
+      - chunked
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
+      x-kong-proxy-latency:
       - '1'
-      X-Kong-Upstream-Latency:
-      - '202'
+      x-kong-upstream-latency:
+      - '244'
     status:
       code: 200
       message: OK
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -59,52 +59,62 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
-    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=JkBqVJDW3PpqefBb274BCZ
+    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=hetznerapizoneid
   response:
     body:
-      string: '{"records":[{"id":"8jEciPwo7wF2obPTuBe3Yg","type":"SOA","name":"@","value":"ns1.your-server.de.
-        dns.hetzner.com. 2020041582 86400 7200 3600000 3600","zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        15:17:43.061 +0000 UTC","modified":"2020-04-13 20:34:36.046 +0000 UTC"},{"id":"ccLnXePkikrTK7MjNY2fqb","type":"A","name":"localhost.softwarekollektiv.de.","value":"127.0.0.1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:37.644 +0000 UTC","modified":"2020-04-13 20:32:37.644 +0000 UTC"},{"id":"JQmTbgVAzdx4AADJeLMM3X","type":"CNAME","name":"docs.softwarekollektiv.de.","value":"docs.example.com","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:43.98 +0000 UTC","modified":"2020-04-13 20:32:43.98 +0000 UTC"},{"id":"PJpHrVw6wqik5CTzECpacD","type":"TXT","name":"_acme-challenge.fqdn.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:51.209 +0000 UTC","modified":"2020-04-13 20:32:51.209 +0000 UTC"},{"id":"JB9a4EZrNKbRTLKKAmT6M4","type":"TXT","name":"_acme-challenge.full.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:59.487 +0000 UTC","modified":"2020-04-13 20:32:59.487 +0000 UTC"},{"id":"3KU7EYhoWvAzTENjVAsqwB","type":"TXT","name":"_acme-challenge.test.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:08.017 +0000 UTC","modified":"2020-04-13 20:33:08.017 +0000 UTC"},{"id":"JmFdAr7ZKkv3WFyxnEJL43","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:18.136 +0000 UTC","modified":"2020-04-13 20:33:18.136 +0000 UTC"},{"id":"XJBbqzDiukFE3f2YGcTokY","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:25.929 +0000 UTC","modified":"2020-04-13 20:33:25.929 +0000 UTC"},{"id":"fdSKTmeja8M8pc5vztxb64","type":"TXT","name":"_acme-challenge.noop.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:33.653 +0000 UTC","modified":"2020-04-13 20:33:33.653 +0000 UTC"}]}
+      string: !!python/unicode '{"records":[{"id":"9720b5653ca6fd0517ec91a8c6104685","type":"SOA","name":"@","value":"ns1.first-ns.de.
+        dns.hetzner.com. 2020061216 14400 3600 1814400 3600","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:24:42 +0000 UTC","modified":"2020-06-12 08:20:56.661 +0000 UTC"},{"id":"5b378a7097bdb11e6cbb5f58db6bb101","type":"MX","name":"@","value":"10
+        mail.server-zugang.eu.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:12 +0000 UTC","modified":"2020-04-07 01:25:12 +0000 UTC"},{"id":"a26cfdd36217e559c14b305a558f2a3c","type":"AAAA","name":"@","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"7d6f741802597845b97713596e35eaa7","type":"AAAA","name":"*","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"993bafd3e3b110a6a3acde9fe874426a","type":"NS","name":"@","value":"ns1.first-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"cc3e8297060b7bd794fed5fdec3ed91b","type":"NS","name":"@","value":"robotns2.second-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"c4602b1239d9f0747016f551c52b5774","type":"NS","name":"@","value":"robotns3.second-ns.com.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"77ae87e42a04bace81119eb2280c8dca","type":"A","name":"@","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"faff62d59434c666bac4174a1d18a955","type":"A","name":"*","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"fe6ac2081c630974662caeaa8715d435","type":"A","name":"localhost","value":"127.0.0.1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:37.307 +0000 UTC","modified":"2020-06-12 08:20:37.307 +0000 UTC"},{"id":"8e6b81a856d20f0c1802703b56d1b53d","type":"CNAME","name":"docs","value":"docs.example.com","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:38.743 +0000 UTC","modified":"2020-06-12 08:20:38.743 +0000 UTC"},{"id":"a5fc9854314c160019d9bd0fcaaf2e2a","type":"TXT","name":"_acme-challenge.fqdn","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:40.141 +0000 UTC","modified":"2020-06-12 08:20:40.141 +0000 UTC"},{"id":"101296724cdf3710d18ea43a06b39e6c","type":"TXT","name":"_acme-challenge.full","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:41.421 +0000 UTC","modified":"2020-06-12 08:20:41.421 +0000 UTC"},{"id":"1c06fee6923324bc2727916d2157b3d8","type":"TXT","name":"_acme-challenge.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:43.363 +0000 UTC","modified":"2020-06-12 08:20:43.363 +0000 UTC"},{"id":"97dcfc7f529a65b944a11554e15dcdfb","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:44.557 +0000 UTC","modified":"2020-06-12 08:20:44.557 +0000 UTC"},{"id":"880d3713398b9301dda21a611cbd9ab0","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:45.499 +0000 UTC","modified":"2020-06-12 08:20:45.499 +0000 UTC"},{"id":"f794c3584778621edfa903a30a993f9b","type":"TXT","name":"_acme-challenge.noop","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:46.766 +0000 UTC","modified":"2020-06-12 08:20:46.766 +0000 UTC"}]}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Type:
+      content-length:
+      - '3991'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:34:48 GMT
-      Transfer-Encoding:
+      date:
+      - Fri, 12 Jun 2020 08:20:57 GMT
+      transfer-encoding:
       - chunked
-      Vary:
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
+      x-kong-proxy-latency:
       - '2'
-      X-Kong-Upstream-Latency:
-      - '3099'
+      x-kong-upstream-latency:
+      - '55'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"name": "_acme-challenge.deleterecordinset.softwarekollektiv.de.", "type":
-      "TXT", "value": "challengetoken1", "zone_id": "JkBqVJDW3PpqefBb274BCZ", "ttl":
-      3600}'
+    body: !!python/unicode '{"ttl": 3600, "type": "TXT", "name": "_acme-challenge.deleterecordinset",
+      "value": "challengetoken1", "zone_id": "hetznerapizoneid"}'
     headers:
       Accept:
       - '*/*'
@@ -113,43 +123,45 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '160'
+      - '138'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: POST
     uri: https://dns.hetzner.com/api/v1/records
   response:
     body:
-      string: '{"record":{"id":"dqxVeAD24HDxUkzPtDmA4K","type":"TXT","name":"_acme-challenge.deleterecordinset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:34:48.394 +0000 UTC","modified":"2020-04-13 20:34:48.394 +0000 UTC"}}
+      string: !!python/unicode '{"record":{"id":"3f2c32d49b4b304d217205747beead4e","type":"TXT","name":"_acme-challenge.deleterecordinset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:57.975 +0000 UTC","modified":"2020-06-12 08:20:57.975 +0000 UTC"}}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '286'
-      Content-Type:
+      content-length:
+      - '274'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:34:51 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:20:58 GMT
+      transfer-encoding:
+      - chunked
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
+      x-kong-proxy-latency:
       - '1'
-      X-Kong-Upstream-Latency:
-      - '3280'
+      x-kong-upstream-latency:
+      - '681'
     status:
       code: 200
       message: OK
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -160,53 +172,63 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
-    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=JkBqVJDW3PpqefBb274BCZ
+    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=hetznerapizoneid
   response:
     body:
-      string: '{"records":[{"id":"8jEciPwo7wF2obPTuBe3Yg","type":"SOA","name":"@","value":"ns1.your-server.de.
-        dns.hetzner.com. 2020041583 86400 7200 3600000 3600","zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        15:17:43.061 +0000 UTC","modified":"2020-04-13 20:34:50.936 +0000 UTC"},{"id":"ccLnXePkikrTK7MjNY2fqb","type":"A","name":"localhost.softwarekollektiv.de.","value":"127.0.0.1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:37.644 +0000 UTC","modified":"2020-04-13 20:32:37.644 +0000 UTC"},{"id":"JQmTbgVAzdx4AADJeLMM3X","type":"CNAME","name":"docs.softwarekollektiv.de.","value":"docs.example.com","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:43.98 +0000 UTC","modified":"2020-04-13 20:32:43.98 +0000 UTC"},{"id":"PJpHrVw6wqik5CTzECpacD","type":"TXT","name":"_acme-challenge.fqdn.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:51.209 +0000 UTC","modified":"2020-04-13 20:32:51.209 +0000 UTC"},{"id":"JB9a4EZrNKbRTLKKAmT6M4","type":"TXT","name":"_acme-challenge.full.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:59.487 +0000 UTC","modified":"2020-04-13 20:32:59.487 +0000 UTC"},{"id":"3KU7EYhoWvAzTENjVAsqwB","type":"TXT","name":"_acme-challenge.test.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:08.017 +0000 UTC","modified":"2020-04-13 20:33:08.017 +0000 UTC"},{"id":"JmFdAr7ZKkv3WFyxnEJL43","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:18.136 +0000 UTC","modified":"2020-04-13 20:33:18.136 +0000 UTC"},{"id":"XJBbqzDiukFE3f2YGcTokY","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:25.929 +0000 UTC","modified":"2020-04-13 20:33:25.929 +0000 UTC"},{"id":"fdSKTmeja8M8pc5vztxb64","type":"TXT","name":"_acme-challenge.noop.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:33.653 +0000 UTC","modified":"2020-04-13 20:33:33.653 +0000 UTC"},{"id":"dqxVeAD24HDxUkzPtDmA4K","type":"TXT","name":"_acme-challenge.deleterecordinset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:34:48.394 +0000 UTC","modified":"2020-04-13 20:34:48.394 +0000 UTC"}]}
+      string: !!python/unicode '{"records":[{"id":"9720b5653ca6fd0517ec91a8c6104685","type":"SOA","name":"@","value":"ns1.first-ns.de.
+        dns.hetzner.com. 2020061217 14400 3600 1814400 3600","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:24:42 +0000 UTC","modified":"2020-06-12 08:20:58.083 +0000 UTC"},{"id":"5b378a7097bdb11e6cbb5f58db6bb101","type":"MX","name":"@","value":"10
+        mail.server-zugang.eu.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:12 +0000 UTC","modified":"2020-04-07 01:25:12 +0000 UTC"},{"id":"a26cfdd36217e559c14b305a558f2a3c","type":"AAAA","name":"@","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"7d6f741802597845b97713596e35eaa7","type":"AAAA","name":"*","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"993bafd3e3b110a6a3acde9fe874426a","type":"NS","name":"@","value":"ns1.first-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"cc3e8297060b7bd794fed5fdec3ed91b","type":"NS","name":"@","value":"robotns2.second-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"c4602b1239d9f0747016f551c52b5774","type":"NS","name":"@","value":"robotns3.second-ns.com.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"77ae87e42a04bace81119eb2280c8dca","type":"A","name":"@","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"faff62d59434c666bac4174a1d18a955","type":"A","name":"*","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"fe6ac2081c630974662caeaa8715d435","type":"A","name":"localhost","value":"127.0.0.1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:37.307 +0000 UTC","modified":"2020-06-12 08:20:37.307 +0000 UTC"},{"id":"8e6b81a856d20f0c1802703b56d1b53d","type":"CNAME","name":"docs","value":"docs.example.com","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:38.743 +0000 UTC","modified":"2020-06-12 08:20:38.743 +0000 UTC"},{"id":"a5fc9854314c160019d9bd0fcaaf2e2a","type":"TXT","name":"_acme-challenge.fqdn","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:40.141 +0000 UTC","modified":"2020-06-12 08:20:40.141 +0000 UTC"},{"id":"101296724cdf3710d18ea43a06b39e6c","type":"TXT","name":"_acme-challenge.full","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:41.421 +0000 UTC","modified":"2020-06-12 08:20:41.421 +0000 UTC"},{"id":"1c06fee6923324bc2727916d2157b3d8","type":"TXT","name":"_acme-challenge.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:43.363 +0000 UTC","modified":"2020-06-12 08:20:43.363 +0000 UTC"},{"id":"97dcfc7f529a65b944a11554e15dcdfb","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:44.557 +0000 UTC","modified":"2020-06-12 08:20:44.557 +0000 UTC"},{"id":"880d3713398b9301dda21a611cbd9ab0","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:45.499 +0000 UTC","modified":"2020-06-12 08:20:45.499 +0000 UTC"},{"id":"f794c3584778621edfa903a30a993f9b","type":"TXT","name":"_acme-challenge.noop","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:46.766 +0000 UTC","modified":"2020-06-12 08:20:46.766 +0000 UTC"},{"id":"3f2c32d49b4b304d217205747beead4e","type":"TXT","name":"_acme-challenge.deleterecordinset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:57.975 +0000 UTC","modified":"2020-06-12 08:20:57.975 +0000 UTC"}]}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Type:
+      content-length:
+      - '4254'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:34:55 GMT
-      Transfer-Encoding:
+      date:
+      - Fri, 12 Jun 2020 08:20:58 GMT
+      transfer-encoding:
       - chunked
-      Vary:
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
+      x-kong-proxy-latency:
       - '1'
-      X-Kong-Upstream-Latency:
-      - '3923'
+      x-kong-upstream-latency:
+      - '72'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"name": "_acme-challenge.deleterecordinset.softwarekollektiv.de.", "type":
-      "TXT", "value": "challengetoken2", "zone_id": "JkBqVJDW3PpqefBb274BCZ", "ttl":
-      3600}'
+    body: !!python/unicode '{"ttl": 3600, "type": "TXT", "name": "_acme-challenge.deleterecordinset",
+      "value": "challengetoken2", "zone_id": "hetznerapizoneid"}'
     headers:
       Accept:
       - '*/*'
@@ -215,43 +237,45 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '160'
+      - '138'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: POST
     uri: https://dns.hetzner.com/api/v1/records
   response:
     body:
-      string: '{"record":{"id":"uDPTMe8hikMxgVAGznkN5S","type":"TXT","name":"_acme-challenge.deleterecordinset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:34:55.913 +0000 UTC","modified":"2020-04-13 20:34:55.913 +0000 UTC"}}
+      string: !!python/unicode '{"record":{"id":"fe7ddc85cc3c919385d8d2aabfa407eb","type":"TXT","name":"_acme-challenge.deleterecordinset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:58.928 +0000 UTC","modified":"2020-06-12 08:20:58.928 +0000 UTC"}}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '286'
-      Content-Type:
+      content-length:
+      - '274'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:34:59 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:20:59 GMT
+      transfer-encoding:
+      - chunked
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
+      x-kong-proxy-latency:
       - '2'
-      X-Kong-Upstream-Latency:
-      - '3874'
+      x-kong-upstream-latency:
+      - '661'
     status:
       code: 200
       message: OK
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -262,52 +286,63 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
-    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=JkBqVJDW3PpqefBb274BCZ
+    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=hetznerapizoneid
   response:
     body:
-      string: '{"records":[{"id":"8jEciPwo7wF2obPTuBe3Yg","type":"SOA","name":"@","value":"ns1.your-server.de.
-        dns.hetzner.com. 2020041584 86400 7200 3600000 3600","zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        15:17:43.061 +0000 UTC","modified":"2020-04-13 20:34:59.09 +0000 UTC"},{"id":"ccLnXePkikrTK7MjNY2fqb","type":"A","name":"localhost.softwarekollektiv.de.","value":"127.0.0.1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:37.644 +0000 UTC","modified":"2020-04-13 20:32:37.644 +0000 UTC"},{"id":"JQmTbgVAzdx4AADJeLMM3X","type":"CNAME","name":"docs.softwarekollektiv.de.","value":"docs.example.com","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:43.98 +0000 UTC","modified":"2020-04-13 20:32:43.98 +0000 UTC"},{"id":"PJpHrVw6wqik5CTzECpacD","type":"TXT","name":"_acme-challenge.fqdn.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:51.209 +0000 UTC","modified":"2020-04-13 20:32:51.209 +0000 UTC"},{"id":"JB9a4EZrNKbRTLKKAmT6M4","type":"TXT","name":"_acme-challenge.full.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:59.487 +0000 UTC","modified":"2020-04-13 20:32:59.487 +0000 UTC"},{"id":"3KU7EYhoWvAzTENjVAsqwB","type":"TXT","name":"_acme-challenge.test.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:08.017 +0000 UTC","modified":"2020-04-13 20:33:08.017 +0000 UTC"},{"id":"JmFdAr7ZKkv3WFyxnEJL43","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:18.136 +0000 UTC","modified":"2020-04-13 20:33:18.136 +0000 UTC"},{"id":"XJBbqzDiukFE3f2YGcTokY","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:25.929 +0000 UTC","modified":"2020-04-13 20:33:25.929 +0000 UTC"},{"id":"fdSKTmeja8M8pc5vztxb64","type":"TXT","name":"_acme-challenge.noop.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:33.653 +0000 UTC","modified":"2020-04-13 20:33:33.653 +0000 UTC"},{"id":"dqxVeAD24HDxUkzPtDmA4K","type":"TXT","name":"_acme-challenge.deleterecordinset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:34:48.394 +0000 UTC","modified":"2020-04-13 20:34:48.394 +0000 UTC"},{"id":"uDPTMe8hikMxgVAGznkN5S","type":"TXT","name":"_acme-challenge.deleterecordinset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:34:55.913 +0000 UTC","modified":"2020-04-13 20:34:55.913 +0000 UTC"}]}
+      string: !!python/unicode '{"records":[{"id":"9720b5653ca6fd0517ec91a8c6104685","type":"SOA","name":"@","value":"ns1.first-ns.de.
+        dns.hetzner.com. 2020061218 14400 3600 1814400 3600","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:24:42 +0000 UTC","modified":"2020-06-12 08:20:59.033 +0000 UTC"},{"id":"5b378a7097bdb11e6cbb5f58db6bb101","type":"MX","name":"@","value":"10
+        mail.server-zugang.eu.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:12 +0000 UTC","modified":"2020-04-07 01:25:12 +0000 UTC"},{"id":"a26cfdd36217e559c14b305a558f2a3c","type":"AAAA","name":"@","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"7d6f741802597845b97713596e35eaa7","type":"AAAA","name":"*","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"993bafd3e3b110a6a3acde9fe874426a","type":"NS","name":"@","value":"ns1.first-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"cc3e8297060b7bd794fed5fdec3ed91b","type":"NS","name":"@","value":"robotns2.second-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"c4602b1239d9f0747016f551c52b5774","type":"NS","name":"@","value":"robotns3.second-ns.com.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"77ae87e42a04bace81119eb2280c8dca","type":"A","name":"@","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"faff62d59434c666bac4174a1d18a955","type":"A","name":"*","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"fe6ac2081c630974662caeaa8715d435","type":"A","name":"localhost","value":"127.0.0.1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:37.307 +0000 UTC","modified":"2020-06-12 08:20:37.307 +0000 UTC"},{"id":"8e6b81a856d20f0c1802703b56d1b53d","type":"CNAME","name":"docs","value":"docs.example.com","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:38.743 +0000 UTC","modified":"2020-06-12 08:20:38.743 +0000 UTC"},{"id":"a5fc9854314c160019d9bd0fcaaf2e2a","type":"TXT","name":"_acme-challenge.fqdn","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:40.141 +0000 UTC","modified":"2020-06-12 08:20:40.141 +0000 UTC"},{"id":"101296724cdf3710d18ea43a06b39e6c","type":"TXT","name":"_acme-challenge.full","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:41.421 +0000 UTC","modified":"2020-06-12 08:20:41.421 +0000 UTC"},{"id":"1c06fee6923324bc2727916d2157b3d8","type":"TXT","name":"_acme-challenge.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:43.363 +0000 UTC","modified":"2020-06-12 08:20:43.363 +0000 UTC"},{"id":"97dcfc7f529a65b944a11554e15dcdfb","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:44.557 +0000 UTC","modified":"2020-06-12 08:20:44.557 +0000 UTC"},{"id":"880d3713398b9301dda21a611cbd9ab0","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:45.499 +0000 UTC","modified":"2020-06-12 08:20:45.499 +0000 UTC"},{"id":"f794c3584778621edfa903a30a993f9b","type":"TXT","name":"_acme-challenge.noop","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:46.766 +0000 UTC","modified":"2020-06-12 08:20:46.766 +0000 UTC"},{"id":"3f2c32d49b4b304d217205747beead4e","type":"TXT","name":"_acme-challenge.deleterecordinset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:57.975 +0000 UTC","modified":"2020-06-12 08:20:57.975 +0000 UTC"},{"id":"fe7ddc85cc3c919385d8d2aabfa407eb","type":"TXT","name":"_acme-challenge.deleterecordinset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:58.928 +0000 UTC","modified":"2020-06-12 08:20:58.928 +0000 UTC"}]}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Type:
+      content-length:
+      - '4517'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:35:03 GMT
-      Transfer-Encoding:
+      date:
+      - Fri, 12 Jun 2020 08:20:59 GMT
+      transfer-encoding:
       - chunked
-      Vary:
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
+      x-kong-proxy-latency:
       - '1'
-      X-Kong-Upstream-Latency:
-      - '3117'
+      x-kong-upstream-latency:
+      - '74'
     status:
       code: 200
       message: OK
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -318,40 +353,40 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: DELETE
-    uri: https://dns.hetzner.com/api/v1/records/dqxVeAD24HDxUkzPtDmA4K
+    uri: https://dns.hetzner.com/api/v1/records/3f2c32d49b4b304d217205747beead4e
   response:
     body:
-      string: '{"error":{}}
+      string: !!python/unicode '{"error":{}}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
+      content-length:
       - '13'
-      Content-Type:
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:35:03 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:21:00 GMT
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
-      - '1'
-      X-Kong-Upstream-Latency:
-      - '278'
+      x-kong-proxy-latency:
+      - '2'
+      x-kong-upstream-latency:
+      - '669'
     status:
       code: 200
       message: OK
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -362,46 +397,57 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
-    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=JkBqVJDW3PpqefBb274BCZ
+    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=hetznerapizoneid
   response:
     body:
-      string: '{"records":[{"id":"8jEciPwo7wF2obPTuBe3Yg","type":"SOA","name":"@","value":"ns1.your-server.de.
-        dns.hetzner.com. 2020041584 86400 7200 3600000 3600","zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        15:17:43.061 +0000 UTC","modified":"2020-04-13 20:34:59.09 +0000 UTC"},{"id":"ccLnXePkikrTK7MjNY2fqb","type":"A","name":"localhost.softwarekollektiv.de.","value":"127.0.0.1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:37.644 +0000 UTC","modified":"2020-04-13 20:32:37.644 +0000 UTC"},{"id":"JQmTbgVAzdx4AADJeLMM3X","type":"CNAME","name":"docs.softwarekollektiv.de.","value":"docs.example.com","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:43.98 +0000 UTC","modified":"2020-04-13 20:32:43.98 +0000 UTC"},{"id":"PJpHrVw6wqik5CTzECpacD","type":"TXT","name":"_acme-challenge.fqdn.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:51.209 +0000 UTC","modified":"2020-04-13 20:32:51.209 +0000 UTC"},{"id":"JB9a4EZrNKbRTLKKAmT6M4","type":"TXT","name":"_acme-challenge.full.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:59.487 +0000 UTC","modified":"2020-04-13 20:32:59.487 +0000 UTC"},{"id":"3KU7EYhoWvAzTENjVAsqwB","type":"TXT","name":"_acme-challenge.test.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:08.017 +0000 UTC","modified":"2020-04-13 20:33:08.017 +0000 UTC"},{"id":"JmFdAr7ZKkv3WFyxnEJL43","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:18.136 +0000 UTC","modified":"2020-04-13 20:33:18.136 +0000 UTC"},{"id":"XJBbqzDiukFE3f2YGcTokY","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:25.929 +0000 UTC","modified":"2020-04-13 20:33:25.929 +0000 UTC"},{"id":"fdSKTmeja8M8pc5vztxb64","type":"TXT","name":"_acme-challenge.noop.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:33.653 +0000 UTC","modified":"2020-04-13 20:33:33.653 +0000 UTC"},{"id":"uDPTMe8hikMxgVAGznkN5S","type":"TXT","name":"_acme-challenge.deleterecordinset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:34:55.913 +0000 UTC","modified":"2020-04-13 20:34:55.913 +0000 UTC"}]}
+      string: !!python/unicode '{"records":[{"id":"9720b5653ca6fd0517ec91a8c6104685","type":"SOA","name":"@","value":"ns1.first-ns.de.
+        dns.hetzner.com. 2020061219 14400 3600 1814400 3600","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:24:42 +0000 UTC","modified":"2020-06-12 08:20:59.977 +0000 UTC"},{"id":"5b378a7097bdb11e6cbb5f58db6bb101","type":"MX","name":"@","value":"10
+        mail.server-zugang.eu.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:12 +0000 UTC","modified":"2020-04-07 01:25:12 +0000 UTC"},{"id":"a26cfdd36217e559c14b305a558f2a3c","type":"AAAA","name":"@","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"7d6f741802597845b97713596e35eaa7","type":"AAAA","name":"*","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"993bafd3e3b110a6a3acde9fe874426a","type":"NS","name":"@","value":"ns1.first-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"cc3e8297060b7bd794fed5fdec3ed91b","type":"NS","name":"@","value":"robotns2.second-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"c4602b1239d9f0747016f551c52b5774","type":"NS","name":"@","value":"robotns3.second-ns.com.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"77ae87e42a04bace81119eb2280c8dca","type":"A","name":"@","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"faff62d59434c666bac4174a1d18a955","type":"A","name":"*","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"fe6ac2081c630974662caeaa8715d435","type":"A","name":"localhost","value":"127.0.0.1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:37.307 +0000 UTC","modified":"2020-06-12 08:20:37.307 +0000 UTC"},{"id":"8e6b81a856d20f0c1802703b56d1b53d","type":"CNAME","name":"docs","value":"docs.example.com","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:38.743 +0000 UTC","modified":"2020-06-12 08:20:38.743 +0000 UTC"},{"id":"a5fc9854314c160019d9bd0fcaaf2e2a","type":"TXT","name":"_acme-challenge.fqdn","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:40.141 +0000 UTC","modified":"2020-06-12 08:20:40.141 +0000 UTC"},{"id":"101296724cdf3710d18ea43a06b39e6c","type":"TXT","name":"_acme-challenge.full","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:41.421 +0000 UTC","modified":"2020-06-12 08:20:41.421 +0000 UTC"},{"id":"1c06fee6923324bc2727916d2157b3d8","type":"TXT","name":"_acme-challenge.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:43.363 +0000 UTC","modified":"2020-06-12 08:20:43.363 +0000 UTC"},{"id":"97dcfc7f529a65b944a11554e15dcdfb","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:44.557 +0000 UTC","modified":"2020-06-12 08:20:44.557 +0000 UTC"},{"id":"880d3713398b9301dda21a611cbd9ab0","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:45.499 +0000 UTC","modified":"2020-06-12 08:20:45.499 +0000 UTC"},{"id":"f794c3584778621edfa903a30a993f9b","type":"TXT","name":"_acme-challenge.noop","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:46.766 +0000 UTC","modified":"2020-06-12 08:20:46.766 +0000 UTC"},{"id":"fe7ddc85cc3c919385d8d2aabfa407eb","type":"TXT","name":"_acme-challenge.deleterecordinset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:58.928 +0000 UTC","modified":"2020-06-12 08:20:58.928 +0000 UTC"}]}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Type:
+      content-length:
+      - '4254'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:35:06 GMT
-      Transfer-Encoding:
+      date:
+      - Fri, 12 Jun 2020 08:21:00 GMT
+      transfer-encoding:
       - chunked
-      Vary:
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
+      x-kong-proxy-latency:
       - '1'
-      X-Kong-Upstream-Latency:
-      - '2943'
+      x-kong-upstream-latency:
+      - '69'
     status:
       code: 200
       message: OK

--- a/tests/fixtures/cassettes/hetzner/IntegrationTests/test_provider_when_calling_delete_record_with_record_set_name_remove_all.yaml
+++ b/tests/fixtures/cassettes/hetzner/IntegrationTests/test_provider_when_calling_delete_record_with_record_set_name_remove_all.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -11,44 +11,44 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
     uri: https://dns.hetzner.com/api/v1/zones
   response:
     body:
-      string: '{"zones":[{"id":"xyncsydKx5x44qDZQCzpNM","name":"alt.coop","ttl":300,"registrar":"","legacy_dns_host":"","legacy_ns":["oxygen.ns.hetzner.com.","hydrogen.ns.hetzner.com.","helium.ns.hetzner.com."],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-07
-        01:23:59 +0000 UTC","verified":"2020-04-07 01:53:05.934062806 +0000 UTC m=+578.060435172","modified":"2020-04-08
-        10:38:16.278 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":75},{"id":"JkBqVJDW3PpqefBb274BCZ","name":"softwarekollektiv.de","ttl":86400,"registrar":"","legacy_dns_host":"","legacy_ns":[],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-08
-        18:53:25.589 +0000 UTC","verified":"2020-04-08T18:53:27Z","modified":"2020-04-13
-        15:17:43.767 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":10}],"meta":{"pagination":{"page":1,"per_page":100,"previous_page":1,"next_page":1,"last_page":1,"total_entries":2}}}
+      string: !!python/unicode '{"zones":[{"id":"hetznerapizoneid","name":"hetzner-api-test.de","ttl":3600,"registrar":"","legacy_dns_host":"","legacy_ns":["ns1.first-ns.de.","robotns2.second-ns.de.","robotns3.second-ns.com."],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-07
+        01:24:00 +0000 UTC","verified":"2020-04-07 01:51:26.114056422 +0000 UTC m=+478.240428717","modified":"2020-06-11
+        07:02:20.999 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":9}],"meta":{"pagination":{"page":1,"per_page":100,"previous_page":1,"next_page":1,"last_page":1,"total_entries":12}}}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '1330'
-      Content-Type:
+      content-length:
+      - '7887'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:35:07 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:21:01 GMT
+      transfer-encoding:
+      - chunked
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
-      - '0'
-      X-Kong-Upstream-Latency:
-      - '195'
+      x-kong-proxy-latency:
+      - '1'
+      x-kong-upstream-latency:
+      - '246'
     status:
       code: 200
       message: OK
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -59,53 +59,63 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
-    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=JkBqVJDW3PpqefBb274BCZ
+    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=hetznerapizoneid
   response:
     body:
-      string: '{"records":[{"id":"8jEciPwo7wF2obPTuBe3Yg","type":"SOA","name":"@","value":"ns1.your-server.de.
-        dns.hetzner.com. 2020041584 86400 7200 3600000 3600","zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        15:17:43.061 +0000 UTC","modified":"2020-04-13 20:34:59.09 +0000 UTC"},{"id":"ccLnXePkikrTK7MjNY2fqb","type":"A","name":"localhost.softwarekollektiv.de.","value":"127.0.0.1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:37.644 +0000 UTC","modified":"2020-04-13 20:32:37.644 +0000 UTC"},{"id":"JQmTbgVAzdx4AADJeLMM3X","type":"CNAME","name":"docs.softwarekollektiv.de.","value":"docs.example.com","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:43.98 +0000 UTC","modified":"2020-04-13 20:32:43.98 +0000 UTC"},{"id":"PJpHrVw6wqik5CTzECpacD","type":"TXT","name":"_acme-challenge.fqdn.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:51.209 +0000 UTC","modified":"2020-04-13 20:32:51.209 +0000 UTC"},{"id":"JB9a4EZrNKbRTLKKAmT6M4","type":"TXT","name":"_acme-challenge.full.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:59.487 +0000 UTC","modified":"2020-04-13 20:32:59.487 +0000 UTC"},{"id":"3KU7EYhoWvAzTENjVAsqwB","type":"TXT","name":"_acme-challenge.test.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:08.017 +0000 UTC","modified":"2020-04-13 20:33:08.017 +0000 UTC"},{"id":"JmFdAr7ZKkv3WFyxnEJL43","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:18.136 +0000 UTC","modified":"2020-04-13 20:33:18.136 +0000 UTC"},{"id":"XJBbqzDiukFE3f2YGcTokY","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:25.929 +0000 UTC","modified":"2020-04-13 20:33:25.929 +0000 UTC"},{"id":"fdSKTmeja8M8pc5vztxb64","type":"TXT","name":"_acme-challenge.noop.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:33.653 +0000 UTC","modified":"2020-04-13 20:33:33.653 +0000 UTC"},{"id":"uDPTMe8hikMxgVAGznkN5S","type":"TXT","name":"_acme-challenge.deleterecordinset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:34:55.913 +0000 UTC","modified":"2020-04-13 20:34:55.913 +0000 UTC"}]}
+      string: !!python/unicode '{"records":[{"id":"9720b5653ca6fd0517ec91a8c6104685","type":"SOA","name":"@","value":"ns1.first-ns.de.
+        dns.hetzner.com. 2020061219 14400 3600 1814400 3600","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:24:42 +0000 UTC","modified":"2020-06-12 08:20:59.977 +0000 UTC"},{"id":"5b378a7097bdb11e6cbb5f58db6bb101","type":"MX","name":"@","value":"10
+        mail.server-zugang.eu.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:12 +0000 UTC","modified":"2020-04-07 01:25:12 +0000 UTC"},{"id":"a26cfdd36217e559c14b305a558f2a3c","type":"AAAA","name":"@","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"7d6f741802597845b97713596e35eaa7","type":"AAAA","name":"*","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"993bafd3e3b110a6a3acde9fe874426a","type":"NS","name":"@","value":"ns1.first-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"cc3e8297060b7bd794fed5fdec3ed91b","type":"NS","name":"@","value":"robotns2.second-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"c4602b1239d9f0747016f551c52b5774","type":"NS","name":"@","value":"robotns3.second-ns.com.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"77ae87e42a04bace81119eb2280c8dca","type":"A","name":"@","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"faff62d59434c666bac4174a1d18a955","type":"A","name":"*","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"fe6ac2081c630974662caeaa8715d435","type":"A","name":"localhost","value":"127.0.0.1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:37.307 +0000 UTC","modified":"2020-06-12 08:20:37.307 +0000 UTC"},{"id":"8e6b81a856d20f0c1802703b56d1b53d","type":"CNAME","name":"docs","value":"docs.example.com","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:38.743 +0000 UTC","modified":"2020-06-12 08:20:38.743 +0000 UTC"},{"id":"a5fc9854314c160019d9bd0fcaaf2e2a","type":"TXT","name":"_acme-challenge.fqdn","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:40.141 +0000 UTC","modified":"2020-06-12 08:20:40.141 +0000 UTC"},{"id":"101296724cdf3710d18ea43a06b39e6c","type":"TXT","name":"_acme-challenge.full","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:41.421 +0000 UTC","modified":"2020-06-12 08:20:41.421 +0000 UTC"},{"id":"1c06fee6923324bc2727916d2157b3d8","type":"TXT","name":"_acme-challenge.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:43.363 +0000 UTC","modified":"2020-06-12 08:20:43.363 +0000 UTC"},{"id":"97dcfc7f529a65b944a11554e15dcdfb","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:44.557 +0000 UTC","modified":"2020-06-12 08:20:44.557 +0000 UTC"},{"id":"880d3713398b9301dda21a611cbd9ab0","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:45.499 +0000 UTC","modified":"2020-06-12 08:20:45.499 +0000 UTC"},{"id":"f794c3584778621edfa903a30a993f9b","type":"TXT","name":"_acme-challenge.noop","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:46.766 +0000 UTC","modified":"2020-06-12 08:20:46.766 +0000 UTC"},{"id":"fe7ddc85cc3c919385d8d2aabfa407eb","type":"TXT","name":"_acme-challenge.deleterecordinset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:58.928 +0000 UTC","modified":"2020-06-12 08:20:58.928 +0000 UTC"}]}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Type:
+      content-length:
+      - '4254'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:35:10 GMT
-      Transfer-Encoding:
+      date:
+      - Fri, 12 Jun 2020 08:21:01 GMT
+      transfer-encoding:
       - chunked
-      Vary:
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
-      - '2'
-      X-Kong-Upstream-Latency:
-      - '3305'
+      x-kong-proxy-latency:
+      - '1'
+      x-kong-upstream-latency:
+      - '55'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"name": "_acme-challenge.deleterecordset.softwarekollektiv.de.", "type":
-      "TXT", "value": "challengetoken1", "zone_id": "JkBqVJDW3PpqefBb274BCZ", "ttl":
-      3600}'
+    body: !!python/unicode '{"ttl": 3600, "type": "TXT", "name": "_acme-challenge.deleterecordset",
+      "value": "challengetoken1", "zone_id": "hetznerapizoneid"}'
     headers:
       Accept:
       - '*/*'
@@ -114,43 +124,45 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '158'
+      - '136'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: POST
     uri: https://dns.hetzner.com/api/v1/records
   response:
     body:
-      string: '{"record":{"id":"s2MXhU85uhNMKCSjCfeWLn","type":"TXT","name":"_acme-challenge.deleterecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:35:10.749 +0000 UTC","modified":"2020-04-13 20:35:10.749 +0000 UTC"}}
+      string: !!python/unicode '{"record":{"id":"f59c6fe34b3c3ac203a2690ef71b11b3","type":"TXT","name":"_acme-challenge.deleterecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:01.335 +0000 UTC","modified":"2020-06-12 08:21:01.335 +0000 UTC"}}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '284'
-      Content-Type:
+      content-length:
+      - '272'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:35:15 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:21:01 GMT
+      transfer-encoding:
+      - chunked
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
+      x-kong-proxy-latency:
       - '1'
-      X-Kong-Upstream-Latency:
-      - '4317'
+      x-kong-upstream-latency:
+      - '619'
     status:
       code: 200
       message: OK
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -161,54 +173,64 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
-    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=JkBqVJDW3PpqefBb274BCZ
+    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=hetznerapizoneid
   response:
     body:
-      string: '{"records":[{"id":"8jEciPwo7wF2obPTuBe3Yg","type":"SOA","name":"@","value":"ns1.your-server.de.
-        dns.hetzner.com. 2020041585 86400 7200 3600000 3600","zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        15:17:43.061 +0000 UTC","modified":"2020-04-13 20:35:14.26 +0000 UTC"},{"id":"ccLnXePkikrTK7MjNY2fqb","type":"A","name":"localhost.softwarekollektiv.de.","value":"127.0.0.1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:37.644 +0000 UTC","modified":"2020-04-13 20:32:37.644 +0000 UTC"},{"id":"JQmTbgVAzdx4AADJeLMM3X","type":"CNAME","name":"docs.softwarekollektiv.de.","value":"docs.example.com","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:43.98 +0000 UTC","modified":"2020-04-13 20:32:43.98 +0000 UTC"},{"id":"PJpHrVw6wqik5CTzECpacD","type":"TXT","name":"_acme-challenge.fqdn.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:51.209 +0000 UTC","modified":"2020-04-13 20:32:51.209 +0000 UTC"},{"id":"JB9a4EZrNKbRTLKKAmT6M4","type":"TXT","name":"_acme-challenge.full.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:59.487 +0000 UTC","modified":"2020-04-13 20:32:59.487 +0000 UTC"},{"id":"3KU7EYhoWvAzTENjVAsqwB","type":"TXT","name":"_acme-challenge.test.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:08.017 +0000 UTC","modified":"2020-04-13 20:33:08.017 +0000 UTC"},{"id":"JmFdAr7ZKkv3WFyxnEJL43","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:18.136 +0000 UTC","modified":"2020-04-13 20:33:18.136 +0000 UTC"},{"id":"XJBbqzDiukFE3f2YGcTokY","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:25.929 +0000 UTC","modified":"2020-04-13 20:33:25.929 +0000 UTC"},{"id":"fdSKTmeja8M8pc5vztxb64","type":"TXT","name":"_acme-challenge.noop.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:33.653 +0000 UTC","modified":"2020-04-13 20:33:33.653 +0000 UTC"},{"id":"uDPTMe8hikMxgVAGznkN5S","type":"TXT","name":"_acme-challenge.deleterecordinset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:34:55.913 +0000 UTC","modified":"2020-04-13 20:34:55.913 +0000 UTC"},{"id":"s2MXhU85uhNMKCSjCfeWLn","type":"TXT","name":"_acme-challenge.deleterecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:35:10.749 +0000 UTC","modified":"2020-04-13 20:35:10.749 +0000 UTC"}]}
+      string: !!python/unicode '{"records":[{"id":"9720b5653ca6fd0517ec91a8c6104685","type":"SOA","name":"@","value":"ns1.first-ns.de.
+        dns.hetzner.com. 2020061220 14400 3600 1814400 3600","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:24:42 +0000 UTC","modified":"2020-06-12 08:21:01.445 +0000 UTC"},{"id":"5b378a7097bdb11e6cbb5f58db6bb101","type":"MX","name":"@","value":"10
+        mail.server-zugang.eu.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:12 +0000 UTC","modified":"2020-04-07 01:25:12 +0000 UTC"},{"id":"a26cfdd36217e559c14b305a558f2a3c","type":"AAAA","name":"@","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"7d6f741802597845b97713596e35eaa7","type":"AAAA","name":"*","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"993bafd3e3b110a6a3acde9fe874426a","type":"NS","name":"@","value":"ns1.first-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"cc3e8297060b7bd794fed5fdec3ed91b","type":"NS","name":"@","value":"robotns2.second-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"c4602b1239d9f0747016f551c52b5774","type":"NS","name":"@","value":"robotns3.second-ns.com.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"77ae87e42a04bace81119eb2280c8dca","type":"A","name":"@","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"faff62d59434c666bac4174a1d18a955","type":"A","name":"*","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"fe6ac2081c630974662caeaa8715d435","type":"A","name":"localhost","value":"127.0.0.1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:37.307 +0000 UTC","modified":"2020-06-12 08:20:37.307 +0000 UTC"},{"id":"8e6b81a856d20f0c1802703b56d1b53d","type":"CNAME","name":"docs","value":"docs.example.com","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:38.743 +0000 UTC","modified":"2020-06-12 08:20:38.743 +0000 UTC"},{"id":"a5fc9854314c160019d9bd0fcaaf2e2a","type":"TXT","name":"_acme-challenge.fqdn","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:40.141 +0000 UTC","modified":"2020-06-12 08:20:40.141 +0000 UTC"},{"id":"101296724cdf3710d18ea43a06b39e6c","type":"TXT","name":"_acme-challenge.full","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:41.421 +0000 UTC","modified":"2020-06-12 08:20:41.421 +0000 UTC"},{"id":"1c06fee6923324bc2727916d2157b3d8","type":"TXT","name":"_acme-challenge.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:43.363 +0000 UTC","modified":"2020-06-12 08:20:43.363 +0000 UTC"},{"id":"97dcfc7f529a65b944a11554e15dcdfb","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:44.557 +0000 UTC","modified":"2020-06-12 08:20:44.557 +0000 UTC"},{"id":"880d3713398b9301dda21a611cbd9ab0","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:45.499 +0000 UTC","modified":"2020-06-12 08:20:45.499 +0000 UTC"},{"id":"f794c3584778621edfa903a30a993f9b","type":"TXT","name":"_acme-challenge.noop","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:46.766 +0000 UTC","modified":"2020-06-12 08:20:46.766 +0000 UTC"},{"id":"fe7ddc85cc3c919385d8d2aabfa407eb","type":"TXT","name":"_acme-challenge.deleterecordinset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:58.928 +0000 UTC","modified":"2020-06-12 08:20:58.928 +0000 UTC"},{"id":"f59c6fe34b3c3ac203a2690ef71b11b3","type":"TXT","name":"_acme-challenge.deleterecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:01.335 +0000 UTC","modified":"2020-06-12 08:21:01.335 +0000 UTC"}]}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Type:
+      content-length:
+      - '4515'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:35:18 GMT
-      Transfer-Encoding:
+      date:
+      - Fri, 12 Jun 2020 08:21:02 GMT
+      transfer-encoding:
       - chunked
-      Vary:
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
-      - '1'
-      X-Kong-Upstream-Latency:
-      - '3586'
+      x-kong-proxy-latency:
+      - '3'
+      x-kong-upstream-latency:
+      - '68'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"name": "_acme-challenge.deleterecordset.softwarekollektiv.de.", "type":
-      "TXT", "value": "challengetoken2", "zone_id": "JkBqVJDW3PpqefBb274BCZ", "ttl":
-      3600}'
+    body: !!python/unicode '{"ttl": 3600, "type": "TXT", "name": "_acme-challenge.deleterecordset",
+      "value": "challengetoken2", "zone_id": "hetznerapizoneid"}'
     headers:
       Accept:
       - '*/*'
@@ -217,43 +239,45 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '158'
+      - '136'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: POST
     uri: https://dns.hetzner.com/api/v1/records
   response:
     body:
-      string: '{"record":{"id":"fjUFaWqcSVwt7WP2hEaBaf","type":"TXT","name":"_acme-challenge.deleterecordset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:35:19.012 +0000 UTC","modified":"2020-04-13 20:35:19.012 +0000 UTC"}}
+      string: !!python/unicode '{"record":{"id":"419eec002d3f3363e577f2a255c6828f","type":"TXT","name":"_acme-challenge.deleterecordset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:02.229 +0000 UTC","modified":"2020-06-12 08:21:02.229 +0000 UTC"}}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '284'
-      Content-Type:
+      content-length:
+      - '272'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:35:22 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:21:02 GMT
+      transfer-encoding:
+      - chunked
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
-      - '2'
-      X-Kong-Upstream-Latency:
-      - '3225'
+      x-kong-proxy-latency:
+      - '1'
+      x-kong-upstream-latency:
+      - '660'
     status:
       code: 200
       message: OK
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -264,53 +288,108 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
-    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=JkBqVJDW3PpqefBb274BCZ
+    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=hetznerapizoneid
   response:
     body:
-      string: '{"records":[{"id":"8jEciPwo7wF2obPTuBe3Yg","type":"SOA","name":"@","value":"ns1.your-server.de.
-        dns.hetzner.com. 2020041586 86400 7200 3600000 3600","zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        15:17:43.061 +0000 UTC","modified":"2020-04-13 20:35:21.619 +0000 UTC"},{"id":"ccLnXePkikrTK7MjNY2fqb","type":"A","name":"localhost.softwarekollektiv.de.","value":"127.0.0.1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:37.644 +0000 UTC","modified":"2020-04-13 20:32:37.644 +0000 UTC"},{"id":"JQmTbgVAzdx4AADJeLMM3X","type":"CNAME","name":"docs.softwarekollektiv.de.","value":"docs.example.com","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:43.98 +0000 UTC","modified":"2020-04-13 20:32:43.98 +0000 UTC"},{"id":"PJpHrVw6wqik5CTzECpacD","type":"TXT","name":"_acme-challenge.fqdn.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:51.209 +0000 UTC","modified":"2020-04-13 20:32:51.209 +0000 UTC"},{"id":"JB9a4EZrNKbRTLKKAmT6M4","type":"TXT","name":"_acme-challenge.full.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:59.487 +0000 UTC","modified":"2020-04-13 20:32:59.487 +0000 UTC"},{"id":"3KU7EYhoWvAzTENjVAsqwB","type":"TXT","name":"_acme-challenge.test.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:08.017 +0000 UTC","modified":"2020-04-13 20:33:08.017 +0000 UTC"},{"id":"JmFdAr7ZKkv3WFyxnEJL43","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:18.136 +0000 UTC","modified":"2020-04-13 20:33:18.136 +0000 UTC"},{"id":"XJBbqzDiukFE3f2YGcTokY","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:25.929 +0000 UTC","modified":"2020-04-13 20:33:25.929 +0000 UTC"},{"id":"fdSKTmeja8M8pc5vztxb64","type":"TXT","name":"_acme-challenge.noop.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:33.653 +0000 UTC","modified":"2020-04-13 20:33:33.653 +0000 UTC"},{"id":"uDPTMe8hikMxgVAGznkN5S","type":"TXT","name":"_acme-challenge.deleterecordinset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:34:55.913 +0000 UTC","modified":"2020-04-13 20:34:55.913 +0000 UTC"},{"id":"s2MXhU85uhNMKCSjCfeWLn","type":"TXT","name":"_acme-challenge.deleterecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:35:10.749 +0000 UTC","modified":"2020-04-13 20:35:10.749 +0000 UTC"},{"id":"fjUFaWqcSVwt7WP2hEaBaf","type":"TXT","name":"_acme-challenge.deleterecordset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:35:19.012 +0000 UTC","modified":"2020-04-13 20:35:19.012 +0000 UTC"}]}
+      string: !!python/unicode '{"records":[{"id":"9720b5653ca6fd0517ec91a8c6104685","type":"SOA","name":"@","value":"ns1.first-ns.de.
+        dns.hetzner.com. 2020061221 14400 3600 1814400 3600","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:24:42 +0000 UTC","modified":"2020-06-12 08:21:02.344 +0000 UTC"},{"id":"5b378a7097bdb11e6cbb5f58db6bb101","type":"MX","name":"@","value":"10
+        mail.server-zugang.eu.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:12 +0000 UTC","modified":"2020-04-07 01:25:12 +0000 UTC"},{"id":"a26cfdd36217e559c14b305a558f2a3c","type":"AAAA","name":"@","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"7d6f741802597845b97713596e35eaa7","type":"AAAA","name":"*","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"993bafd3e3b110a6a3acde9fe874426a","type":"NS","name":"@","value":"ns1.first-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"cc3e8297060b7bd794fed5fdec3ed91b","type":"NS","name":"@","value":"robotns2.second-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"c4602b1239d9f0747016f551c52b5774","type":"NS","name":"@","value":"robotns3.second-ns.com.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"77ae87e42a04bace81119eb2280c8dca","type":"A","name":"@","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"faff62d59434c666bac4174a1d18a955","type":"A","name":"*","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"fe6ac2081c630974662caeaa8715d435","type":"A","name":"localhost","value":"127.0.0.1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:37.307 +0000 UTC","modified":"2020-06-12 08:20:37.307 +0000 UTC"},{"id":"8e6b81a856d20f0c1802703b56d1b53d","type":"CNAME","name":"docs","value":"docs.example.com","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:38.743 +0000 UTC","modified":"2020-06-12 08:20:38.743 +0000 UTC"},{"id":"a5fc9854314c160019d9bd0fcaaf2e2a","type":"TXT","name":"_acme-challenge.fqdn","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:40.141 +0000 UTC","modified":"2020-06-12 08:20:40.141 +0000 UTC"},{"id":"101296724cdf3710d18ea43a06b39e6c","type":"TXT","name":"_acme-challenge.full","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:41.421 +0000 UTC","modified":"2020-06-12 08:20:41.421 +0000 UTC"},{"id":"1c06fee6923324bc2727916d2157b3d8","type":"TXT","name":"_acme-challenge.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:43.363 +0000 UTC","modified":"2020-06-12 08:20:43.363 +0000 UTC"},{"id":"97dcfc7f529a65b944a11554e15dcdfb","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:44.557 +0000 UTC","modified":"2020-06-12 08:20:44.557 +0000 UTC"},{"id":"880d3713398b9301dda21a611cbd9ab0","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:45.499 +0000 UTC","modified":"2020-06-12 08:20:45.499 +0000 UTC"},{"id":"f794c3584778621edfa903a30a993f9b","type":"TXT","name":"_acme-challenge.noop","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:46.766 +0000 UTC","modified":"2020-06-12 08:20:46.766 +0000 UTC"},{"id":"fe7ddc85cc3c919385d8d2aabfa407eb","type":"TXT","name":"_acme-challenge.deleterecordinset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:58.928 +0000 UTC","modified":"2020-06-12 08:20:58.928 +0000 UTC"},{"id":"f59c6fe34b3c3ac203a2690ef71b11b3","type":"TXT","name":"_acme-challenge.deleterecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:01.335 +0000 UTC","modified":"2020-06-12 08:21:01.335 +0000 UTC"},{"id":"419eec002d3f3363e577f2a255c6828f","type":"TXT","name":"_acme-challenge.deleterecordset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:02.229 +0000 UTC","modified":"2020-06-12 08:21:02.229 +0000 UTC"}]}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Type:
+      content-length:
+      - '4776'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:35:25 GMT
-      Transfer-Encoding:
+      date:
+      - Fri, 12 Jun 2020 08:21:03 GMT
+      transfer-encoding:
       - chunked
-      Vary:
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
+      x-kong-proxy-latency:
+      - '25'
+      x-kong-upstream-latency:
+      - '75'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - !!python/unicode application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: DELETE
+    uri: https://dns.hetzner.com/api/v1/records/f59c6fe34b3c3ac203a2690ef71b11b3
+  response:
+    body:
+      string: !!python/unicode '{"error":{}}
+
+        '
+    headers:
+      access-control-allow-origin:
+      - '*'
+      connection:
+      - keep-alive
+      content-length:
+      - '13'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 12 Jun 2020 08:21:03 GMT
+      vary:
+      - Origin
+      via:
+      - kong/2.0.2
+      x-kong-proxy-latency:
       - '1'
-      X-Kong-Upstream-Latency:
-      - '3306'
+      x-kong-upstream-latency:
+      - '694'
     status:
       code: 200
       message: OK
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -321,40 +400,40 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: DELETE
-    uri: https://dns.hetzner.com/api/v1/records/s2MXhU85uhNMKCSjCfeWLn
+    uri: https://dns.hetzner.com/api/v1/records/419eec002d3f3363e577f2a255c6828f
   response:
     body:
-      string: '{"error":{}}
+      string: !!python/unicode '{"error":{}}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
+      content-length:
       - '13'
-      Content-Type:
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:35:26 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:21:04 GMT
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
+      x-kong-proxy-latency:
       - '2'
-      X-Kong-Upstream-Latency:
-      - '223'
+      x-kong-upstream-latency:
+      - '709'
     status:
       code: 200
       message: OK
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -365,90 +444,57 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.23.0
-    method: DELETE
-    uri: https://dns.hetzner.com/api/v1/records/fjUFaWqcSVwt7WP2hEaBaf
-  response:
-    body:
-      string: '{"error":{}}
-
-        '
-    headers:
-      Access-Control-Allow-Origin:
-      - '*'
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '13'
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:35:26 GMT
-      Vary:
-      - Origin
-      Via:
-      - kong/2.0.2
-      X-Kong-Proxy-Latency:
-      - '2'
-      X-Kong-Upstream-Latency:
-      - '104'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{}'
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '2'
-      Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
-    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=JkBqVJDW3PpqefBb274BCZ
+    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=hetznerapizoneid
   response:
     body:
-      string: '{"records":[{"id":"8jEciPwo7wF2obPTuBe3Yg","type":"SOA","name":"@","value":"ns1.your-server.de.
-        dns.hetzner.com. 2020041586 86400 7200 3600000 3600","zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        15:17:43.061 +0000 UTC","modified":"2020-04-13 20:35:21.619 +0000 UTC"},{"id":"ccLnXePkikrTK7MjNY2fqb","type":"A","name":"localhost.softwarekollektiv.de.","value":"127.0.0.1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:37.644 +0000 UTC","modified":"2020-04-13 20:32:37.644 +0000 UTC"},{"id":"JQmTbgVAzdx4AADJeLMM3X","type":"CNAME","name":"docs.softwarekollektiv.de.","value":"docs.example.com","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:43.98 +0000 UTC","modified":"2020-04-13 20:32:43.98 +0000 UTC"},{"id":"PJpHrVw6wqik5CTzECpacD","type":"TXT","name":"_acme-challenge.fqdn.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:51.209 +0000 UTC","modified":"2020-04-13 20:32:51.209 +0000 UTC"},{"id":"JB9a4EZrNKbRTLKKAmT6M4","type":"TXT","name":"_acme-challenge.full.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:59.487 +0000 UTC","modified":"2020-04-13 20:32:59.487 +0000 UTC"},{"id":"3KU7EYhoWvAzTENjVAsqwB","type":"TXT","name":"_acme-challenge.test.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:08.017 +0000 UTC","modified":"2020-04-13 20:33:08.017 +0000 UTC"},{"id":"JmFdAr7ZKkv3WFyxnEJL43","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:18.136 +0000 UTC","modified":"2020-04-13 20:33:18.136 +0000 UTC"},{"id":"XJBbqzDiukFE3f2YGcTokY","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:25.929 +0000 UTC","modified":"2020-04-13 20:33:25.929 +0000 UTC"},{"id":"fdSKTmeja8M8pc5vztxb64","type":"TXT","name":"_acme-challenge.noop.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:33.653 +0000 UTC","modified":"2020-04-13 20:33:33.653 +0000 UTC"},{"id":"uDPTMe8hikMxgVAGznkN5S","type":"TXT","name":"_acme-challenge.deleterecordinset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:34:55.913 +0000 UTC","modified":"2020-04-13 20:34:55.913 +0000 UTC"}]}
+      string: !!python/unicode '{"records":[{"id":"9720b5653ca6fd0517ec91a8c6104685","type":"SOA","name":"@","value":"ns1.first-ns.de.
+        dns.hetzner.com. 2020061223 14400 3600 1814400 3600","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:24:42 +0000 UTC","modified":"2020-06-12 08:21:04.097 +0000 UTC"},{"id":"5b378a7097bdb11e6cbb5f58db6bb101","type":"MX","name":"@","value":"10
+        mail.server-zugang.eu.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:12 +0000 UTC","modified":"2020-04-07 01:25:12 +0000 UTC"},{"id":"a26cfdd36217e559c14b305a558f2a3c","type":"AAAA","name":"@","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"7d6f741802597845b97713596e35eaa7","type":"AAAA","name":"*","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"993bafd3e3b110a6a3acde9fe874426a","type":"NS","name":"@","value":"ns1.first-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"cc3e8297060b7bd794fed5fdec3ed91b","type":"NS","name":"@","value":"robotns2.second-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"c4602b1239d9f0747016f551c52b5774","type":"NS","name":"@","value":"robotns3.second-ns.com.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"77ae87e42a04bace81119eb2280c8dca","type":"A","name":"@","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"faff62d59434c666bac4174a1d18a955","type":"A","name":"*","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"fe6ac2081c630974662caeaa8715d435","type":"A","name":"localhost","value":"127.0.0.1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:37.307 +0000 UTC","modified":"2020-06-12 08:20:37.307 +0000 UTC"},{"id":"8e6b81a856d20f0c1802703b56d1b53d","type":"CNAME","name":"docs","value":"docs.example.com","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:38.743 +0000 UTC","modified":"2020-06-12 08:20:38.743 +0000 UTC"},{"id":"a5fc9854314c160019d9bd0fcaaf2e2a","type":"TXT","name":"_acme-challenge.fqdn","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:40.141 +0000 UTC","modified":"2020-06-12 08:20:40.141 +0000 UTC"},{"id":"101296724cdf3710d18ea43a06b39e6c","type":"TXT","name":"_acme-challenge.full","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:41.421 +0000 UTC","modified":"2020-06-12 08:20:41.421 +0000 UTC"},{"id":"1c06fee6923324bc2727916d2157b3d8","type":"TXT","name":"_acme-challenge.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:43.363 +0000 UTC","modified":"2020-06-12 08:20:43.363 +0000 UTC"},{"id":"97dcfc7f529a65b944a11554e15dcdfb","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:44.557 +0000 UTC","modified":"2020-06-12 08:20:44.557 +0000 UTC"},{"id":"880d3713398b9301dda21a611cbd9ab0","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:45.499 +0000 UTC","modified":"2020-06-12 08:20:45.499 +0000 UTC"},{"id":"f794c3584778621edfa903a30a993f9b","type":"TXT","name":"_acme-challenge.noop","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:46.766 +0000 UTC","modified":"2020-06-12 08:20:46.766 +0000 UTC"},{"id":"fe7ddc85cc3c919385d8d2aabfa407eb","type":"TXT","name":"_acme-challenge.deleterecordinset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:58.928 +0000 UTC","modified":"2020-06-12 08:20:58.928 +0000 UTC"}]}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Type:
+      content-length:
+      - '4254'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:35:30 GMT
-      Transfer-Encoding:
+      date:
+      - Fri, 12 Jun 2020 08:21:04 GMT
+      transfer-encoding:
       - chunked
-      Vary:
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
+      x-kong-proxy-latency:
       - '1'
-      X-Kong-Upstream-Latency:
-      - '3746'
+      x-kong-upstream-latency:
+      - '131'
     status:
       code: 200
       message: OK

--- a/tests/fixtures/cassettes/hetzner/IntegrationTests/test_provider_when_calling_list_records_after_setting_ttl.yaml
+++ b/tests/fixtures/cassettes/hetzner/IntegrationTests/test_provider_when_calling_list_records_after_setting_ttl.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -11,44 +11,44 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
     uri: https://dns.hetzner.com/api/v1/zones
   response:
     body:
-      string: '{"zones":[{"id":"xyncsydKx5x44qDZQCzpNM","name":"alt.coop","ttl":300,"registrar":"","legacy_dns_host":"","legacy_ns":["oxygen.ns.hetzner.com.","hydrogen.ns.hetzner.com.","helium.ns.hetzner.com."],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-07
-        01:23:59 +0000 UTC","verified":"2020-04-07 01:53:05.934062806 +0000 UTC m=+578.060435172","modified":"2020-04-08
-        10:38:16.278 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":75},{"id":"JkBqVJDW3PpqefBb274BCZ","name":"softwarekollektiv.de","ttl":86400,"registrar":"","legacy_dns_host":"","legacy_ns":[],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-08
-        18:53:25.589 +0000 UTC","verified":"2020-04-08T18:53:27Z","modified":"2020-04-13
-        15:17:43.767 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":10}],"meta":{"pagination":{"page":1,"per_page":100,"previous_page":1,"next_page":1,"last_page":1,"total_entries":2}}}
+      string: !!python/unicode '{"zones":[{"id":"hetznerapizoneid","name":"hetzner-api-test.de","ttl":3600,"registrar":"","legacy_dns_host":"","legacy_ns":["ns1.first-ns.de.","robotns2.second-ns.de.","robotns3.second-ns.com."],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-07
+        01:24:00 +0000 UTC","verified":"2020-04-07 01:51:26.114056422 +0000 UTC m=+478.240428717","modified":"2020-06-11
+        07:02:20.999 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":9}],"meta":{"pagination":{"page":1,"per_page":100,"previous_page":1,"next_page":1,"last_page":1,"total_entries":12}}}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '1330'
-      Content-Type:
+      content-length:
+      - '7887'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:35:30 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:21:05 GMT
+      transfer-encoding:
+      - chunked
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
-      - '3'
-      X-Kong-Upstream-Latency:
-      - '195'
+      x-kong-proxy-latency:
+      - '1'
+      x-kong-upstream-latency:
+      - '270'
     status:
       code: 200
       message: OK
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -59,52 +59,63 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
-    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=JkBqVJDW3PpqefBb274BCZ
+    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=hetznerapizoneid
   response:
     body:
-      string: '{"records":[{"id":"8jEciPwo7wF2obPTuBe3Yg","type":"SOA","name":"@","value":"ns1.your-server.de.
-        dns.hetzner.com. 2020041586 86400 7200 3600000 3600","zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        15:17:43.061 +0000 UTC","modified":"2020-04-13 20:35:21.619 +0000 UTC"},{"id":"ccLnXePkikrTK7MjNY2fqb","type":"A","name":"localhost.softwarekollektiv.de.","value":"127.0.0.1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:37.644 +0000 UTC","modified":"2020-04-13 20:32:37.644 +0000 UTC"},{"id":"JQmTbgVAzdx4AADJeLMM3X","type":"CNAME","name":"docs.softwarekollektiv.de.","value":"docs.example.com","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:43.98 +0000 UTC","modified":"2020-04-13 20:32:43.98 +0000 UTC"},{"id":"PJpHrVw6wqik5CTzECpacD","type":"TXT","name":"_acme-challenge.fqdn.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:51.209 +0000 UTC","modified":"2020-04-13 20:32:51.209 +0000 UTC"},{"id":"JB9a4EZrNKbRTLKKAmT6M4","type":"TXT","name":"_acme-challenge.full.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:59.487 +0000 UTC","modified":"2020-04-13 20:32:59.487 +0000 UTC"},{"id":"3KU7EYhoWvAzTENjVAsqwB","type":"TXT","name":"_acme-challenge.test.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:08.017 +0000 UTC","modified":"2020-04-13 20:33:08.017 +0000 UTC"},{"id":"JmFdAr7ZKkv3WFyxnEJL43","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:18.136 +0000 UTC","modified":"2020-04-13 20:33:18.136 +0000 UTC"},{"id":"XJBbqzDiukFE3f2YGcTokY","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:25.929 +0000 UTC","modified":"2020-04-13 20:33:25.929 +0000 UTC"},{"id":"fdSKTmeja8M8pc5vztxb64","type":"TXT","name":"_acme-challenge.noop.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:33.653 +0000 UTC","modified":"2020-04-13 20:33:33.653 +0000 UTC"},{"id":"uDPTMe8hikMxgVAGznkN5S","type":"TXT","name":"_acme-challenge.deleterecordinset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:34:55.913 +0000 UTC","modified":"2020-04-13 20:34:55.913 +0000 UTC"}]}
+      string: !!python/unicode '{"records":[{"id":"9720b5653ca6fd0517ec91a8c6104685","type":"SOA","name":"@","value":"ns1.first-ns.de.
+        dns.hetzner.com. 2020061223 14400 3600 1814400 3600","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:24:42 +0000 UTC","modified":"2020-06-12 08:21:04.097 +0000 UTC"},{"id":"5b378a7097bdb11e6cbb5f58db6bb101","type":"MX","name":"@","value":"10
+        mail.server-zugang.eu.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:12 +0000 UTC","modified":"2020-04-07 01:25:12 +0000 UTC"},{"id":"a26cfdd36217e559c14b305a558f2a3c","type":"AAAA","name":"@","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"7d6f741802597845b97713596e35eaa7","type":"AAAA","name":"*","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"993bafd3e3b110a6a3acde9fe874426a","type":"NS","name":"@","value":"ns1.first-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"cc3e8297060b7bd794fed5fdec3ed91b","type":"NS","name":"@","value":"robotns2.second-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"c4602b1239d9f0747016f551c52b5774","type":"NS","name":"@","value":"robotns3.second-ns.com.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"77ae87e42a04bace81119eb2280c8dca","type":"A","name":"@","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"faff62d59434c666bac4174a1d18a955","type":"A","name":"*","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"fe6ac2081c630974662caeaa8715d435","type":"A","name":"localhost","value":"127.0.0.1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:37.307 +0000 UTC","modified":"2020-06-12 08:20:37.307 +0000 UTC"},{"id":"8e6b81a856d20f0c1802703b56d1b53d","type":"CNAME","name":"docs","value":"docs.example.com","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:38.743 +0000 UTC","modified":"2020-06-12 08:20:38.743 +0000 UTC"},{"id":"a5fc9854314c160019d9bd0fcaaf2e2a","type":"TXT","name":"_acme-challenge.fqdn","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:40.141 +0000 UTC","modified":"2020-06-12 08:20:40.141 +0000 UTC"},{"id":"101296724cdf3710d18ea43a06b39e6c","type":"TXT","name":"_acme-challenge.full","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:41.421 +0000 UTC","modified":"2020-06-12 08:20:41.421 +0000 UTC"},{"id":"1c06fee6923324bc2727916d2157b3d8","type":"TXT","name":"_acme-challenge.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:43.363 +0000 UTC","modified":"2020-06-12 08:20:43.363 +0000 UTC"},{"id":"97dcfc7f529a65b944a11554e15dcdfb","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:44.557 +0000 UTC","modified":"2020-06-12 08:20:44.557 +0000 UTC"},{"id":"880d3713398b9301dda21a611cbd9ab0","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:45.499 +0000 UTC","modified":"2020-06-12 08:20:45.499 +0000 UTC"},{"id":"f794c3584778621edfa903a30a993f9b","type":"TXT","name":"_acme-challenge.noop","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:46.766 +0000 UTC","modified":"2020-06-12 08:20:46.766 +0000 UTC"},{"id":"fe7ddc85cc3c919385d8d2aabfa407eb","type":"TXT","name":"_acme-challenge.deleterecordinset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:58.928 +0000 UTC","modified":"2020-06-12 08:20:58.928 +0000 UTC"}]}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Type:
+      content-length:
+      - '4254'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:35:33 GMT
-      Transfer-Encoding:
+      date:
+      - Fri, 12 Jun 2020 08:21:05 GMT
+      transfer-encoding:
       - chunked
-      Vary:
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
-      - '7'
-      X-Kong-Upstream-Latency:
-      - '2678'
+      x-kong-proxy-latency:
+      - '1'
+      x-kong-upstream-latency:
+      - '84'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"name": "ttl.fqdn.softwarekollektiv.de.", "type": "TXT", "value": "ttlshouldbe3600",
-      "zone_id": "JkBqVJDW3PpqefBb274BCZ", "ttl": 3600}'
+    body: !!python/unicode '{"ttl": 3600, "type": "TXT", "name": "ttl.fqdn", "value":
+      "ttlshouldbe3600", "zone_id": "hetznerapizoneid"}'
     headers:
       Accept:
       - '*/*'
@@ -113,43 +124,45 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '135'
+      - '113'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: POST
     uri: https://dns.hetzner.com/api/v1/records
   response:
     body:
-      string: '{"record":{"id":"pwek8RBHdnTi2eS3NGEkCG","type":"TXT","name":"ttl.fqdn.softwarekollektiv.de.","value":"ttlshouldbe3600","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:35:33.676 +0000 UTC","modified":"2020-04-13 20:35:33.676 +0000 UTC"}}
+      string: !!python/unicode '{"record":{"id":"61efb963c73466f54f6bba592e9340d4","type":"TXT","name":"ttl.fqdn","value":"ttlshouldbe3600","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:05.618 +0000 UTC","modified":"2020-06-12 08:21:05.618 +0000 UTC"}}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '261'
-      Content-Type:
+      content-length:
+      - '249'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:35:36 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:21:06 GMT
+      transfer-encoding:
+      - chunked
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
-      - '0'
-      X-Kong-Upstream-Latency:
-      - '3357'
+      x-kong-proxy-latency:
+      - '1'
+      x-kong-upstream-latency:
+      - '655'
     status:
       code: 200
       message: OK
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -160,47 +173,58 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
-    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=JkBqVJDW3PpqefBb274BCZ
+    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=hetznerapizoneid
   response:
     body:
-      string: '{"records":[{"id":"8jEciPwo7wF2obPTuBe3Yg","type":"SOA","name":"@","value":"ns1.your-server.de.
-        dns.hetzner.com. 2020041587 86400 7200 3600000 3600","zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        15:17:43.061 +0000 UTC","modified":"2020-04-13 20:35:36.447 +0000 UTC"},{"id":"ccLnXePkikrTK7MjNY2fqb","type":"A","name":"localhost.softwarekollektiv.de.","value":"127.0.0.1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:37.644 +0000 UTC","modified":"2020-04-13 20:32:37.644 +0000 UTC"},{"id":"JQmTbgVAzdx4AADJeLMM3X","type":"CNAME","name":"docs.softwarekollektiv.de.","value":"docs.example.com","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:43.98 +0000 UTC","modified":"2020-04-13 20:32:43.98 +0000 UTC"},{"id":"PJpHrVw6wqik5CTzECpacD","type":"TXT","name":"_acme-challenge.fqdn.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:51.209 +0000 UTC","modified":"2020-04-13 20:32:51.209 +0000 UTC"},{"id":"JB9a4EZrNKbRTLKKAmT6M4","type":"TXT","name":"_acme-challenge.full.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:59.487 +0000 UTC","modified":"2020-04-13 20:32:59.487 +0000 UTC"},{"id":"3KU7EYhoWvAzTENjVAsqwB","type":"TXT","name":"_acme-challenge.test.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:08.017 +0000 UTC","modified":"2020-04-13 20:33:08.017 +0000 UTC"},{"id":"JmFdAr7ZKkv3WFyxnEJL43","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:18.136 +0000 UTC","modified":"2020-04-13 20:33:18.136 +0000 UTC"},{"id":"XJBbqzDiukFE3f2YGcTokY","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:25.929 +0000 UTC","modified":"2020-04-13 20:33:25.929 +0000 UTC"},{"id":"fdSKTmeja8M8pc5vztxb64","type":"TXT","name":"_acme-challenge.noop.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:33.653 +0000 UTC","modified":"2020-04-13 20:33:33.653 +0000 UTC"},{"id":"uDPTMe8hikMxgVAGznkN5S","type":"TXT","name":"_acme-challenge.deleterecordinset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:34:55.913 +0000 UTC","modified":"2020-04-13 20:34:55.913 +0000 UTC"},{"id":"pwek8RBHdnTi2eS3NGEkCG","type":"TXT","name":"ttl.fqdn.softwarekollektiv.de.","value":"ttlshouldbe3600","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:35:33.676 +0000 UTC","modified":"2020-04-13 20:35:33.676 +0000 UTC"}]}
+      string: !!python/unicode '{"records":[{"id":"9720b5653ca6fd0517ec91a8c6104685","type":"SOA","name":"@","value":"ns1.first-ns.de.
+        dns.hetzner.com. 2020061224 14400 3600 1814400 3600","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:24:42 +0000 UTC","modified":"2020-06-12 08:21:05.72 +0000 UTC"},{"id":"5b378a7097bdb11e6cbb5f58db6bb101","type":"MX","name":"@","value":"10
+        mail.server-zugang.eu.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:12 +0000 UTC","modified":"2020-04-07 01:25:12 +0000 UTC"},{"id":"a26cfdd36217e559c14b305a558f2a3c","type":"AAAA","name":"@","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"7d6f741802597845b97713596e35eaa7","type":"AAAA","name":"*","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"993bafd3e3b110a6a3acde9fe874426a","type":"NS","name":"@","value":"ns1.first-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"cc3e8297060b7bd794fed5fdec3ed91b","type":"NS","name":"@","value":"robotns2.second-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"c4602b1239d9f0747016f551c52b5774","type":"NS","name":"@","value":"robotns3.second-ns.com.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"77ae87e42a04bace81119eb2280c8dca","type":"A","name":"@","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"faff62d59434c666bac4174a1d18a955","type":"A","name":"*","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"fe6ac2081c630974662caeaa8715d435","type":"A","name":"localhost","value":"127.0.0.1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:37.307 +0000 UTC","modified":"2020-06-12 08:20:37.307 +0000 UTC"},{"id":"8e6b81a856d20f0c1802703b56d1b53d","type":"CNAME","name":"docs","value":"docs.example.com","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:38.743 +0000 UTC","modified":"2020-06-12 08:20:38.743 +0000 UTC"},{"id":"a5fc9854314c160019d9bd0fcaaf2e2a","type":"TXT","name":"_acme-challenge.fqdn","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:40.141 +0000 UTC","modified":"2020-06-12 08:20:40.141 +0000 UTC"},{"id":"101296724cdf3710d18ea43a06b39e6c","type":"TXT","name":"_acme-challenge.full","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:41.421 +0000 UTC","modified":"2020-06-12 08:20:41.421 +0000 UTC"},{"id":"1c06fee6923324bc2727916d2157b3d8","type":"TXT","name":"_acme-challenge.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:43.363 +0000 UTC","modified":"2020-06-12 08:20:43.363 +0000 UTC"},{"id":"97dcfc7f529a65b944a11554e15dcdfb","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:44.557 +0000 UTC","modified":"2020-06-12 08:20:44.557 +0000 UTC"},{"id":"880d3713398b9301dda21a611cbd9ab0","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:45.499 +0000 UTC","modified":"2020-06-12 08:20:45.499 +0000 UTC"},{"id":"f794c3584778621edfa903a30a993f9b","type":"TXT","name":"_acme-challenge.noop","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:46.766 +0000 UTC","modified":"2020-06-12 08:20:46.766 +0000 UTC"},{"id":"fe7ddc85cc3c919385d8d2aabfa407eb","type":"TXT","name":"_acme-challenge.deleterecordinset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:58.928 +0000 UTC","modified":"2020-06-12 08:20:58.928 +0000 UTC"},{"id":"61efb963c73466f54f6bba592e9340d4","type":"TXT","name":"ttl.fqdn","value":"ttlshouldbe3600","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:05.618 +0000 UTC","modified":"2020-06-12 08:21:05.618 +0000 UTC"}]}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Type:
+      content-length:
+      - '4491'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:35:40 GMT
-      Transfer-Encoding:
+      date:
+      - Fri, 12 Jun 2020 08:21:06 GMT
+      transfer-encoding:
       - chunked
-      Vary:
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
+      x-kong-proxy-latency:
       - '1'
-      X-Kong-Upstream-Latency:
-      - '3613'
+      x-kong-upstream-latency:
+      - '79'
     status:
       code: 200
       message: OK

--- a/tests/fixtures/cassettes/hetzner/IntegrationTests/test_provider_when_calling_list_records_should_handle_record_sets.yaml
+++ b/tests/fixtures/cassettes/hetzner/IntegrationTests/test_provider_when_calling_list_records_should_handle_record_sets.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -11,44 +11,44 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
     uri: https://dns.hetzner.com/api/v1/zones
   response:
     body:
-      string: '{"zones":[{"id":"xyncsydKx5x44qDZQCzpNM","name":"alt.coop","ttl":300,"registrar":"","legacy_dns_host":"","legacy_ns":["helium.ns.hetzner.com.","oxygen.ns.hetzner.com.","hydrogen.ns.hetzner.com."],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-07
-        01:23:59 +0000 UTC","verified":"2020-04-07 01:53:05.934062806 +0000 UTC m=+578.060435172","modified":"2020-04-08
-        10:38:16.278 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":75},{"id":"JkBqVJDW3PpqefBb274BCZ","name":"softwarekollektiv.de","ttl":86400,"registrar":"","legacy_dns_host":"","legacy_ns":[],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-08
-        18:53:25.589 +0000 UTC","verified":"2020-04-08T18:53:27Z","modified":"2020-04-13
-        15:17:43.767 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":11}],"meta":{"pagination":{"page":1,"per_page":100,"previous_page":1,"next_page":1,"last_page":1,"total_entries":2}}}
+      string: !!python/unicode '{"zones":[{"id":"hetznerapizoneid","name":"hetzner-api-test.de","ttl":3600,"registrar":"","legacy_dns_host":"","legacy_ns":["ns1.first-ns.de.","robotns2.second-ns.de.","robotns3.second-ns.com."],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-07
+        01:24:00 +0000 UTC","verified":"2020-04-07 01:51:26.114056422 +0000 UTC m=+478.240428717","modified":"2020-06-11
+        07:02:20.999 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":9}],"meta":{"pagination":{"page":1,"per_page":100,"previous_page":1,"next_page":1,"last_page":1,"total_entries":12}}}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '1330'
-      Content-Type:
+      content-length:
+      - '7887'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:35:41 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:21:06 GMT
+      transfer-encoding:
+      - chunked
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
-      - '2'
-      X-Kong-Upstream-Latency:
-      - '190'
+      x-kong-proxy-latency:
+      - '1'
+      x-kong-upstream-latency:
+      - '230'
     status:
       code: 200
       message: OK
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -59,54 +59,64 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
-    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=JkBqVJDW3PpqefBb274BCZ
+    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=hetznerapizoneid
   response:
     body:
-      string: '{"records":[{"id":"8jEciPwo7wF2obPTuBe3Yg","type":"SOA","name":"@","value":"ns1.your-server.de.
-        dns.hetzner.com. 2020041587 86400 7200 3600000 3600","zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        15:17:43.061 +0000 UTC","modified":"2020-04-13 20:35:36.447 +0000 UTC"},{"id":"ccLnXePkikrTK7MjNY2fqb","type":"A","name":"localhost.softwarekollektiv.de.","value":"127.0.0.1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:37.644 +0000 UTC","modified":"2020-04-13 20:32:37.644 +0000 UTC"},{"id":"JQmTbgVAzdx4AADJeLMM3X","type":"CNAME","name":"docs.softwarekollektiv.de.","value":"docs.example.com","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:43.98 +0000 UTC","modified":"2020-04-13 20:32:43.98 +0000 UTC"},{"id":"PJpHrVw6wqik5CTzECpacD","type":"TXT","name":"_acme-challenge.fqdn.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:51.209 +0000 UTC","modified":"2020-04-13 20:32:51.209 +0000 UTC"},{"id":"JB9a4EZrNKbRTLKKAmT6M4","type":"TXT","name":"_acme-challenge.full.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:59.487 +0000 UTC","modified":"2020-04-13 20:32:59.487 +0000 UTC"},{"id":"3KU7EYhoWvAzTENjVAsqwB","type":"TXT","name":"_acme-challenge.test.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:08.017 +0000 UTC","modified":"2020-04-13 20:33:08.017 +0000 UTC"},{"id":"JmFdAr7ZKkv3WFyxnEJL43","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:18.136 +0000 UTC","modified":"2020-04-13 20:33:18.136 +0000 UTC"},{"id":"XJBbqzDiukFE3f2YGcTokY","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:25.929 +0000 UTC","modified":"2020-04-13 20:33:25.929 +0000 UTC"},{"id":"fdSKTmeja8M8pc5vztxb64","type":"TXT","name":"_acme-challenge.noop.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:33.653 +0000 UTC","modified":"2020-04-13 20:33:33.653 +0000 UTC"},{"id":"uDPTMe8hikMxgVAGznkN5S","type":"TXT","name":"_acme-challenge.deleterecordinset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:34:55.913 +0000 UTC","modified":"2020-04-13 20:34:55.913 +0000 UTC"},{"id":"pwek8RBHdnTi2eS3NGEkCG","type":"TXT","name":"ttl.fqdn.softwarekollektiv.de.","value":"ttlshouldbe3600","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:35:33.676 +0000 UTC","modified":"2020-04-13 20:35:33.676 +0000 UTC"}]}
+      string: !!python/unicode '{"records":[{"id":"9720b5653ca6fd0517ec91a8c6104685","type":"SOA","name":"@","value":"ns1.first-ns.de.
+        dns.hetzner.com. 2020061224 14400 3600 1814400 3600","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:24:42 +0000 UTC","modified":"2020-06-12 08:21:05.72 +0000 UTC"},{"id":"5b378a7097bdb11e6cbb5f58db6bb101","type":"MX","name":"@","value":"10
+        mail.server-zugang.eu.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:12 +0000 UTC","modified":"2020-04-07 01:25:12 +0000 UTC"},{"id":"a26cfdd36217e559c14b305a558f2a3c","type":"AAAA","name":"@","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"7d6f741802597845b97713596e35eaa7","type":"AAAA","name":"*","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"993bafd3e3b110a6a3acde9fe874426a","type":"NS","name":"@","value":"ns1.first-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"cc3e8297060b7bd794fed5fdec3ed91b","type":"NS","name":"@","value":"robotns2.second-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"c4602b1239d9f0747016f551c52b5774","type":"NS","name":"@","value":"robotns3.second-ns.com.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"77ae87e42a04bace81119eb2280c8dca","type":"A","name":"@","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"faff62d59434c666bac4174a1d18a955","type":"A","name":"*","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"fe6ac2081c630974662caeaa8715d435","type":"A","name":"localhost","value":"127.0.0.1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:37.307 +0000 UTC","modified":"2020-06-12 08:20:37.307 +0000 UTC"},{"id":"8e6b81a856d20f0c1802703b56d1b53d","type":"CNAME","name":"docs","value":"docs.example.com","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:38.743 +0000 UTC","modified":"2020-06-12 08:20:38.743 +0000 UTC"},{"id":"a5fc9854314c160019d9bd0fcaaf2e2a","type":"TXT","name":"_acme-challenge.fqdn","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:40.141 +0000 UTC","modified":"2020-06-12 08:20:40.141 +0000 UTC"},{"id":"101296724cdf3710d18ea43a06b39e6c","type":"TXT","name":"_acme-challenge.full","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:41.421 +0000 UTC","modified":"2020-06-12 08:20:41.421 +0000 UTC"},{"id":"1c06fee6923324bc2727916d2157b3d8","type":"TXT","name":"_acme-challenge.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:43.363 +0000 UTC","modified":"2020-06-12 08:20:43.363 +0000 UTC"},{"id":"97dcfc7f529a65b944a11554e15dcdfb","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:44.557 +0000 UTC","modified":"2020-06-12 08:20:44.557 +0000 UTC"},{"id":"880d3713398b9301dda21a611cbd9ab0","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:45.499 +0000 UTC","modified":"2020-06-12 08:20:45.499 +0000 UTC"},{"id":"f794c3584778621edfa903a30a993f9b","type":"TXT","name":"_acme-challenge.noop","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:46.766 +0000 UTC","modified":"2020-06-12 08:20:46.766 +0000 UTC"},{"id":"fe7ddc85cc3c919385d8d2aabfa407eb","type":"TXT","name":"_acme-challenge.deleterecordinset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:58.928 +0000 UTC","modified":"2020-06-12 08:20:58.928 +0000 UTC"},{"id":"61efb963c73466f54f6bba592e9340d4","type":"TXT","name":"ttl.fqdn","value":"ttlshouldbe3600","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:05.618 +0000 UTC","modified":"2020-06-12 08:21:05.618 +0000 UTC"}]}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Type:
+      content-length:
+      - '4491'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:35:43 GMT
-      Transfer-Encoding:
+      date:
+      - Fri, 12 Jun 2020 08:21:06 GMT
+      transfer-encoding:
       - chunked
-      Vary:
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
+      x-kong-proxy-latency:
       - '1'
-      X-Kong-Upstream-Latency:
-      - '2536'
+      x-kong-upstream-latency:
+      - '72'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"name": "_acme-challenge.listrecordset.softwarekollektiv.de.", "type":
-      "TXT", "value": "challengetoken1", "zone_id": "JkBqVJDW3PpqefBb274BCZ", "ttl":
-      3600}'
+    body: !!python/unicode '{"ttl": 3600, "type": "TXT", "name": "_acme-challenge.listrecordset",
+      "value": "challengetoken1", "zone_id": "hetznerapizoneid"}'
     headers:
       Accept:
       - '*/*'
@@ -115,43 +125,45 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '156'
+      - '134'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: POST
     uri: https://dns.hetzner.com/api/v1/records
   response:
     body:
-      string: '{"record":{"id":"wei55NH2jLAWwwnmB6ZFjf","type":"TXT","name":"_acme-challenge.listrecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:35:43.97 +0000 UTC","modified":"2020-04-13 20:35:43.97 +0000 UTC"}}
+      string: !!python/unicode '{"record":{"id":"2d5abe2e3b1030903b6ededf674fb76a","type":"TXT","name":"_acme-challenge.listrecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:07.078 +0000 UTC","modified":"2020-06-12 08:21:07.078 +0000 UTC"}}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '280'
-      Content-Type:
+      content-length:
+      - '270'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:35:47 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:21:07 GMT
+      transfer-encoding:
+      - chunked
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
+      x-kong-proxy-latency:
       - '1'
-      X-Kong-Upstream-Latency:
-      - '3480'
+      x-kong-upstream-latency:
+      - '611'
     status:
       code: 200
       message: OK
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -162,55 +174,65 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
-    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=JkBqVJDW3PpqefBb274BCZ
+    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=hetznerapizoneid
   response:
     body:
-      string: '{"records":[{"id":"8jEciPwo7wF2obPTuBe3Yg","type":"SOA","name":"@","value":"ns1.your-server.de.
-        dns.hetzner.com. 2020041588 86400 7200 3600000 3600","zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        15:17:43.061 +0000 UTC","modified":"2020-04-13 20:35:46.687 +0000 UTC"},{"id":"ccLnXePkikrTK7MjNY2fqb","type":"A","name":"localhost.softwarekollektiv.de.","value":"127.0.0.1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:37.644 +0000 UTC","modified":"2020-04-13 20:32:37.644 +0000 UTC"},{"id":"JQmTbgVAzdx4AADJeLMM3X","type":"CNAME","name":"docs.softwarekollektiv.de.","value":"docs.example.com","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:43.98 +0000 UTC","modified":"2020-04-13 20:32:43.98 +0000 UTC"},{"id":"PJpHrVw6wqik5CTzECpacD","type":"TXT","name":"_acme-challenge.fqdn.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:51.209 +0000 UTC","modified":"2020-04-13 20:32:51.209 +0000 UTC"},{"id":"JB9a4EZrNKbRTLKKAmT6M4","type":"TXT","name":"_acme-challenge.full.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:59.487 +0000 UTC","modified":"2020-04-13 20:32:59.487 +0000 UTC"},{"id":"3KU7EYhoWvAzTENjVAsqwB","type":"TXT","name":"_acme-challenge.test.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:08.017 +0000 UTC","modified":"2020-04-13 20:33:08.017 +0000 UTC"},{"id":"JmFdAr7ZKkv3WFyxnEJL43","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:18.136 +0000 UTC","modified":"2020-04-13 20:33:18.136 +0000 UTC"},{"id":"XJBbqzDiukFE3f2YGcTokY","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:25.929 +0000 UTC","modified":"2020-04-13 20:33:25.929 +0000 UTC"},{"id":"fdSKTmeja8M8pc5vztxb64","type":"TXT","name":"_acme-challenge.noop.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:33.653 +0000 UTC","modified":"2020-04-13 20:33:33.653 +0000 UTC"},{"id":"uDPTMe8hikMxgVAGznkN5S","type":"TXT","name":"_acme-challenge.deleterecordinset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:34:55.913 +0000 UTC","modified":"2020-04-13 20:34:55.913 +0000 UTC"},{"id":"pwek8RBHdnTi2eS3NGEkCG","type":"TXT","name":"ttl.fqdn.softwarekollektiv.de.","value":"ttlshouldbe3600","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:35:33.676 +0000 UTC","modified":"2020-04-13 20:35:33.676 +0000 UTC"},{"id":"wei55NH2jLAWwwnmB6ZFjf","type":"TXT","name":"_acme-challenge.listrecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:35:43.97 +0000 UTC","modified":"2020-04-13 20:35:43.97 +0000 UTC"}]}
+      string: !!python/unicode '{"records":[{"id":"9720b5653ca6fd0517ec91a8c6104685","type":"SOA","name":"@","value":"ns1.first-ns.de.
+        dns.hetzner.com. 2020061225 14400 3600 1814400 3600","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:24:42 +0000 UTC","modified":"2020-06-12 08:21:07.196 +0000 UTC"},{"id":"5b378a7097bdb11e6cbb5f58db6bb101","type":"MX","name":"@","value":"10
+        mail.server-zugang.eu.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:12 +0000 UTC","modified":"2020-04-07 01:25:12 +0000 UTC"},{"id":"a26cfdd36217e559c14b305a558f2a3c","type":"AAAA","name":"@","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"7d6f741802597845b97713596e35eaa7","type":"AAAA","name":"*","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"993bafd3e3b110a6a3acde9fe874426a","type":"NS","name":"@","value":"ns1.first-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"cc3e8297060b7bd794fed5fdec3ed91b","type":"NS","name":"@","value":"robotns2.second-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"c4602b1239d9f0747016f551c52b5774","type":"NS","name":"@","value":"robotns3.second-ns.com.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"77ae87e42a04bace81119eb2280c8dca","type":"A","name":"@","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"faff62d59434c666bac4174a1d18a955","type":"A","name":"*","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"fe6ac2081c630974662caeaa8715d435","type":"A","name":"localhost","value":"127.0.0.1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:37.307 +0000 UTC","modified":"2020-06-12 08:20:37.307 +0000 UTC"},{"id":"8e6b81a856d20f0c1802703b56d1b53d","type":"CNAME","name":"docs","value":"docs.example.com","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:38.743 +0000 UTC","modified":"2020-06-12 08:20:38.743 +0000 UTC"},{"id":"a5fc9854314c160019d9bd0fcaaf2e2a","type":"TXT","name":"_acme-challenge.fqdn","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:40.141 +0000 UTC","modified":"2020-06-12 08:20:40.141 +0000 UTC"},{"id":"101296724cdf3710d18ea43a06b39e6c","type":"TXT","name":"_acme-challenge.full","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:41.421 +0000 UTC","modified":"2020-06-12 08:20:41.421 +0000 UTC"},{"id":"1c06fee6923324bc2727916d2157b3d8","type":"TXT","name":"_acme-challenge.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:43.363 +0000 UTC","modified":"2020-06-12 08:20:43.363 +0000 UTC"},{"id":"97dcfc7f529a65b944a11554e15dcdfb","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:44.557 +0000 UTC","modified":"2020-06-12 08:20:44.557 +0000 UTC"},{"id":"880d3713398b9301dda21a611cbd9ab0","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:45.499 +0000 UTC","modified":"2020-06-12 08:20:45.499 +0000 UTC"},{"id":"f794c3584778621edfa903a30a993f9b","type":"TXT","name":"_acme-challenge.noop","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:46.766 +0000 UTC","modified":"2020-06-12 08:20:46.766 +0000 UTC"},{"id":"fe7ddc85cc3c919385d8d2aabfa407eb","type":"TXT","name":"_acme-challenge.deleterecordinset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:58.928 +0000 UTC","modified":"2020-06-12 08:20:58.928 +0000 UTC"},{"id":"61efb963c73466f54f6bba592e9340d4","type":"TXT","name":"ttl.fqdn","value":"ttlshouldbe3600","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:05.618 +0000 UTC","modified":"2020-06-12 08:21:05.618 +0000 UTC"},{"id":"2d5abe2e3b1030903b6ededf674fb76a","type":"TXT","name":"_acme-challenge.listrecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:07.078 +0000 UTC","modified":"2020-06-12 08:21:07.078 +0000 UTC"}]}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Type:
+      content-length:
+      - '4751'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:35:51 GMT
-      Transfer-Encoding:
+      date:
+      - Fri, 12 Jun 2020 08:21:07 GMT
+      transfer-encoding:
       - chunked
-      Vary:
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
-      - '0'
-      X-Kong-Upstream-Latency:
-      - '3837'
+      x-kong-proxy-latency:
+      - '1'
+      x-kong-upstream-latency:
+      - '107'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"name": "_acme-challenge.listrecordset.softwarekollektiv.de.", "type":
-      "TXT", "value": "challengetoken2", "zone_id": "JkBqVJDW3PpqefBb274BCZ", "ttl":
-      3600}'
+    body: !!python/unicode '{"ttl": 3600, "type": "TXT", "name": "_acme-challenge.listrecordset",
+      "value": "challengetoken2", "zone_id": "hetznerapizoneid"}'
     headers:
       Accept:
       - '*/*'
@@ -219,43 +241,45 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '156'
+      - '134'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: POST
     uri: https://dns.hetzner.com/api/v1/records
   response:
     body:
-      string: '{"record":{"id":"jGjWxzipctQH5C3oFV7NeJ","type":"TXT","name":"_acme-challenge.listrecordset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:35:51.62 +0000 UTC","modified":"2020-04-13 20:35:51.62 +0000 UTC"}}
+      string: !!python/unicode '{"record":{"id":"50aaf8ab858357c3289d2a51d2ea04dc","type":"TXT","name":"_acme-challenge.listrecordset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:08.01 +0000 UTC","modified":"2020-06-12 08:21:08.01 +0000 UTC"}}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '280'
-      Content-Type:
+      content-length:
+      - '268'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:35:55 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:21:08 GMT
+      transfer-encoding:
+      - chunked
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
-      - '1'
-      X-Kong-Upstream-Latency:
-      - '3544'
+      x-kong-proxy-latency:
+      - '2'
+      x-kong-upstream-latency:
+      - '674'
     status:
       code: 200
       message: OK
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -266,49 +290,60 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
-    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=JkBqVJDW3PpqefBb274BCZ
+    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=hetznerapizoneid
   response:
     body:
-      string: '{"records":[{"id":"8jEciPwo7wF2obPTuBe3Yg","type":"SOA","name":"@","value":"ns1.your-server.de.
-        dns.hetzner.com. 2020041589 86400 7200 3600000 3600","zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        15:17:43.061 +0000 UTC","modified":"2020-04-13 20:35:54.457 +0000 UTC"},{"id":"ccLnXePkikrTK7MjNY2fqb","type":"A","name":"localhost.softwarekollektiv.de.","value":"127.0.0.1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:37.644 +0000 UTC","modified":"2020-04-13 20:32:37.644 +0000 UTC"},{"id":"JQmTbgVAzdx4AADJeLMM3X","type":"CNAME","name":"docs.softwarekollektiv.de.","value":"docs.example.com","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:43.98 +0000 UTC","modified":"2020-04-13 20:32:43.98 +0000 UTC"},{"id":"PJpHrVw6wqik5CTzECpacD","type":"TXT","name":"_acme-challenge.fqdn.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:51.209 +0000 UTC","modified":"2020-04-13 20:32:51.209 +0000 UTC"},{"id":"JB9a4EZrNKbRTLKKAmT6M4","type":"TXT","name":"_acme-challenge.full.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:59.487 +0000 UTC","modified":"2020-04-13 20:32:59.487 +0000 UTC"},{"id":"3KU7EYhoWvAzTENjVAsqwB","type":"TXT","name":"_acme-challenge.test.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:08.017 +0000 UTC","modified":"2020-04-13 20:33:08.017 +0000 UTC"},{"id":"JmFdAr7ZKkv3WFyxnEJL43","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:18.136 +0000 UTC","modified":"2020-04-13 20:33:18.136 +0000 UTC"},{"id":"XJBbqzDiukFE3f2YGcTokY","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:25.929 +0000 UTC","modified":"2020-04-13 20:33:25.929 +0000 UTC"},{"id":"fdSKTmeja8M8pc5vztxb64","type":"TXT","name":"_acme-challenge.noop.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:33.653 +0000 UTC","modified":"2020-04-13 20:33:33.653 +0000 UTC"},{"id":"uDPTMe8hikMxgVAGznkN5S","type":"TXT","name":"_acme-challenge.deleterecordinset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:34:55.913 +0000 UTC","modified":"2020-04-13 20:34:55.913 +0000 UTC"},{"id":"pwek8RBHdnTi2eS3NGEkCG","type":"TXT","name":"ttl.fqdn.softwarekollektiv.de.","value":"ttlshouldbe3600","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:35:33.676 +0000 UTC","modified":"2020-04-13 20:35:33.676 +0000 UTC"},{"id":"wei55NH2jLAWwwnmB6ZFjf","type":"TXT","name":"_acme-challenge.listrecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:35:43.97 +0000 UTC","modified":"2020-04-13 20:35:43.97 +0000 UTC"},{"id":"jGjWxzipctQH5C3oFV7NeJ","type":"TXT","name":"_acme-challenge.listrecordset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:35:51.62 +0000 UTC","modified":"2020-04-13 20:35:51.62 +0000 UTC"}]}
+      string: !!python/unicode '{"records":[{"id":"9720b5653ca6fd0517ec91a8c6104685","type":"SOA","name":"@","value":"ns1.first-ns.de.
+        dns.hetzner.com. 2020061226 14400 3600 1814400 3600","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:24:42 +0000 UTC","modified":"2020-06-12 08:21:08.129 +0000 UTC"},{"id":"5b378a7097bdb11e6cbb5f58db6bb101","type":"MX","name":"@","value":"10
+        mail.server-zugang.eu.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:12 +0000 UTC","modified":"2020-04-07 01:25:12 +0000 UTC"},{"id":"a26cfdd36217e559c14b305a558f2a3c","type":"AAAA","name":"@","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"7d6f741802597845b97713596e35eaa7","type":"AAAA","name":"*","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"993bafd3e3b110a6a3acde9fe874426a","type":"NS","name":"@","value":"ns1.first-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"cc3e8297060b7bd794fed5fdec3ed91b","type":"NS","name":"@","value":"robotns2.second-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"c4602b1239d9f0747016f551c52b5774","type":"NS","name":"@","value":"robotns3.second-ns.com.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"77ae87e42a04bace81119eb2280c8dca","type":"A","name":"@","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"faff62d59434c666bac4174a1d18a955","type":"A","name":"*","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"fe6ac2081c630974662caeaa8715d435","type":"A","name":"localhost","value":"127.0.0.1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:37.307 +0000 UTC","modified":"2020-06-12 08:20:37.307 +0000 UTC"},{"id":"8e6b81a856d20f0c1802703b56d1b53d","type":"CNAME","name":"docs","value":"docs.example.com","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:38.743 +0000 UTC","modified":"2020-06-12 08:20:38.743 +0000 UTC"},{"id":"a5fc9854314c160019d9bd0fcaaf2e2a","type":"TXT","name":"_acme-challenge.fqdn","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:40.141 +0000 UTC","modified":"2020-06-12 08:20:40.141 +0000 UTC"},{"id":"101296724cdf3710d18ea43a06b39e6c","type":"TXT","name":"_acme-challenge.full","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:41.421 +0000 UTC","modified":"2020-06-12 08:20:41.421 +0000 UTC"},{"id":"1c06fee6923324bc2727916d2157b3d8","type":"TXT","name":"_acme-challenge.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:43.363 +0000 UTC","modified":"2020-06-12 08:20:43.363 +0000 UTC"},{"id":"97dcfc7f529a65b944a11554e15dcdfb","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:44.557 +0000 UTC","modified":"2020-06-12 08:20:44.557 +0000 UTC"},{"id":"880d3713398b9301dda21a611cbd9ab0","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:45.499 +0000 UTC","modified":"2020-06-12 08:20:45.499 +0000 UTC"},{"id":"f794c3584778621edfa903a30a993f9b","type":"TXT","name":"_acme-challenge.noop","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:46.766 +0000 UTC","modified":"2020-06-12 08:20:46.766 +0000 UTC"},{"id":"fe7ddc85cc3c919385d8d2aabfa407eb","type":"TXT","name":"_acme-challenge.deleterecordinset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:58.928 +0000 UTC","modified":"2020-06-12 08:20:58.928 +0000 UTC"},{"id":"61efb963c73466f54f6bba592e9340d4","type":"TXT","name":"ttl.fqdn","value":"ttlshouldbe3600","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:05.618 +0000 UTC","modified":"2020-06-12 08:21:05.618 +0000 UTC"},{"id":"2d5abe2e3b1030903b6ededf674fb76a","type":"TXT","name":"_acme-challenge.listrecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:07.078 +0000 UTC","modified":"2020-06-12 08:21:07.078 +0000 UTC"},{"id":"50aaf8ab858357c3289d2a51d2ea04dc","type":"TXT","name":"_acme-challenge.listrecordset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:08.01 +0000 UTC","modified":"2020-06-12 08:21:08.01 +0000 UTC"}]}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Type:
+      content-length:
+      - '5008'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:35:58 GMT
-      Transfer-Encoding:
+      date:
+      - Fri, 12 Jun 2020 08:21:08 GMT
+      transfer-encoding:
       - chunked
-      Vary:
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
-      - '0'
-      X-Kong-Upstream-Latency:
-      - '3345'
+      x-kong-proxy-latency:
+      - '1'
+      x-kong-upstream-latency:
+      - '74'
     status:
       code: 200
       message: OK

--- a/tests/fixtures/cassettes/hetzner/IntegrationTests/test_provider_when_calling_list_records_with_fqdn_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/hetzner/IntegrationTests/test_provider_when_calling_list_records_with_fqdn_name_filter_should_return_record.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -11,44 +11,44 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
     uri: https://dns.hetzner.com/api/v1/zones
   response:
     body:
-      string: '{"zones":[{"id":"xyncsydKx5x44qDZQCzpNM","name":"alt.coop","ttl":300,"registrar":"","legacy_dns_host":"","legacy_ns":["oxygen.ns.hetzner.com.","hydrogen.ns.hetzner.com.","helium.ns.hetzner.com."],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-07
-        01:23:59 +0000 UTC","verified":"2020-04-07 01:53:05.934062806 +0000 UTC m=+578.060435172","modified":"2020-04-08
-        10:38:16.278 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":75},{"id":"JkBqVJDW3PpqefBb274BCZ","name":"softwarekollektiv.de","ttl":86400,"registrar":"","legacy_dns_host":"","legacy_ns":[],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-08
-        18:53:25.589 +0000 UTC","verified":"2020-04-08T18:53:27Z","modified":"2020-04-13
-        15:17:43.767 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":13}],"meta":{"pagination":{"page":1,"per_page":100,"previous_page":1,"next_page":1,"last_page":1,"total_entries":2}}}
+      string: !!python/unicode '{"zones":[{"id":"hetznerapizoneid","name":"hetzner-api-test.de","ttl":3600,"registrar":"","legacy_dns_host":"","legacy_ns":["ns1.first-ns.de.","robotns2.second-ns.de.","robotns3.second-ns.com."],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-07
+        01:24:00 +0000 UTC","verified":"2020-04-07 01:51:26.114056422 +0000 UTC m=+478.240428717","modified":"2020-06-11
+        07:02:20.999 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":9}],"meta":{"pagination":{"page":1,"per_page":100,"previous_page":1,"next_page":1,"last_page":1,"total_entries":12}}}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '1330'
-      Content-Type:
+      content-length:
+      - '7887'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:35:59 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:21:09 GMT
+      transfer-encoding:
+      - chunked
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
+      x-kong-proxy-latency:
       - '1'
-      X-Kong-Upstream-Latency:
-      - '213'
+      x-kong-upstream-latency:
+      - '332'
     status:
       code: 200
       message: OK
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -59,55 +59,66 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
-    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=JkBqVJDW3PpqefBb274BCZ
+    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=hetznerapizoneid
   response:
     body:
-      string: '{"records":[{"id":"8jEciPwo7wF2obPTuBe3Yg","type":"SOA","name":"@","value":"ns1.your-server.de.
-        dns.hetzner.com. 2020041589 86400 7200 3600000 3600","zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        15:17:43.061 +0000 UTC","modified":"2020-04-13 20:35:54.457 +0000 UTC"},{"id":"ccLnXePkikrTK7MjNY2fqb","type":"A","name":"localhost.softwarekollektiv.de.","value":"127.0.0.1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:37.644 +0000 UTC","modified":"2020-04-13 20:32:37.644 +0000 UTC"},{"id":"JQmTbgVAzdx4AADJeLMM3X","type":"CNAME","name":"docs.softwarekollektiv.de.","value":"docs.example.com","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:43.98 +0000 UTC","modified":"2020-04-13 20:32:43.98 +0000 UTC"},{"id":"PJpHrVw6wqik5CTzECpacD","type":"TXT","name":"_acme-challenge.fqdn.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:51.209 +0000 UTC","modified":"2020-04-13 20:32:51.209 +0000 UTC"},{"id":"JB9a4EZrNKbRTLKKAmT6M4","type":"TXT","name":"_acme-challenge.full.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:59.487 +0000 UTC","modified":"2020-04-13 20:32:59.487 +0000 UTC"},{"id":"3KU7EYhoWvAzTENjVAsqwB","type":"TXT","name":"_acme-challenge.test.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:08.017 +0000 UTC","modified":"2020-04-13 20:33:08.017 +0000 UTC"},{"id":"JmFdAr7ZKkv3WFyxnEJL43","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:18.136 +0000 UTC","modified":"2020-04-13 20:33:18.136 +0000 UTC"},{"id":"XJBbqzDiukFE3f2YGcTokY","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:25.929 +0000 UTC","modified":"2020-04-13 20:33:25.929 +0000 UTC"},{"id":"fdSKTmeja8M8pc5vztxb64","type":"TXT","name":"_acme-challenge.noop.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:33.653 +0000 UTC","modified":"2020-04-13 20:33:33.653 +0000 UTC"},{"id":"uDPTMe8hikMxgVAGznkN5S","type":"TXT","name":"_acme-challenge.deleterecordinset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:34:55.913 +0000 UTC","modified":"2020-04-13 20:34:55.913 +0000 UTC"},{"id":"pwek8RBHdnTi2eS3NGEkCG","type":"TXT","name":"ttl.fqdn.softwarekollektiv.de.","value":"ttlshouldbe3600","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:35:33.676 +0000 UTC","modified":"2020-04-13 20:35:33.676 +0000 UTC"},{"id":"wei55NH2jLAWwwnmB6ZFjf","type":"TXT","name":"_acme-challenge.listrecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:35:43.97 +0000 UTC","modified":"2020-04-13 20:35:43.97 +0000 UTC"},{"id":"jGjWxzipctQH5C3oFV7NeJ","type":"TXT","name":"_acme-challenge.listrecordset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:35:51.62 +0000 UTC","modified":"2020-04-13 20:35:51.62 +0000 UTC"}]}
+      string: !!python/unicode '{"records":[{"id":"9720b5653ca6fd0517ec91a8c6104685","type":"SOA","name":"@","value":"ns1.first-ns.de.
+        dns.hetzner.com. 2020061226 14400 3600 1814400 3600","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:24:42 +0000 UTC","modified":"2020-06-12 08:21:08.129 +0000 UTC"},{"id":"5b378a7097bdb11e6cbb5f58db6bb101","type":"MX","name":"@","value":"10
+        mail.server-zugang.eu.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:12 +0000 UTC","modified":"2020-04-07 01:25:12 +0000 UTC"},{"id":"a26cfdd36217e559c14b305a558f2a3c","type":"AAAA","name":"@","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"7d6f741802597845b97713596e35eaa7","type":"AAAA","name":"*","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"993bafd3e3b110a6a3acde9fe874426a","type":"NS","name":"@","value":"ns1.first-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"cc3e8297060b7bd794fed5fdec3ed91b","type":"NS","name":"@","value":"robotns2.second-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"c4602b1239d9f0747016f551c52b5774","type":"NS","name":"@","value":"robotns3.second-ns.com.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"77ae87e42a04bace81119eb2280c8dca","type":"A","name":"@","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"faff62d59434c666bac4174a1d18a955","type":"A","name":"*","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"fe6ac2081c630974662caeaa8715d435","type":"A","name":"localhost","value":"127.0.0.1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:37.307 +0000 UTC","modified":"2020-06-12 08:20:37.307 +0000 UTC"},{"id":"8e6b81a856d20f0c1802703b56d1b53d","type":"CNAME","name":"docs","value":"docs.example.com","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:38.743 +0000 UTC","modified":"2020-06-12 08:20:38.743 +0000 UTC"},{"id":"a5fc9854314c160019d9bd0fcaaf2e2a","type":"TXT","name":"_acme-challenge.fqdn","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:40.141 +0000 UTC","modified":"2020-06-12 08:20:40.141 +0000 UTC"},{"id":"101296724cdf3710d18ea43a06b39e6c","type":"TXT","name":"_acme-challenge.full","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:41.421 +0000 UTC","modified":"2020-06-12 08:20:41.421 +0000 UTC"},{"id":"1c06fee6923324bc2727916d2157b3d8","type":"TXT","name":"_acme-challenge.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:43.363 +0000 UTC","modified":"2020-06-12 08:20:43.363 +0000 UTC"},{"id":"97dcfc7f529a65b944a11554e15dcdfb","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:44.557 +0000 UTC","modified":"2020-06-12 08:20:44.557 +0000 UTC"},{"id":"880d3713398b9301dda21a611cbd9ab0","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:45.499 +0000 UTC","modified":"2020-06-12 08:20:45.499 +0000 UTC"},{"id":"f794c3584778621edfa903a30a993f9b","type":"TXT","name":"_acme-challenge.noop","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:46.766 +0000 UTC","modified":"2020-06-12 08:20:46.766 +0000 UTC"},{"id":"fe7ddc85cc3c919385d8d2aabfa407eb","type":"TXT","name":"_acme-challenge.deleterecordinset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:58.928 +0000 UTC","modified":"2020-06-12 08:20:58.928 +0000 UTC"},{"id":"61efb963c73466f54f6bba592e9340d4","type":"TXT","name":"ttl.fqdn","value":"ttlshouldbe3600","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:05.618 +0000 UTC","modified":"2020-06-12 08:21:05.618 +0000 UTC"},{"id":"2d5abe2e3b1030903b6ededf674fb76a","type":"TXT","name":"_acme-challenge.listrecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:07.078 +0000 UTC","modified":"2020-06-12 08:21:07.078 +0000 UTC"},{"id":"50aaf8ab858357c3289d2a51d2ea04dc","type":"TXT","name":"_acme-challenge.listrecordset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:08.01 +0000 UTC","modified":"2020-06-12 08:21:08.01 +0000 UTC"}]}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Type:
+      content-length:
+      - '5008'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:36:02 GMT
-      Transfer-Encoding:
+      date:
+      - Fri, 12 Jun 2020 08:21:09 GMT
+      transfer-encoding:
       - chunked
-      Vary:
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
-      - '2'
-      X-Kong-Upstream-Latency:
-      - '3210'
+      x-kong-proxy-latency:
+      - '3'
+      x-kong-upstream-latency:
+      - '85'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"name": "random.fqdntest.softwarekollektiv.de.", "type": "TXT", "value":
-      "challengetoken", "zone_id": "JkBqVJDW3PpqefBb274BCZ", "ttl": 3600}'
+    body: !!python/unicode '{"ttl": 3600, "type": "TXT", "name": "random.fqdntest",
+      "value": "challengetoken", "zone_id": "hetznerapizoneid"}'
     headers:
       Accept:
       - '*/*'
@@ -116,43 +127,45 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '141'
+      - '119'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: POST
     uri: https://dns.hetzner.com/api/v1/records
   response:
     body:
-      string: '{"record":{"id":"jRamHUs2Xyt4Gh3BP4UaCd","type":"TXT","name":"random.fqdntest.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:36:02.609 +0000 UTC","modified":"2020-04-13 20:36:02.609 +0000 UTC"}}
+      string: !!python/unicode '{"record":{"id":"b358c2b15c05b3315352ee2a149ce3bc","type":"TXT","name":"random.fqdntest","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:09.601 +0000 UTC","modified":"2020-06-12 08:21:09.601 +0000 UTC"}}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '267'
-      Content-Type:
+      content-length:
+      - '255'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:36:05 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:21:10 GMT
+      transfer-encoding:
+      - chunked
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
-      - '1'
-      X-Kong-Upstream-Latency:
-      - '2786'
+      x-kong-proxy-latency:
+      - '2'
+      x-kong-upstream-latency:
+      - '617'
     status:
       code: 200
       message: OK
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -163,50 +176,61 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
-    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=JkBqVJDW3PpqefBb274BCZ
+    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=hetznerapizoneid
   response:
     body:
-      string: '{"records":[{"id":"8jEciPwo7wF2obPTuBe3Yg","type":"SOA","name":"@","value":"ns1.your-server.de.
-        dns.hetzner.com. 2020041590 86400 7200 3600000 3600","zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        15:17:43.061 +0000 UTC","modified":"2020-04-13 20:36:04.673 +0000 UTC"},{"id":"ccLnXePkikrTK7MjNY2fqb","type":"A","name":"localhost.softwarekollektiv.de.","value":"127.0.0.1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:37.644 +0000 UTC","modified":"2020-04-13 20:32:37.644 +0000 UTC"},{"id":"JQmTbgVAzdx4AADJeLMM3X","type":"CNAME","name":"docs.softwarekollektiv.de.","value":"docs.example.com","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:43.98 +0000 UTC","modified":"2020-04-13 20:32:43.98 +0000 UTC"},{"id":"PJpHrVw6wqik5CTzECpacD","type":"TXT","name":"_acme-challenge.fqdn.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:51.209 +0000 UTC","modified":"2020-04-13 20:32:51.209 +0000 UTC"},{"id":"JB9a4EZrNKbRTLKKAmT6M4","type":"TXT","name":"_acme-challenge.full.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:59.487 +0000 UTC","modified":"2020-04-13 20:32:59.487 +0000 UTC"},{"id":"3KU7EYhoWvAzTENjVAsqwB","type":"TXT","name":"_acme-challenge.test.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:08.017 +0000 UTC","modified":"2020-04-13 20:33:08.017 +0000 UTC"},{"id":"JmFdAr7ZKkv3WFyxnEJL43","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:18.136 +0000 UTC","modified":"2020-04-13 20:33:18.136 +0000 UTC"},{"id":"XJBbqzDiukFE3f2YGcTokY","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:25.929 +0000 UTC","modified":"2020-04-13 20:33:25.929 +0000 UTC"},{"id":"fdSKTmeja8M8pc5vztxb64","type":"TXT","name":"_acme-challenge.noop.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:33.653 +0000 UTC","modified":"2020-04-13 20:33:33.653 +0000 UTC"},{"id":"uDPTMe8hikMxgVAGznkN5S","type":"TXT","name":"_acme-challenge.deleterecordinset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:34:55.913 +0000 UTC","modified":"2020-04-13 20:34:55.913 +0000 UTC"},{"id":"pwek8RBHdnTi2eS3NGEkCG","type":"TXT","name":"ttl.fqdn.softwarekollektiv.de.","value":"ttlshouldbe3600","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:35:33.676 +0000 UTC","modified":"2020-04-13 20:35:33.676 +0000 UTC"},{"id":"wei55NH2jLAWwwnmB6ZFjf","type":"TXT","name":"_acme-challenge.listrecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:35:43.97 +0000 UTC","modified":"2020-04-13 20:35:43.97 +0000 UTC"},{"id":"jGjWxzipctQH5C3oFV7NeJ","type":"TXT","name":"_acme-challenge.listrecordset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:35:51.62 +0000 UTC","modified":"2020-04-13 20:35:51.62 +0000 UTC"},{"id":"jRamHUs2Xyt4Gh3BP4UaCd","type":"TXT","name":"random.fqdntest.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:36:02.609 +0000 UTC","modified":"2020-04-13 20:36:02.609 +0000 UTC"}]}
+      string: !!python/unicode '{"records":[{"id":"9720b5653ca6fd0517ec91a8c6104685","type":"SOA","name":"@","value":"ns1.first-ns.de.
+        dns.hetzner.com. 2020061227 14400 3600 1814400 3600","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:24:42 +0000 UTC","modified":"2020-06-12 08:21:09.705 +0000 UTC"},{"id":"5b378a7097bdb11e6cbb5f58db6bb101","type":"MX","name":"@","value":"10
+        mail.server-zugang.eu.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:12 +0000 UTC","modified":"2020-04-07 01:25:12 +0000 UTC"},{"id":"a26cfdd36217e559c14b305a558f2a3c","type":"AAAA","name":"@","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"7d6f741802597845b97713596e35eaa7","type":"AAAA","name":"*","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"993bafd3e3b110a6a3acde9fe874426a","type":"NS","name":"@","value":"ns1.first-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"cc3e8297060b7bd794fed5fdec3ed91b","type":"NS","name":"@","value":"robotns2.second-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"c4602b1239d9f0747016f551c52b5774","type":"NS","name":"@","value":"robotns3.second-ns.com.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"77ae87e42a04bace81119eb2280c8dca","type":"A","name":"@","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"faff62d59434c666bac4174a1d18a955","type":"A","name":"*","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"fe6ac2081c630974662caeaa8715d435","type":"A","name":"localhost","value":"127.0.0.1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:37.307 +0000 UTC","modified":"2020-06-12 08:20:37.307 +0000 UTC"},{"id":"8e6b81a856d20f0c1802703b56d1b53d","type":"CNAME","name":"docs","value":"docs.example.com","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:38.743 +0000 UTC","modified":"2020-06-12 08:20:38.743 +0000 UTC"},{"id":"a5fc9854314c160019d9bd0fcaaf2e2a","type":"TXT","name":"_acme-challenge.fqdn","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:40.141 +0000 UTC","modified":"2020-06-12 08:20:40.141 +0000 UTC"},{"id":"101296724cdf3710d18ea43a06b39e6c","type":"TXT","name":"_acme-challenge.full","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:41.421 +0000 UTC","modified":"2020-06-12 08:20:41.421 +0000 UTC"},{"id":"1c06fee6923324bc2727916d2157b3d8","type":"TXT","name":"_acme-challenge.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:43.363 +0000 UTC","modified":"2020-06-12 08:20:43.363 +0000 UTC"},{"id":"97dcfc7f529a65b944a11554e15dcdfb","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:44.557 +0000 UTC","modified":"2020-06-12 08:20:44.557 +0000 UTC"},{"id":"880d3713398b9301dda21a611cbd9ab0","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:45.499 +0000 UTC","modified":"2020-06-12 08:20:45.499 +0000 UTC"},{"id":"f794c3584778621edfa903a30a993f9b","type":"TXT","name":"_acme-challenge.noop","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:46.766 +0000 UTC","modified":"2020-06-12 08:20:46.766 +0000 UTC"},{"id":"fe7ddc85cc3c919385d8d2aabfa407eb","type":"TXT","name":"_acme-challenge.deleterecordinset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:58.928 +0000 UTC","modified":"2020-06-12 08:20:58.928 +0000 UTC"},{"id":"61efb963c73466f54f6bba592e9340d4","type":"TXT","name":"ttl.fqdn","value":"ttlshouldbe3600","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:05.618 +0000 UTC","modified":"2020-06-12 08:21:05.618 +0000 UTC"},{"id":"2d5abe2e3b1030903b6ededf674fb76a","type":"TXT","name":"_acme-challenge.listrecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:07.078 +0000 UTC","modified":"2020-06-12 08:21:07.078 +0000 UTC"},{"id":"50aaf8ab858357c3289d2a51d2ea04dc","type":"TXT","name":"_acme-challenge.listrecordset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:08.01 +0000 UTC","modified":"2020-06-12 08:21:08.01 +0000 UTC"},{"id":"b358c2b15c05b3315352ee2a149ce3bc","type":"TXT","name":"random.fqdntest","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:09.601 +0000 UTC","modified":"2020-06-12 08:21:09.601 +0000 UTC"}]}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Type:
+      content-length:
+      - '5252'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:36:08 GMT
-      Transfer-Encoding:
+      date:
+      - Fri, 12 Jun 2020 08:21:10 GMT
+      transfer-encoding:
       - chunked
-      Vary:
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
-      - '1'
-      X-Kong-Upstream-Latency:
-      - '3233'
+      x-kong-proxy-latency:
+      - '2'
+      x-kong-upstream-latency:
+      - '117'
     status:
       code: 200
       message: OK

--- a/tests/fixtures/cassettes/hetzner/IntegrationTests/test_provider_when_calling_list_records_with_full_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/hetzner/IntegrationTests/test_provider_when_calling_list_records_with_full_name_filter_should_return_record.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -11,44 +11,44 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
     uri: https://dns.hetzner.com/api/v1/zones
   response:
     body:
-      string: '{"zones":[{"id":"xyncsydKx5x44qDZQCzpNM","name":"alt.coop","ttl":300,"registrar":"","legacy_dns_host":"","legacy_ns":["oxygen.ns.hetzner.com.","hydrogen.ns.hetzner.com.","helium.ns.hetzner.com."],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-07
-        01:23:59 +0000 UTC","verified":"2020-04-07 01:53:05.934062806 +0000 UTC m=+578.060435172","modified":"2020-04-08
-        10:38:16.278 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":75},{"id":"JkBqVJDW3PpqefBb274BCZ","name":"softwarekollektiv.de","ttl":86400,"registrar":"","legacy_dns_host":"","legacy_ns":[],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-08
-        18:53:25.589 +0000 UTC","verified":"2020-04-08T18:53:27Z","modified":"2020-04-13
-        15:17:43.767 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":14}],"meta":{"pagination":{"page":1,"per_page":100,"previous_page":1,"next_page":1,"last_page":1,"total_entries":2}}}
+      string: !!python/unicode '{"zones":[{"id":"hetznerapizoneid","name":"hetzner-api-test.de","ttl":3600,"registrar":"","legacy_dns_host":"","legacy_ns":["ns1.first-ns.de.","robotns2.second-ns.de.","robotns3.second-ns.com."],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-07
+        01:24:00 +0000 UTC","verified":"2020-04-07 01:51:26.114056422 +0000 UTC m=+478.240428717","modified":"2020-06-11
+        07:02:20.999 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":9}],"meta":{"pagination":{"page":1,"per_page":100,"previous_page":1,"next_page":1,"last_page":1,"total_entries":12}}}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '1330'
-      Content-Type:
+      content-length:
+      - '7887'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:36:09 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:21:10 GMT
+      transfer-encoding:
+      - chunked
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
-      - '1'
-      X-Kong-Upstream-Latency:
-      - '206'
+      x-kong-proxy-latency:
+      - '2'
+      x-kong-upstream-latency:
+      - '267'
     status:
       code: 200
       message: OK
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -59,56 +59,67 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
-    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=JkBqVJDW3PpqefBb274BCZ
+    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=hetznerapizoneid
   response:
     body:
-      string: '{"records":[{"id":"8jEciPwo7wF2obPTuBe3Yg","type":"SOA","name":"@","value":"ns1.your-server.de.
-        dns.hetzner.com. 2020041590 86400 7200 3600000 3600","zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        15:17:43.061 +0000 UTC","modified":"2020-04-13 20:36:04.673 +0000 UTC"},{"id":"ccLnXePkikrTK7MjNY2fqb","type":"A","name":"localhost.softwarekollektiv.de.","value":"127.0.0.1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:37.644 +0000 UTC","modified":"2020-04-13 20:32:37.644 +0000 UTC"},{"id":"JQmTbgVAzdx4AADJeLMM3X","type":"CNAME","name":"docs.softwarekollektiv.de.","value":"docs.example.com","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:43.98 +0000 UTC","modified":"2020-04-13 20:32:43.98 +0000 UTC"},{"id":"PJpHrVw6wqik5CTzECpacD","type":"TXT","name":"_acme-challenge.fqdn.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:51.209 +0000 UTC","modified":"2020-04-13 20:32:51.209 +0000 UTC"},{"id":"JB9a4EZrNKbRTLKKAmT6M4","type":"TXT","name":"_acme-challenge.full.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:59.487 +0000 UTC","modified":"2020-04-13 20:32:59.487 +0000 UTC"},{"id":"3KU7EYhoWvAzTENjVAsqwB","type":"TXT","name":"_acme-challenge.test.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:08.017 +0000 UTC","modified":"2020-04-13 20:33:08.017 +0000 UTC"},{"id":"JmFdAr7ZKkv3WFyxnEJL43","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:18.136 +0000 UTC","modified":"2020-04-13 20:33:18.136 +0000 UTC"},{"id":"XJBbqzDiukFE3f2YGcTokY","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:25.929 +0000 UTC","modified":"2020-04-13 20:33:25.929 +0000 UTC"},{"id":"fdSKTmeja8M8pc5vztxb64","type":"TXT","name":"_acme-challenge.noop.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:33.653 +0000 UTC","modified":"2020-04-13 20:33:33.653 +0000 UTC"},{"id":"uDPTMe8hikMxgVAGznkN5S","type":"TXT","name":"_acme-challenge.deleterecordinset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:34:55.913 +0000 UTC","modified":"2020-04-13 20:34:55.913 +0000 UTC"},{"id":"pwek8RBHdnTi2eS3NGEkCG","type":"TXT","name":"ttl.fqdn.softwarekollektiv.de.","value":"ttlshouldbe3600","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:35:33.676 +0000 UTC","modified":"2020-04-13 20:35:33.676 +0000 UTC"},{"id":"wei55NH2jLAWwwnmB6ZFjf","type":"TXT","name":"_acme-challenge.listrecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:35:43.97 +0000 UTC","modified":"2020-04-13 20:35:43.97 +0000 UTC"},{"id":"jGjWxzipctQH5C3oFV7NeJ","type":"TXT","name":"_acme-challenge.listrecordset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:35:51.62 +0000 UTC","modified":"2020-04-13 20:35:51.62 +0000 UTC"},{"id":"jRamHUs2Xyt4Gh3BP4UaCd","type":"TXT","name":"random.fqdntest.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:36:02.609 +0000 UTC","modified":"2020-04-13 20:36:02.609 +0000 UTC"}]}
+      string: !!python/unicode '{"records":[{"id":"9720b5653ca6fd0517ec91a8c6104685","type":"SOA","name":"@","value":"ns1.first-ns.de.
+        dns.hetzner.com. 2020061227 14400 3600 1814400 3600","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:24:42 +0000 UTC","modified":"2020-06-12 08:21:09.705 +0000 UTC"},{"id":"5b378a7097bdb11e6cbb5f58db6bb101","type":"MX","name":"@","value":"10
+        mail.server-zugang.eu.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:12 +0000 UTC","modified":"2020-04-07 01:25:12 +0000 UTC"},{"id":"a26cfdd36217e559c14b305a558f2a3c","type":"AAAA","name":"@","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"7d6f741802597845b97713596e35eaa7","type":"AAAA","name":"*","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"993bafd3e3b110a6a3acde9fe874426a","type":"NS","name":"@","value":"ns1.first-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"cc3e8297060b7bd794fed5fdec3ed91b","type":"NS","name":"@","value":"robotns2.second-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"c4602b1239d9f0747016f551c52b5774","type":"NS","name":"@","value":"robotns3.second-ns.com.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"77ae87e42a04bace81119eb2280c8dca","type":"A","name":"@","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"faff62d59434c666bac4174a1d18a955","type":"A","name":"*","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"fe6ac2081c630974662caeaa8715d435","type":"A","name":"localhost","value":"127.0.0.1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:37.307 +0000 UTC","modified":"2020-06-12 08:20:37.307 +0000 UTC"},{"id":"8e6b81a856d20f0c1802703b56d1b53d","type":"CNAME","name":"docs","value":"docs.example.com","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:38.743 +0000 UTC","modified":"2020-06-12 08:20:38.743 +0000 UTC"},{"id":"a5fc9854314c160019d9bd0fcaaf2e2a","type":"TXT","name":"_acme-challenge.fqdn","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:40.141 +0000 UTC","modified":"2020-06-12 08:20:40.141 +0000 UTC"},{"id":"101296724cdf3710d18ea43a06b39e6c","type":"TXT","name":"_acme-challenge.full","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:41.421 +0000 UTC","modified":"2020-06-12 08:20:41.421 +0000 UTC"},{"id":"1c06fee6923324bc2727916d2157b3d8","type":"TXT","name":"_acme-challenge.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:43.363 +0000 UTC","modified":"2020-06-12 08:20:43.363 +0000 UTC"},{"id":"97dcfc7f529a65b944a11554e15dcdfb","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:44.557 +0000 UTC","modified":"2020-06-12 08:20:44.557 +0000 UTC"},{"id":"880d3713398b9301dda21a611cbd9ab0","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:45.499 +0000 UTC","modified":"2020-06-12 08:20:45.499 +0000 UTC"},{"id":"f794c3584778621edfa903a30a993f9b","type":"TXT","name":"_acme-challenge.noop","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:46.766 +0000 UTC","modified":"2020-06-12 08:20:46.766 +0000 UTC"},{"id":"fe7ddc85cc3c919385d8d2aabfa407eb","type":"TXT","name":"_acme-challenge.deleterecordinset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:58.928 +0000 UTC","modified":"2020-06-12 08:20:58.928 +0000 UTC"},{"id":"61efb963c73466f54f6bba592e9340d4","type":"TXT","name":"ttl.fqdn","value":"ttlshouldbe3600","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:05.618 +0000 UTC","modified":"2020-06-12 08:21:05.618 +0000 UTC"},{"id":"2d5abe2e3b1030903b6ededf674fb76a","type":"TXT","name":"_acme-challenge.listrecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:07.078 +0000 UTC","modified":"2020-06-12 08:21:07.078 +0000 UTC"},{"id":"50aaf8ab858357c3289d2a51d2ea04dc","type":"TXT","name":"_acme-challenge.listrecordset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:08.01 +0000 UTC","modified":"2020-06-12 08:21:08.01 +0000 UTC"},{"id":"b358c2b15c05b3315352ee2a149ce3bc","type":"TXT","name":"random.fqdntest","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:09.601 +0000 UTC","modified":"2020-06-12 08:21:09.601 +0000 UTC"}]}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Type:
+      content-length:
+      - '5252'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:36:12 GMT
-      Transfer-Encoding:
+      date:
+      - Fri, 12 Jun 2020 08:21:10 GMT
+      transfer-encoding:
       - chunked
-      Vary:
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
-      - '2'
-      X-Kong-Upstream-Latency:
-      - '3180'
+      x-kong-proxy-latency:
+      - '3'
+      x-kong-upstream-latency:
+      - '54'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"name": "random.fulltest.softwarekollektiv.de.", "type": "TXT", "value":
-      "challengetoken", "zone_id": "JkBqVJDW3PpqefBb274BCZ", "ttl": 3600}'
+    body: !!python/unicode '{"ttl": 3600, "type": "TXT", "name": "random.fulltest",
+      "value": "challengetoken", "zone_id": "hetznerapizoneid"}'
     headers:
       Accept:
       - '*/*'
@@ -117,43 +128,45 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '141'
+      - '119'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: POST
     uri: https://dns.hetzner.com/api/v1/records
   response:
     body:
-      string: '{"record":{"id":"SZspS6AU4CT7ux7M6LaDrG","type":"TXT","name":"random.fulltest.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:36:12.704 +0000 UTC","modified":"2020-04-13 20:36:12.704 +0000 UTC"}}
+      string: !!python/unicode '{"record":{"id":"9bf9fc6d8c2b7c277f2da14475d545b3","type":"TXT","name":"random.fulltest","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:11.083 +0000 UTC","modified":"2020-06-12 08:21:11.083 +0000 UTC"}}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '267'
-      Content-Type:
+      content-length:
+      - '255'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:36:15 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:21:11 GMT
+      transfer-encoding:
+      - chunked
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
-      - '0'
-      X-Kong-Upstream-Latency:
-      - '3272'
+      x-kong-proxy-latency:
+      - '2'
+      x-kong-upstream-latency:
+      - '716'
     status:
       code: 200
       message: OK
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -164,51 +177,62 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
-    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=JkBqVJDW3PpqefBb274BCZ
+    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=hetznerapizoneid
   response:
     body:
-      string: '{"records":[{"id":"8jEciPwo7wF2obPTuBe3Yg","type":"SOA","name":"@","value":"ns1.your-server.de.
-        dns.hetzner.com. 2020041591 86400 7200 3600000 3600","zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        15:17:43.061 +0000 UTC","modified":"2020-04-13 20:36:15.281 +0000 UTC"},{"id":"ccLnXePkikrTK7MjNY2fqb","type":"A","name":"localhost.softwarekollektiv.de.","value":"127.0.0.1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:37.644 +0000 UTC","modified":"2020-04-13 20:32:37.644 +0000 UTC"},{"id":"JQmTbgVAzdx4AADJeLMM3X","type":"CNAME","name":"docs.softwarekollektiv.de.","value":"docs.example.com","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:43.98 +0000 UTC","modified":"2020-04-13 20:32:43.98 +0000 UTC"},{"id":"PJpHrVw6wqik5CTzECpacD","type":"TXT","name":"_acme-challenge.fqdn.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:51.209 +0000 UTC","modified":"2020-04-13 20:32:51.209 +0000 UTC"},{"id":"JB9a4EZrNKbRTLKKAmT6M4","type":"TXT","name":"_acme-challenge.full.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:59.487 +0000 UTC","modified":"2020-04-13 20:32:59.487 +0000 UTC"},{"id":"3KU7EYhoWvAzTENjVAsqwB","type":"TXT","name":"_acme-challenge.test.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:08.017 +0000 UTC","modified":"2020-04-13 20:33:08.017 +0000 UTC"},{"id":"JmFdAr7ZKkv3WFyxnEJL43","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:18.136 +0000 UTC","modified":"2020-04-13 20:33:18.136 +0000 UTC"},{"id":"XJBbqzDiukFE3f2YGcTokY","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:25.929 +0000 UTC","modified":"2020-04-13 20:33:25.929 +0000 UTC"},{"id":"fdSKTmeja8M8pc5vztxb64","type":"TXT","name":"_acme-challenge.noop.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:33.653 +0000 UTC","modified":"2020-04-13 20:33:33.653 +0000 UTC"},{"id":"uDPTMe8hikMxgVAGznkN5S","type":"TXT","name":"_acme-challenge.deleterecordinset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:34:55.913 +0000 UTC","modified":"2020-04-13 20:34:55.913 +0000 UTC"},{"id":"pwek8RBHdnTi2eS3NGEkCG","type":"TXT","name":"ttl.fqdn.softwarekollektiv.de.","value":"ttlshouldbe3600","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:35:33.676 +0000 UTC","modified":"2020-04-13 20:35:33.676 +0000 UTC"},{"id":"wei55NH2jLAWwwnmB6ZFjf","type":"TXT","name":"_acme-challenge.listrecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:35:43.97 +0000 UTC","modified":"2020-04-13 20:35:43.97 +0000 UTC"},{"id":"jGjWxzipctQH5C3oFV7NeJ","type":"TXT","name":"_acme-challenge.listrecordset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:35:51.62 +0000 UTC","modified":"2020-04-13 20:35:51.62 +0000 UTC"},{"id":"jRamHUs2Xyt4Gh3BP4UaCd","type":"TXT","name":"random.fqdntest.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:36:02.609 +0000 UTC","modified":"2020-04-13 20:36:02.609 +0000 UTC"},{"id":"SZspS6AU4CT7ux7M6LaDrG","type":"TXT","name":"random.fulltest.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:36:12.704 +0000 UTC","modified":"2020-04-13 20:36:12.704 +0000 UTC"}]}
+      string: !!python/unicode '{"records":[{"id":"9720b5653ca6fd0517ec91a8c6104685","type":"SOA","name":"@","value":"ns1.first-ns.de.
+        dns.hetzner.com. 2020061228 14400 3600 1814400 3600","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:24:42 +0000 UTC","modified":"2020-06-12 08:21:11.196 +0000 UTC"},{"id":"5b378a7097bdb11e6cbb5f58db6bb101","type":"MX","name":"@","value":"10
+        mail.server-zugang.eu.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:12 +0000 UTC","modified":"2020-04-07 01:25:12 +0000 UTC"},{"id":"a26cfdd36217e559c14b305a558f2a3c","type":"AAAA","name":"@","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"7d6f741802597845b97713596e35eaa7","type":"AAAA","name":"*","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"993bafd3e3b110a6a3acde9fe874426a","type":"NS","name":"@","value":"ns1.first-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"cc3e8297060b7bd794fed5fdec3ed91b","type":"NS","name":"@","value":"robotns2.second-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"c4602b1239d9f0747016f551c52b5774","type":"NS","name":"@","value":"robotns3.second-ns.com.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"77ae87e42a04bace81119eb2280c8dca","type":"A","name":"@","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"faff62d59434c666bac4174a1d18a955","type":"A","name":"*","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"fe6ac2081c630974662caeaa8715d435","type":"A","name":"localhost","value":"127.0.0.1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:37.307 +0000 UTC","modified":"2020-06-12 08:20:37.307 +0000 UTC"},{"id":"8e6b81a856d20f0c1802703b56d1b53d","type":"CNAME","name":"docs","value":"docs.example.com","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:38.743 +0000 UTC","modified":"2020-06-12 08:20:38.743 +0000 UTC"},{"id":"a5fc9854314c160019d9bd0fcaaf2e2a","type":"TXT","name":"_acme-challenge.fqdn","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:40.141 +0000 UTC","modified":"2020-06-12 08:20:40.141 +0000 UTC"},{"id":"101296724cdf3710d18ea43a06b39e6c","type":"TXT","name":"_acme-challenge.full","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:41.421 +0000 UTC","modified":"2020-06-12 08:20:41.421 +0000 UTC"},{"id":"1c06fee6923324bc2727916d2157b3d8","type":"TXT","name":"_acme-challenge.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:43.363 +0000 UTC","modified":"2020-06-12 08:20:43.363 +0000 UTC"},{"id":"97dcfc7f529a65b944a11554e15dcdfb","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:44.557 +0000 UTC","modified":"2020-06-12 08:20:44.557 +0000 UTC"},{"id":"880d3713398b9301dda21a611cbd9ab0","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:45.499 +0000 UTC","modified":"2020-06-12 08:20:45.499 +0000 UTC"},{"id":"f794c3584778621edfa903a30a993f9b","type":"TXT","name":"_acme-challenge.noop","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:46.766 +0000 UTC","modified":"2020-06-12 08:20:46.766 +0000 UTC"},{"id":"fe7ddc85cc3c919385d8d2aabfa407eb","type":"TXT","name":"_acme-challenge.deleterecordinset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:58.928 +0000 UTC","modified":"2020-06-12 08:20:58.928 +0000 UTC"},{"id":"61efb963c73466f54f6bba592e9340d4","type":"TXT","name":"ttl.fqdn","value":"ttlshouldbe3600","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:05.618 +0000 UTC","modified":"2020-06-12 08:21:05.618 +0000 UTC"},{"id":"2d5abe2e3b1030903b6ededf674fb76a","type":"TXT","name":"_acme-challenge.listrecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:07.078 +0000 UTC","modified":"2020-06-12 08:21:07.078 +0000 UTC"},{"id":"50aaf8ab858357c3289d2a51d2ea04dc","type":"TXT","name":"_acme-challenge.listrecordset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:08.01 +0000 UTC","modified":"2020-06-12 08:21:08.01 +0000 UTC"},{"id":"b358c2b15c05b3315352ee2a149ce3bc","type":"TXT","name":"random.fqdntest","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:09.601 +0000 UTC","modified":"2020-06-12 08:21:09.601 +0000 UTC"},{"id":"9bf9fc6d8c2b7c277f2da14475d545b3","type":"TXT","name":"random.fulltest","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:11.083 +0000 UTC","modified":"2020-06-12 08:21:11.083 +0000 UTC"}]}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Type:
+      content-length:
+      - '5496'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:36:19 GMT
-      Transfer-Encoding:
+      date:
+      - Fri, 12 Jun 2020 08:21:11 GMT
+      transfer-encoding:
       - chunked
-      Vary:
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
+      x-kong-proxy-latency:
       - '1'
-      X-Kong-Upstream-Latency:
-      - '3637'
+      x-kong-upstream-latency:
+      - '107'
     status:
       code: 200
       message: OK

--- a/tests/fixtures/cassettes/hetzner/IntegrationTests/test_provider_when_calling_list_records_with_invalid_filter_should_be_empty_list.yaml
+++ b/tests/fixtures/cassettes/hetzner/IntegrationTests/test_provider_when_calling_list_records_with_invalid_filter_should_be_empty_list.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -11,44 +11,44 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
     uri: https://dns.hetzner.com/api/v1/zones
   response:
     body:
-      string: '{"zones":[{"id":"xyncsydKx5x44qDZQCzpNM","name":"alt.coop","ttl":300,"registrar":"","legacy_dns_host":"","legacy_ns":["helium.ns.hetzner.com.","oxygen.ns.hetzner.com.","hydrogen.ns.hetzner.com."],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-07
-        01:23:59 +0000 UTC","verified":"2020-04-07 01:53:05.934062806 +0000 UTC m=+578.060435172","modified":"2020-04-08
-        10:38:16.278 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":75},{"id":"JkBqVJDW3PpqefBb274BCZ","name":"softwarekollektiv.de","ttl":86400,"registrar":"","legacy_dns_host":"","legacy_ns":[],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-08
-        18:53:25.589 +0000 UTC","verified":"2020-04-08T18:53:27Z","modified":"2020-04-13
-        15:17:43.767 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":15}],"meta":{"pagination":{"page":1,"per_page":100,"previous_page":1,"next_page":1,"last_page":1,"total_entries":2}}}
+      string: !!python/unicode '{"zones":[{"id":"hetznerapizoneid","name":"hetzner-api-test.de","ttl":3600,"registrar":"","legacy_dns_host":"","legacy_ns":["ns1.first-ns.de.","robotns2.second-ns.de.","robotns3.second-ns.com."],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-07
+        01:24:00 +0000 UTC","verified":"2020-04-07 01:51:26.114056422 +0000 UTC m=+478.240428717","modified":"2020-06-11
+        07:02:20.999 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":9}],"meta":{"pagination":{"page":1,"per_page":100,"previous_page":1,"next_page":1,"last_page":1,"total_entries":12}}}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '1330'
-      Content-Type:
+      content-length:
+      - '7887'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:36:20 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:21:12 GMT
+      transfer-encoding:
+      - chunked
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
+      x-kong-proxy-latency:
       - '2'
-      X-Kong-Upstream-Latency:
-      - '181'
+      x-kong-upstream-latency:
+      - '207'
     status:
       code: 200
       message: OK
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -59,51 +59,62 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
-    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=JkBqVJDW3PpqefBb274BCZ
+    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=hetznerapizoneid
   response:
     body:
-      string: '{"records":[{"id":"8jEciPwo7wF2obPTuBe3Yg","type":"SOA","name":"@","value":"ns1.your-server.de.
-        dns.hetzner.com. 2020041591 86400 7200 3600000 3600","zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        15:17:43.061 +0000 UTC","modified":"2020-04-13 20:36:15.281 +0000 UTC"},{"id":"ccLnXePkikrTK7MjNY2fqb","type":"A","name":"localhost.softwarekollektiv.de.","value":"127.0.0.1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:37.644 +0000 UTC","modified":"2020-04-13 20:32:37.644 +0000 UTC"},{"id":"JQmTbgVAzdx4AADJeLMM3X","type":"CNAME","name":"docs.softwarekollektiv.de.","value":"docs.example.com","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:43.98 +0000 UTC","modified":"2020-04-13 20:32:43.98 +0000 UTC"},{"id":"PJpHrVw6wqik5CTzECpacD","type":"TXT","name":"_acme-challenge.fqdn.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:51.209 +0000 UTC","modified":"2020-04-13 20:32:51.209 +0000 UTC"},{"id":"JB9a4EZrNKbRTLKKAmT6M4","type":"TXT","name":"_acme-challenge.full.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:59.487 +0000 UTC","modified":"2020-04-13 20:32:59.487 +0000 UTC"},{"id":"3KU7EYhoWvAzTENjVAsqwB","type":"TXT","name":"_acme-challenge.test.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:08.017 +0000 UTC","modified":"2020-04-13 20:33:08.017 +0000 UTC"},{"id":"JmFdAr7ZKkv3WFyxnEJL43","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:18.136 +0000 UTC","modified":"2020-04-13 20:33:18.136 +0000 UTC"},{"id":"XJBbqzDiukFE3f2YGcTokY","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:25.929 +0000 UTC","modified":"2020-04-13 20:33:25.929 +0000 UTC"},{"id":"fdSKTmeja8M8pc5vztxb64","type":"TXT","name":"_acme-challenge.noop.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:33.653 +0000 UTC","modified":"2020-04-13 20:33:33.653 +0000 UTC"},{"id":"uDPTMe8hikMxgVAGznkN5S","type":"TXT","name":"_acme-challenge.deleterecordinset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:34:55.913 +0000 UTC","modified":"2020-04-13 20:34:55.913 +0000 UTC"},{"id":"pwek8RBHdnTi2eS3NGEkCG","type":"TXT","name":"ttl.fqdn.softwarekollektiv.de.","value":"ttlshouldbe3600","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:35:33.676 +0000 UTC","modified":"2020-04-13 20:35:33.676 +0000 UTC"},{"id":"wei55NH2jLAWwwnmB6ZFjf","type":"TXT","name":"_acme-challenge.listrecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:35:43.97 +0000 UTC","modified":"2020-04-13 20:35:43.97 +0000 UTC"},{"id":"jGjWxzipctQH5C3oFV7NeJ","type":"TXT","name":"_acme-challenge.listrecordset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:35:51.62 +0000 UTC","modified":"2020-04-13 20:35:51.62 +0000 UTC"},{"id":"jRamHUs2Xyt4Gh3BP4UaCd","type":"TXT","name":"random.fqdntest.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:36:02.609 +0000 UTC","modified":"2020-04-13 20:36:02.609 +0000 UTC"},{"id":"SZspS6AU4CT7ux7M6LaDrG","type":"TXT","name":"random.fulltest.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:36:12.704 +0000 UTC","modified":"2020-04-13 20:36:12.704 +0000 UTC"}]}
+      string: !!python/unicode '{"records":[{"id":"9720b5653ca6fd0517ec91a8c6104685","type":"SOA","name":"@","value":"ns1.first-ns.de.
+        dns.hetzner.com. 2020061228 14400 3600 1814400 3600","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:24:42 +0000 UTC","modified":"2020-06-12 08:21:11.196 +0000 UTC"},{"id":"5b378a7097bdb11e6cbb5f58db6bb101","type":"MX","name":"@","value":"10
+        mail.server-zugang.eu.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:12 +0000 UTC","modified":"2020-04-07 01:25:12 +0000 UTC"},{"id":"a26cfdd36217e559c14b305a558f2a3c","type":"AAAA","name":"@","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"7d6f741802597845b97713596e35eaa7","type":"AAAA","name":"*","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"993bafd3e3b110a6a3acde9fe874426a","type":"NS","name":"@","value":"ns1.first-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"cc3e8297060b7bd794fed5fdec3ed91b","type":"NS","name":"@","value":"robotns2.second-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"c4602b1239d9f0747016f551c52b5774","type":"NS","name":"@","value":"robotns3.second-ns.com.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"77ae87e42a04bace81119eb2280c8dca","type":"A","name":"@","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"faff62d59434c666bac4174a1d18a955","type":"A","name":"*","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"fe6ac2081c630974662caeaa8715d435","type":"A","name":"localhost","value":"127.0.0.1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:37.307 +0000 UTC","modified":"2020-06-12 08:20:37.307 +0000 UTC"},{"id":"8e6b81a856d20f0c1802703b56d1b53d","type":"CNAME","name":"docs","value":"docs.example.com","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:38.743 +0000 UTC","modified":"2020-06-12 08:20:38.743 +0000 UTC"},{"id":"a5fc9854314c160019d9bd0fcaaf2e2a","type":"TXT","name":"_acme-challenge.fqdn","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:40.141 +0000 UTC","modified":"2020-06-12 08:20:40.141 +0000 UTC"},{"id":"101296724cdf3710d18ea43a06b39e6c","type":"TXT","name":"_acme-challenge.full","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:41.421 +0000 UTC","modified":"2020-06-12 08:20:41.421 +0000 UTC"},{"id":"1c06fee6923324bc2727916d2157b3d8","type":"TXT","name":"_acme-challenge.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:43.363 +0000 UTC","modified":"2020-06-12 08:20:43.363 +0000 UTC"},{"id":"97dcfc7f529a65b944a11554e15dcdfb","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:44.557 +0000 UTC","modified":"2020-06-12 08:20:44.557 +0000 UTC"},{"id":"880d3713398b9301dda21a611cbd9ab0","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:45.499 +0000 UTC","modified":"2020-06-12 08:20:45.499 +0000 UTC"},{"id":"f794c3584778621edfa903a30a993f9b","type":"TXT","name":"_acme-challenge.noop","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:46.766 +0000 UTC","modified":"2020-06-12 08:20:46.766 +0000 UTC"},{"id":"fe7ddc85cc3c919385d8d2aabfa407eb","type":"TXT","name":"_acme-challenge.deleterecordinset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:58.928 +0000 UTC","modified":"2020-06-12 08:20:58.928 +0000 UTC"},{"id":"61efb963c73466f54f6bba592e9340d4","type":"TXT","name":"ttl.fqdn","value":"ttlshouldbe3600","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:05.618 +0000 UTC","modified":"2020-06-12 08:21:05.618 +0000 UTC"},{"id":"2d5abe2e3b1030903b6ededf674fb76a","type":"TXT","name":"_acme-challenge.listrecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:07.078 +0000 UTC","modified":"2020-06-12 08:21:07.078 +0000 UTC"},{"id":"50aaf8ab858357c3289d2a51d2ea04dc","type":"TXT","name":"_acme-challenge.listrecordset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:08.01 +0000 UTC","modified":"2020-06-12 08:21:08.01 +0000 UTC"},{"id":"b358c2b15c05b3315352ee2a149ce3bc","type":"TXT","name":"random.fqdntest","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:09.601 +0000 UTC","modified":"2020-06-12 08:21:09.601 +0000 UTC"},{"id":"9bf9fc6d8c2b7c277f2da14475d545b3","type":"TXT","name":"random.fulltest","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:11.083 +0000 UTC","modified":"2020-06-12 08:21:11.083 +0000 UTC"}]}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Type:
+      content-length:
+      - '5496'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:36:24 GMT
-      Transfer-Encoding:
+      date:
+      - Fri, 12 Jun 2020 08:21:12 GMT
+      transfer-encoding:
       - chunked
-      Vary:
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
-      - '2'
-      X-Kong-Upstream-Latency:
-      - '3816'
+      x-kong-proxy-latency:
+      - '3'
+      x-kong-upstream-latency:
+      - '88'
     status:
       code: 200
       message: OK

--- a/tests/fixtures/cassettes/hetzner/IntegrationTests/test_provider_when_calling_list_records_with_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/hetzner/IntegrationTests/test_provider_when_calling_list_records_with_name_filter_should_return_record.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -11,44 +11,44 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
     uri: https://dns.hetzner.com/api/v1/zones
   response:
     body:
-      string: '{"zones":[{"id":"xyncsydKx5x44qDZQCzpNM","name":"alt.coop","ttl":300,"registrar":"","legacy_dns_host":"","legacy_ns":["hydrogen.ns.hetzner.com.","helium.ns.hetzner.com.","oxygen.ns.hetzner.com."],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-07
-        01:23:59 +0000 UTC","verified":"2020-04-07 01:53:05.934062806 +0000 UTC m=+578.060435172","modified":"2020-04-08
-        10:38:16.278 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":75},{"id":"JkBqVJDW3PpqefBb274BCZ","name":"softwarekollektiv.de","ttl":86400,"registrar":"","legacy_dns_host":"","legacy_ns":[],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-08
-        18:53:25.589 +0000 UTC","verified":"2020-04-08T18:53:27Z","modified":"2020-04-13
-        15:17:43.767 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":15}],"meta":{"pagination":{"page":1,"per_page":100,"previous_page":1,"next_page":1,"last_page":1,"total_entries":2}}}
+      string: !!python/unicode '{"zones":[{"id":"hetznerapizoneid","name":"hetzner-api-test.de","ttl":3600,"registrar":"","legacy_dns_host":"","legacy_ns":["ns1.first-ns.de.","robotns2.second-ns.de.","robotns3.second-ns.com."],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-07
+        01:24:00 +0000 UTC","verified":"2020-04-07 01:51:26.114056422 +0000 UTC m=+478.240428717","modified":"2020-06-11
+        07:02:20.999 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":9}],"meta":{"pagination":{"page":1,"per_page":100,"previous_page":1,"next_page":1,"last_page":1,"total_entries":12}}}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '1330'
-      Content-Type:
+      content-length:
+      - '7887'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:36:24 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:21:12 GMT
+      transfer-encoding:
+      - chunked
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
+      x-kong-proxy-latency:
       - '1'
-      X-Kong-Upstream-Latency:
-      - '231'
+      x-kong-upstream-latency:
+      - '239'
     status:
       code: 200
       message: OK
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -59,57 +59,68 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
-    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=JkBqVJDW3PpqefBb274BCZ
+    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=hetznerapizoneid
   response:
     body:
-      string: '{"records":[{"id":"8jEciPwo7wF2obPTuBe3Yg","type":"SOA","name":"@","value":"ns1.your-server.de.
-        dns.hetzner.com. 2020041591 86400 7200 3600000 3600","zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        15:17:43.061 +0000 UTC","modified":"2020-04-13 20:36:15.281 +0000 UTC"},{"id":"ccLnXePkikrTK7MjNY2fqb","type":"A","name":"localhost.softwarekollektiv.de.","value":"127.0.0.1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:37.644 +0000 UTC","modified":"2020-04-13 20:32:37.644 +0000 UTC"},{"id":"JQmTbgVAzdx4AADJeLMM3X","type":"CNAME","name":"docs.softwarekollektiv.de.","value":"docs.example.com","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:43.98 +0000 UTC","modified":"2020-04-13 20:32:43.98 +0000 UTC"},{"id":"PJpHrVw6wqik5CTzECpacD","type":"TXT","name":"_acme-challenge.fqdn.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:51.209 +0000 UTC","modified":"2020-04-13 20:32:51.209 +0000 UTC"},{"id":"JB9a4EZrNKbRTLKKAmT6M4","type":"TXT","name":"_acme-challenge.full.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:59.487 +0000 UTC","modified":"2020-04-13 20:32:59.487 +0000 UTC"},{"id":"3KU7EYhoWvAzTENjVAsqwB","type":"TXT","name":"_acme-challenge.test.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:08.017 +0000 UTC","modified":"2020-04-13 20:33:08.017 +0000 UTC"},{"id":"JmFdAr7ZKkv3WFyxnEJL43","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:18.136 +0000 UTC","modified":"2020-04-13 20:33:18.136 +0000 UTC"},{"id":"XJBbqzDiukFE3f2YGcTokY","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:25.929 +0000 UTC","modified":"2020-04-13 20:33:25.929 +0000 UTC"},{"id":"fdSKTmeja8M8pc5vztxb64","type":"TXT","name":"_acme-challenge.noop.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:33.653 +0000 UTC","modified":"2020-04-13 20:33:33.653 +0000 UTC"},{"id":"uDPTMe8hikMxgVAGznkN5S","type":"TXT","name":"_acme-challenge.deleterecordinset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:34:55.913 +0000 UTC","modified":"2020-04-13 20:34:55.913 +0000 UTC"},{"id":"pwek8RBHdnTi2eS3NGEkCG","type":"TXT","name":"ttl.fqdn.softwarekollektiv.de.","value":"ttlshouldbe3600","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:35:33.676 +0000 UTC","modified":"2020-04-13 20:35:33.676 +0000 UTC"},{"id":"wei55NH2jLAWwwnmB6ZFjf","type":"TXT","name":"_acme-challenge.listrecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:35:43.97 +0000 UTC","modified":"2020-04-13 20:35:43.97 +0000 UTC"},{"id":"jGjWxzipctQH5C3oFV7NeJ","type":"TXT","name":"_acme-challenge.listrecordset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:35:51.62 +0000 UTC","modified":"2020-04-13 20:35:51.62 +0000 UTC"},{"id":"jRamHUs2Xyt4Gh3BP4UaCd","type":"TXT","name":"random.fqdntest.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:36:02.609 +0000 UTC","modified":"2020-04-13 20:36:02.609 +0000 UTC"},{"id":"SZspS6AU4CT7ux7M6LaDrG","type":"TXT","name":"random.fulltest.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:36:12.704 +0000 UTC","modified":"2020-04-13 20:36:12.704 +0000 UTC"}]}
+      string: !!python/unicode '{"records":[{"id":"9720b5653ca6fd0517ec91a8c6104685","type":"SOA","name":"@","value":"ns1.first-ns.de.
+        dns.hetzner.com. 2020061228 14400 3600 1814400 3600","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:24:42 +0000 UTC","modified":"2020-06-12 08:21:11.196 +0000 UTC"},{"id":"5b378a7097bdb11e6cbb5f58db6bb101","type":"MX","name":"@","value":"10
+        mail.server-zugang.eu.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:12 +0000 UTC","modified":"2020-04-07 01:25:12 +0000 UTC"},{"id":"a26cfdd36217e559c14b305a558f2a3c","type":"AAAA","name":"@","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"7d6f741802597845b97713596e35eaa7","type":"AAAA","name":"*","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"993bafd3e3b110a6a3acde9fe874426a","type":"NS","name":"@","value":"ns1.first-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"cc3e8297060b7bd794fed5fdec3ed91b","type":"NS","name":"@","value":"robotns2.second-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"c4602b1239d9f0747016f551c52b5774","type":"NS","name":"@","value":"robotns3.second-ns.com.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"77ae87e42a04bace81119eb2280c8dca","type":"A","name":"@","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"faff62d59434c666bac4174a1d18a955","type":"A","name":"*","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"fe6ac2081c630974662caeaa8715d435","type":"A","name":"localhost","value":"127.0.0.1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:37.307 +0000 UTC","modified":"2020-06-12 08:20:37.307 +0000 UTC"},{"id":"8e6b81a856d20f0c1802703b56d1b53d","type":"CNAME","name":"docs","value":"docs.example.com","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:38.743 +0000 UTC","modified":"2020-06-12 08:20:38.743 +0000 UTC"},{"id":"a5fc9854314c160019d9bd0fcaaf2e2a","type":"TXT","name":"_acme-challenge.fqdn","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:40.141 +0000 UTC","modified":"2020-06-12 08:20:40.141 +0000 UTC"},{"id":"101296724cdf3710d18ea43a06b39e6c","type":"TXT","name":"_acme-challenge.full","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:41.421 +0000 UTC","modified":"2020-06-12 08:20:41.421 +0000 UTC"},{"id":"1c06fee6923324bc2727916d2157b3d8","type":"TXT","name":"_acme-challenge.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:43.363 +0000 UTC","modified":"2020-06-12 08:20:43.363 +0000 UTC"},{"id":"97dcfc7f529a65b944a11554e15dcdfb","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:44.557 +0000 UTC","modified":"2020-06-12 08:20:44.557 +0000 UTC"},{"id":"880d3713398b9301dda21a611cbd9ab0","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:45.499 +0000 UTC","modified":"2020-06-12 08:20:45.499 +0000 UTC"},{"id":"f794c3584778621edfa903a30a993f9b","type":"TXT","name":"_acme-challenge.noop","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:46.766 +0000 UTC","modified":"2020-06-12 08:20:46.766 +0000 UTC"},{"id":"fe7ddc85cc3c919385d8d2aabfa407eb","type":"TXT","name":"_acme-challenge.deleterecordinset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:58.928 +0000 UTC","modified":"2020-06-12 08:20:58.928 +0000 UTC"},{"id":"61efb963c73466f54f6bba592e9340d4","type":"TXT","name":"ttl.fqdn","value":"ttlshouldbe3600","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:05.618 +0000 UTC","modified":"2020-06-12 08:21:05.618 +0000 UTC"},{"id":"2d5abe2e3b1030903b6ededf674fb76a","type":"TXT","name":"_acme-challenge.listrecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:07.078 +0000 UTC","modified":"2020-06-12 08:21:07.078 +0000 UTC"},{"id":"50aaf8ab858357c3289d2a51d2ea04dc","type":"TXT","name":"_acme-challenge.listrecordset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:08.01 +0000 UTC","modified":"2020-06-12 08:21:08.01 +0000 UTC"},{"id":"b358c2b15c05b3315352ee2a149ce3bc","type":"TXT","name":"random.fqdntest","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:09.601 +0000 UTC","modified":"2020-06-12 08:21:09.601 +0000 UTC"},{"id":"9bf9fc6d8c2b7c277f2da14475d545b3","type":"TXT","name":"random.fulltest","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:11.083 +0000 UTC","modified":"2020-06-12 08:21:11.083 +0000 UTC"}]}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Type:
+      content-length:
+      - '5496'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:36:27 GMT
-      Transfer-Encoding:
+      date:
+      - Fri, 12 Jun 2020 08:21:13 GMT
+      transfer-encoding:
       - chunked
-      Vary:
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
+      x-kong-proxy-latency:
       - '2'
-      X-Kong-Upstream-Latency:
-      - '2558'
+      x-kong-upstream-latency:
+      - '78'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"name": "random.test.softwarekollektiv.de.", "type": "TXT", "value": "challengetoken",
-      "zone_id": "JkBqVJDW3PpqefBb274BCZ", "ttl": 3600}'
+    body: !!python/unicode '{"ttl": 3600, "type": "TXT", "name": "random.test", "value":
+      "challengetoken", "zone_id": "hetznerapizoneid"}'
     headers:
       Accept:
       - '*/*'
@@ -118,43 +129,45 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '137'
+      - '115'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: POST
     uri: https://dns.hetzner.com/api/v1/records
   response:
     body:
-      string: '{"record":{"id":"drrxjb4ddap8EjFbQw9p8f","type":"TXT","name":"random.test.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:36:27.598 +0000 UTC","modified":"2020-04-13 20:36:27.598 +0000 UTC"}}
+      string: !!python/unicode '{"record":{"id":"16667dd263f7667ae6d4deec7233b8b5","type":"TXT","name":"random.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:13.182 +0000 UTC","modified":"2020-06-12 08:21:13.182 +0000 UTC"}}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '263'
-      Content-Type:
+      content-length:
+      - '251'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:36:31 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:21:13 GMT
+      transfer-encoding:
+      - chunked
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
-      - '1'
-      X-Kong-Upstream-Latency:
-      - '3532'
+      x-kong-proxy-latency:
+      - '2'
+      x-kong-upstream-latency:
+      - '687'
     status:
       code: 200
       message: OK
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -165,52 +178,63 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
-    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=JkBqVJDW3PpqefBb274BCZ
+    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=hetznerapizoneid
   response:
     body:
-      string: '{"records":[{"id":"8jEciPwo7wF2obPTuBe3Yg","type":"SOA","name":"@","value":"ns1.your-server.de.
-        dns.hetzner.com. 2020041592 86400 7200 3600000 3600","zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        15:17:43.061 +0000 UTC","modified":"2020-04-13 20:36:30.58 +0000 UTC"},{"id":"ccLnXePkikrTK7MjNY2fqb","type":"A","name":"localhost.softwarekollektiv.de.","value":"127.0.0.1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:37.644 +0000 UTC","modified":"2020-04-13 20:32:37.644 +0000 UTC"},{"id":"JQmTbgVAzdx4AADJeLMM3X","type":"CNAME","name":"docs.softwarekollektiv.de.","value":"docs.example.com","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:43.98 +0000 UTC","modified":"2020-04-13 20:32:43.98 +0000 UTC"},{"id":"PJpHrVw6wqik5CTzECpacD","type":"TXT","name":"_acme-challenge.fqdn.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:51.209 +0000 UTC","modified":"2020-04-13 20:32:51.209 +0000 UTC"},{"id":"JB9a4EZrNKbRTLKKAmT6M4","type":"TXT","name":"_acme-challenge.full.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:59.487 +0000 UTC","modified":"2020-04-13 20:32:59.487 +0000 UTC"},{"id":"3KU7EYhoWvAzTENjVAsqwB","type":"TXT","name":"_acme-challenge.test.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:08.017 +0000 UTC","modified":"2020-04-13 20:33:08.017 +0000 UTC"},{"id":"JmFdAr7ZKkv3WFyxnEJL43","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:18.136 +0000 UTC","modified":"2020-04-13 20:33:18.136 +0000 UTC"},{"id":"XJBbqzDiukFE3f2YGcTokY","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:25.929 +0000 UTC","modified":"2020-04-13 20:33:25.929 +0000 UTC"},{"id":"fdSKTmeja8M8pc5vztxb64","type":"TXT","name":"_acme-challenge.noop.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:33.653 +0000 UTC","modified":"2020-04-13 20:33:33.653 +0000 UTC"},{"id":"uDPTMe8hikMxgVAGznkN5S","type":"TXT","name":"_acme-challenge.deleterecordinset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:34:55.913 +0000 UTC","modified":"2020-04-13 20:34:55.913 +0000 UTC"},{"id":"pwek8RBHdnTi2eS3NGEkCG","type":"TXT","name":"ttl.fqdn.softwarekollektiv.de.","value":"ttlshouldbe3600","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:35:33.676 +0000 UTC","modified":"2020-04-13 20:35:33.676 +0000 UTC"},{"id":"wei55NH2jLAWwwnmB6ZFjf","type":"TXT","name":"_acme-challenge.listrecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:35:43.97 +0000 UTC","modified":"2020-04-13 20:35:43.97 +0000 UTC"},{"id":"jGjWxzipctQH5C3oFV7NeJ","type":"TXT","name":"_acme-challenge.listrecordset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:35:51.62 +0000 UTC","modified":"2020-04-13 20:35:51.62 +0000 UTC"},{"id":"jRamHUs2Xyt4Gh3BP4UaCd","type":"TXT","name":"random.fqdntest.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:36:02.609 +0000 UTC","modified":"2020-04-13 20:36:02.609 +0000 UTC"},{"id":"SZspS6AU4CT7ux7M6LaDrG","type":"TXT","name":"random.fulltest.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:36:12.704 +0000 UTC","modified":"2020-04-13 20:36:12.704 +0000 UTC"},{"id":"drrxjb4ddap8EjFbQw9p8f","type":"TXT","name":"random.test.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:36:27.598 +0000 UTC","modified":"2020-04-13 20:36:27.598 +0000 UTC"}]}
+      string: !!python/unicode '{"records":[{"id":"9720b5653ca6fd0517ec91a8c6104685","type":"SOA","name":"@","value":"ns1.first-ns.de.
+        dns.hetzner.com. 2020061229 14400 3600 1814400 3600","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:24:42 +0000 UTC","modified":"2020-06-12 08:21:13.281 +0000 UTC"},{"id":"5b378a7097bdb11e6cbb5f58db6bb101","type":"MX","name":"@","value":"10
+        mail.server-zugang.eu.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:12 +0000 UTC","modified":"2020-04-07 01:25:12 +0000 UTC"},{"id":"a26cfdd36217e559c14b305a558f2a3c","type":"AAAA","name":"@","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"7d6f741802597845b97713596e35eaa7","type":"AAAA","name":"*","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"993bafd3e3b110a6a3acde9fe874426a","type":"NS","name":"@","value":"ns1.first-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"cc3e8297060b7bd794fed5fdec3ed91b","type":"NS","name":"@","value":"robotns2.second-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"c4602b1239d9f0747016f551c52b5774","type":"NS","name":"@","value":"robotns3.second-ns.com.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"77ae87e42a04bace81119eb2280c8dca","type":"A","name":"@","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"faff62d59434c666bac4174a1d18a955","type":"A","name":"*","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"fe6ac2081c630974662caeaa8715d435","type":"A","name":"localhost","value":"127.0.0.1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:37.307 +0000 UTC","modified":"2020-06-12 08:20:37.307 +0000 UTC"},{"id":"8e6b81a856d20f0c1802703b56d1b53d","type":"CNAME","name":"docs","value":"docs.example.com","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:38.743 +0000 UTC","modified":"2020-06-12 08:20:38.743 +0000 UTC"},{"id":"a5fc9854314c160019d9bd0fcaaf2e2a","type":"TXT","name":"_acme-challenge.fqdn","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:40.141 +0000 UTC","modified":"2020-06-12 08:20:40.141 +0000 UTC"},{"id":"101296724cdf3710d18ea43a06b39e6c","type":"TXT","name":"_acme-challenge.full","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:41.421 +0000 UTC","modified":"2020-06-12 08:20:41.421 +0000 UTC"},{"id":"1c06fee6923324bc2727916d2157b3d8","type":"TXT","name":"_acme-challenge.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:43.363 +0000 UTC","modified":"2020-06-12 08:20:43.363 +0000 UTC"},{"id":"97dcfc7f529a65b944a11554e15dcdfb","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:44.557 +0000 UTC","modified":"2020-06-12 08:20:44.557 +0000 UTC"},{"id":"880d3713398b9301dda21a611cbd9ab0","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:45.499 +0000 UTC","modified":"2020-06-12 08:20:45.499 +0000 UTC"},{"id":"f794c3584778621edfa903a30a993f9b","type":"TXT","name":"_acme-challenge.noop","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:46.766 +0000 UTC","modified":"2020-06-12 08:20:46.766 +0000 UTC"},{"id":"fe7ddc85cc3c919385d8d2aabfa407eb","type":"TXT","name":"_acme-challenge.deleterecordinset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:58.928 +0000 UTC","modified":"2020-06-12 08:20:58.928 +0000 UTC"},{"id":"61efb963c73466f54f6bba592e9340d4","type":"TXT","name":"ttl.fqdn","value":"ttlshouldbe3600","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:05.618 +0000 UTC","modified":"2020-06-12 08:21:05.618 +0000 UTC"},{"id":"2d5abe2e3b1030903b6ededf674fb76a","type":"TXT","name":"_acme-challenge.listrecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:07.078 +0000 UTC","modified":"2020-06-12 08:21:07.078 +0000 UTC"},{"id":"50aaf8ab858357c3289d2a51d2ea04dc","type":"TXT","name":"_acme-challenge.listrecordset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:08.01 +0000 UTC","modified":"2020-06-12 08:21:08.01 +0000 UTC"},{"id":"b358c2b15c05b3315352ee2a149ce3bc","type":"TXT","name":"random.fqdntest","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:09.601 +0000 UTC","modified":"2020-06-12 08:21:09.601 +0000 UTC"},{"id":"9bf9fc6d8c2b7c277f2da14475d545b3","type":"TXT","name":"random.fulltest","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:11.083 +0000 UTC","modified":"2020-06-12 08:21:11.083 +0000 UTC"},{"id":"16667dd263f7667ae6d4deec7233b8b5","type":"TXT","name":"random.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:13.182 +0000 UTC","modified":"2020-06-12 08:21:13.182 +0000 UTC"}]}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Type:
+      content-length:
+      - '5736'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:36:34 GMT
-      Transfer-Encoding:
+      date:
+      - Fri, 12 Jun 2020 08:21:14 GMT
+      transfer-encoding:
       - chunked
-      Vary:
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
-      - '1'
-      X-Kong-Upstream-Latency:
-      - '3285'
+      x-kong-proxy-latency:
+      - '2'
+      x-kong-upstream-latency:
+      - '75'
     status:
       code: 200
       message: OK

--- a/tests/fixtures/cassettes/hetzner/IntegrationTests/test_provider_when_calling_list_records_with_no_arguments_should_list_all.yaml
+++ b/tests/fixtures/cassettes/hetzner/IntegrationTests/test_provider_when_calling_list_records_with_no_arguments_should_list_all.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -11,44 +11,44 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
     uri: https://dns.hetzner.com/api/v1/zones
   response:
     body:
-      string: '{"zones":[{"id":"xyncsydKx5x44qDZQCzpNM","name":"alt.coop","ttl":300,"registrar":"","legacy_dns_host":"","legacy_ns":["helium.ns.hetzner.com.","oxygen.ns.hetzner.com.","hydrogen.ns.hetzner.com."],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-07
-        01:23:59 +0000 UTC","verified":"2020-04-07 01:53:05.934062806 +0000 UTC m=+578.060435172","modified":"2020-04-08
-        10:38:16.278 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":75},{"id":"JkBqVJDW3PpqefBb274BCZ","name":"softwarekollektiv.de","ttl":86400,"registrar":"","legacy_dns_host":"","legacy_ns":[],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-08
-        18:53:25.589 +0000 UTC","verified":"2020-04-08T18:53:27Z","modified":"2020-04-13
-        15:17:43.767 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":16}],"meta":{"pagination":{"page":1,"per_page":100,"previous_page":1,"next_page":1,"last_page":1,"total_entries":2}}}
+      string: !!python/unicode '{"zones":[{"id":"hetznerapizoneid","name":"hetzner-api-test.de","ttl":3600,"registrar":"","legacy_dns_host":"","legacy_ns":["ns1.first-ns.de.","robotns2.second-ns.de.","robotns3.second-ns.com."],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-07
+        01:24:00 +0000 UTC","verified":"2020-04-07 01:51:26.114056422 +0000 UTC m=+478.240428717","modified":"2020-06-11
+        07:02:20.999 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":9}],"meta":{"pagination":{"page":1,"per_page":100,"previous_page":1,"next_page":1,"last_page":1,"total_entries":12}}}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '1330'
-      Content-Type:
+      content-length:
+      - '7887'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:36:34 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:21:14 GMT
+      transfer-encoding:
+      - chunked
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
+      x-kong-proxy-latency:
       - '2'
-      X-Kong-Upstream-Latency:
-      - '208'
+      x-kong-upstream-latency:
+      - '212'
     status:
       code: 200
       message: OK
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -59,52 +59,63 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
-    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=JkBqVJDW3PpqefBb274BCZ
+    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=hetznerapizoneid
   response:
     body:
-      string: '{"records":[{"id":"8jEciPwo7wF2obPTuBe3Yg","type":"SOA","name":"@","value":"ns1.your-server.de.
-        dns.hetzner.com. 2020041592 86400 7200 3600000 3600","zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        15:17:43.061 +0000 UTC","modified":"2020-04-13 20:36:30.58 +0000 UTC"},{"id":"ccLnXePkikrTK7MjNY2fqb","type":"A","name":"localhost.softwarekollektiv.de.","value":"127.0.0.1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:37.644 +0000 UTC","modified":"2020-04-13 20:32:37.644 +0000 UTC"},{"id":"JQmTbgVAzdx4AADJeLMM3X","type":"CNAME","name":"docs.softwarekollektiv.de.","value":"docs.example.com","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:43.98 +0000 UTC","modified":"2020-04-13 20:32:43.98 +0000 UTC"},{"id":"PJpHrVw6wqik5CTzECpacD","type":"TXT","name":"_acme-challenge.fqdn.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:51.209 +0000 UTC","modified":"2020-04-13 20:32:51.209 +0000 UTC"},{"id":"JB9a4EZrNKbRTLKKAmT6M4","type":"TXT","name":"_acme-challenge.full.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:59.487 +0000 UTC","modified":"2020-04-13 20:32:59.487 +0000 UTC"},{"id":"3KU7EYhoWvAzTENjVAsqwB","type":"TXT","name":"_acme-challenge.test.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:08.017 +0000 UTC","modified":"2020-04-13 20:33:08.017 +0000 UTC"},{"id":"JmFdAr7ZKkv3WFyxnEJL43","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:18.136 +0000 UTC","modified":"2020-04-13 20:33:18.136 +0000 UTC"},{"id":"XJBbqzDiukFE3f2YGcTokY","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:25.929 +0000 UTC","modified":"2020-04-13 20:33:25.929 +0000 UTC"},{"id":"fdSKTmeja8M8pc5vztxb64","type":"TXT","name":"_acme-challenge.noop.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:33.653 +0000 UTC","modified":"2020-04-13 20:33:33.653 +0000 UTC"},{"id":"uDPTMe8hikMxgVAGznkN5S","type":"TXT","name":"_acme-challenge.deleterecordinset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:34:55.913 +0000 UTC","modified":"2020-04-13 20:34:55.913 +0000 UTC"},{"id":"pwek8RBHdnTi2eS3NGEkCG","type":"TXT","name":"ttl.fqdn.softwarekollektiv.de.","value":"ttlshouldbe3600","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:35:33.676 +0000 UTC","modified":"2020-04-13 20:35:33.676 +0000 UTC"},{"id":"wei55NH2jLAWwwnmB6ZFjf","type":"TXT","name":"_acme-challenge.listrecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:35:43.97 +0000 UTC","modified":"2020-04-13 20:35:43.97 +0000 UTC"},{"id":"jGjWxzipctQH5C3oFV7NeJ","type":"TXT","name":"_acme-challenge.listrecordset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:35:51.62 +0000 UTC","modified":"2020-04-13 20:35:51.62 +0000 UTC"},{"id":"jRamHUs2Xyt4Gh3BP4UaCd","type":"TXT","name":"random.fqdntest.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:36:02.609 +0000 UTC","modified":"2020-04-13 20:36:02.609 +0000 UTC"},{"id":"SZspS6AU4CT7ux7M6LaDrG","type":"TXT","name":"random.fulltest.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:36:12.704 +0000 UTC","modified":"2020-04-13 20:36:12.704 +0000 UTC"},{"id":"drrxjb4ddap8EjFbQw9p8f","type":"TXT","name":"random.test.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:36:27.598 +0000 UTC","modified":"2020-04-13 20:36:27.598 +0000 UTC"}]}
+      string: !!python/unicode '{"records":[{"id":"9720b5653ca6fd0517ec91a8c6104685","type":"SOA","name":"@","value":"ns1.first-ns.de.
+        dns.hetzner.com. 2020061229 14400 3600 1814400 3600","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:24:42 +0000 UTC","modified":"2020-06-12 08:21:13.281 +0000 UTC"},{"id":"5b378a7097bdb11e6cbb5f58db6bb101","type":"MX","name":"@","value":"10
+        mail.server-zugang.eu.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:12 +0000 UTC","modified":"2020-04-07 01:25:12 +0000 UTC"},{"id":"a26cfdd36217e559c14b305a558f2a3c","type":"AAAA","name":"@","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"7d6f741802597845b97713596e35eaa7","type":"AAAA","name":"*","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"993bafd3e3b110a6a3acde9fe874426a","type":"NS","name":"@","value":"ns1.first-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"cc3e8297060b7bd794fed5fdec3ed91b","type":"NS","name":"@","value":"robotns2.second-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"c4602b1239d9f0747016f551c52b5774","type":"NS","name":"@","value":"robotns3.second-ns.com.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"77ae87e42a04bace81119eb2280c8dca","type":"A","name":"@","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"faff62d59434c666bac4174a1d18a955","type":"A","name":"*","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"fe6ac2081c630974662caeaa8715d435","type":"A","name":"localhost","value":"127.0.0.1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:37.307 +0000 UTC","modified":"2020-06-12 08:20:37.307 +0000 UTC"},{"id":"8e6b81a856d20f0c1802703b56d1b53d","type":"CNAME","name":"docs","value":"docs.example.com","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:38.743 +0000 UTC","modified":"2020-06-12 08:20:38.743 +0000 UTC"},{"id":"a5fc9854314c160019d9bd0fcaaf2e2a","type":"TXT","name":"_acme-challenge.fqdn","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:40.141 +0000 UTC","modified":"2020-06-12 08:20:40.141 +0000 UTC"},{"id":"101296724cdf3710d18ea43a06b39e6c","type":"TXT","name":"_acme-challenge.full","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:41.421 +0000 UTC","modified":"2020-06-12 08:20:41.421 +0000 UTC"},{"id":"1c06fee6923324bc2727916d2157b3d8","type":"TXT","name":"_acme-challenge.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:43.363 +0000 UTC","modified":"2020-06-12 08:20:43.363 +0000 UTC"},{"id":"97dcfc7f529a65b944a11554e15dcdfb","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:44.557 +0000 UTC","modified":"2020-06-12 08:20:44.557 +0000 UTC"},{"id":"880d3713398b9301dda21a611cbd9ab0","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:45.499 +0000 UTC","modified":"2020-06-12 08:20:45.499 +0000 UTC"},{"id":"f794c3584778621edfa903a30a993f9b","type":"TXT","name":"_acme-challenge.noop","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:46.766 +0000 UTC","modified":"2020-06-12 08:20:46.766 +0000 UTC"},{"id":"fe7ddc85cc3c919385d8d2aabfa407eb","type":"TXT","name":"_acme-challenge.deleterecordinset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:58.928 +0000 UTC","modified":"2020-06-12 08:20:58.928 +0000 UTC"},{"id":"61efb963c73466f54f6bba592e9340d4","type":"TXT","name":"ttl.fqdn","value":"ttlshouldbe3600","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:05.618 +0000 UTC","modified":"2020-06-12 08:21:05.618 +0000 UTC"},{"id":"2d5abe2e3b1030903b6ededf674fb76a","type":"TXT","name":"_acme-challenge.listrecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:07.078 +0000 UTC","modified":"2020-06-12 08:21:07.078 +0000 UTC"},{"id":"50aaf8ab858357c3289d2a51d2ea04dc","type":"TXT","name":"_acme-challenge.listrecordset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:08.01 +0000 UTC","modified":"2020-06-12 08:21:08.01 +0000 UTC"},{"id":"b358c2b15c05b3315352ee2a149ce3bc","type":"TXT","name":"random.fqdntest","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:09.601 +0000 UTC","modified":"2020-06-12 08:21:09.601 +0000 UTC"},{"id":"9bf9fc6d8c2b7c277f2da14475d545b3","type":"TXT","name":"random.fulltest","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:11.083 +0000 UTC","modified":"2020-06-12 08:21:11.083 +0000 UTC"},{"id":"16667dd263f7667ae6d4deec7233b8b5","type":"TXT","name":"random.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:13.182 +0000 UTC","modified":"2020-06-12 08:21:13.182 +0000 UTC"}]}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Type:
+      content-length:
+      - '5736'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:36:38 GMT
-      Transfer-Encoding:
+      date:
+      - Fri, 12 Jun 2020 08:21:14 GMT
+      transfer-encoding:
       - chunked
-      Vary:
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
+      x-kong-proxy-latency:
       - '2'
-      X-Kong-Upstream-Latency:
-      - '3671'
+      x-kong-upstream-latency:
+      - '72'
     status:
       code: 200
       message: OK

--- a/tests/fixtures/cassettes/hetzner/IntegrationTests/test_provider_when_calling_update_record_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/hetzner/IntegrationTests/test_provider_when_calling_update_record_should_modify_record.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -11,44 +11,44 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
     uri: https://dns.hetzner.com/api/v1/zones
   response:
     body:
-      string: '{"zones":[{"id":"xyncsydKx5x44qDZQCzpNM","name":"alt.coop","ttl":300,"registrar":"","legacy_dns_host":"","legacy_ns":["helium.ns.hetzner.com.","oxygen.ns.hetzner.com.","hydrogen.ns.hetzner.com."],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-07
-        01:23:59 +0000 UTC","verified":"2020-04-07 01:53:05.934062806 +0000 UTC m=+578.060435172","modified":"2020-04-08
-        10:38:16.278 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":75},{"id":"JkBqVJDW3PpqefBb274BCZ","name":"softwarekollektiv.de","ttl":86400,"registrar":"","legacy_dns_host":"","legacy_ns":[],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-08
-        18:53:25.589 +0000 UTC","verified":"2020-04-08T18:53:27Z","modified":"2020-04-13
-        15:17:43.767 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":16}],"meta":{"pagination":{"page":1,"per_page":100,"previous_page":1,"next_page":1,"last_page":1,"total_entries":2}}}
+      string: !!python/unicode '{"zones":[{"id":"hetznerapizoneid","name":"hetzner-api-test.de","ttl":3600,"registrar":"","legacy_dns_host":"","legacy_ns":["ns1.first-ns.de.","robotns2.second-ns.de.","robotns3.second-ns.com."],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-07
+        01:24:00 +0000 UTC","verified":"2020-04-07 01:51:26.114056422 +0000 UTC m=+478.240428717","modified":"2020-06-11
+        07:02:20.999 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":9}],"meta":{"pagination":{"page":1,"per_page":100,"previous_page":1,"next_page":1,"last_page":1,"total_entries":12}}}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '1330'
-      Content-Type:
+      content-length:
+      - '7887'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:36:39 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:21:14 GMT
+      transfer-encoding:
+      - chunked
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
+      x-kong-proxy-latency:
       - '2'
-      X-Kong-Upstream-Latency:
-      - '206'
+      x-kong-upstream-latency:
+      - '253'
     status:
       code: 200
       message: OK
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -59,58 +59,69 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
-    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=JkBqVJDW3PpqefBb274BCZ
+    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=hetznerapizoneid
   response:
     body:
-      string: '{"records":[{"id":"8jEciPwo7wF2obPTuBe3Yg","type":"SOA","name":"@","value":"ns1.your-server.de.
-        dns.hetzner.com. 2020041592 86400 7200 3600000 3600","zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        15:17:43.061 +0000 UTC","modified":"2020-04-13 20:36:30.58 +0000 UTC"},{"id":"ccLnXePkikrTK7MjNY2fqb","type":"A","name":"localhost.softwarekollektiv.de.","value":"127.0.0.1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:37.644 +0000 UTC","modified":"2020-04-13 20:32:37.644 +0000 UTC"},{"id":"JQmTbgVAzdx4AADJeLMM3X","type":"CNAME","name":"docs.softwarekollektiv.de.","value":"docs.example.com","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:43.98 +0000 UTC","modified":"2020-04-13 20:32:43.98 +0000 UTC"},{"id":"PJpHrVw6wqik5CTzECpacD","type":"TXT","name":"_acme-challenge.fqdn.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:51.209 +0000 UTC","modified":"2020-04-13 20:32:51.209 +0000 UTC"},{"id":"JB9a4EZrNKbRTLKKAmT6M4","type":"TXT","name":"_acme-challenge.full.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:59.487 +0000 UTC","modified":"2020-04-13 20:32:59.487 +0000 UTC"},{"id":"3KU7EYhoWvAzTENjVAsqwB","type":"TXT","name":"_acme-challenge.test.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:08.017 +0000 UTC","modified":"2020-04-13 20:33:08.017 +0000 UTC"},{"id":"JmFdAr7ZKkv3WFyxnEJL43","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:18.136 +0000 UTC","modified":"2020-04-13 20:33:18.136 +0000 UTC"},{"id":"XJBbqzDiukFE3f2YGcTokY","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:25.929 +0000 UTC","modified":"2020-04-13 20:33:25.929 +0000 UTC"},{"id":"fdSKTmeja8M8pc5vztxb64","type":"TXT","name":"_acme-challenge.noop.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:33.653 +0000 UTC","modified":"2020-04-13 20:33:33.653 +0000 UTC"},{"id":"uDPTMe8hikMxgVAGznkN5S","type":"TXT","name":"_acme-challenge.deleterecordinset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:34:55.913 +0000 UTC","modified":"2020-04-13 20:34:55.913 +0000 UTC"},{"id":"pwek8RBHdnTi2eS3NGEkCG","type":"TXT","name":"ttl.fqdn.softwarekollektiv.de.","value":"ttlshouldbe3600","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:35:33.676 +0000 UTC","modified":"2020-04-13 20:35:33.676 +0000 UTC"},{"id":"wei55NH2jLAWwwnmB6ZFjf","type":"TXT","name":"_acme-challenge.listrecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:35:43.97 +0000 UTC","modified":"2020-04-13 20:35:43.97 +0000 UTC"},{"id":"jGjWxzipctQH5C3oFV7NeJ","type":"TXT","name":"_acme-challenge.listrecordset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:35:51.62 +0000 UTC","modified":"2020-04-13 20:35:51.62 +0000 UTC"},{"id":"jRamHUs2Xyt4Gh3BP4UaCd","type":"TXT","name":"random.fqdntest.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:36:02.609 +0000 UTC","modified":"2020-04-13 20:36:02.609 +0000 UTC"},{"id":"SZspS6AU4CT7ux7M6LaDrG","type":"TXT","name":"random.fulltest.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:36:12.704 +0000 UTC","modified":"2020-04-13 20:36:12.704 +0000 UTC"},{"id":"drrxjb4ddap8EjFbQw9p8f","type":"TXT","name":"random.test.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:36:27.598 +0000 UTC","modified":"2020-04-13 20:36:27.598 +0000 UTC"}]}
+      string: !!python/unicode '{"records":[{"id":"9720b5653ca6fd0517ec91a8c6104685","type":"SOA","name":"@","value":"ns1.first-ns.de.
+        dns.hetzner.com. 2020061229 14400 3600 1814400 3600","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:24:42 +0000 UTC","modified":"2020-06-12 08:21:13.281 +0000 UTC"},{"id":"5b378a7097bdb11e6cbb5f58db6bb101","type":"MX","name":"@","value":"10
+        mail.server-zugang.eu.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:12 +0000 UTC","modified":"2020-04-07 01:25:12 +0000 UTC"},{"id":"a26cfdd36217e559c14b305a558f2a3c","type":"AAAA","name":"@","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"7d6f741802597845b97713596e35eaa7","type":"AAAA","name":"*","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"993bafd3e3b110a6a3acde9fe874426a","type":"NS","name":"@","value":"ns1.first-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"cc3e8297060b7bd794fed5fdec3ed91b","type":"NS","name":"@","value":"robotns2.second-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"c4602b1239d9f0747016f551c52b5774","type":"NS","name":"@","value":"robotns3.second-ns.com.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"77ae87e42a04bace81119eb2280c8dca","type":"A","name":"@","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"faff62d59434c666bac4174a1d18a955","type":"A","name":"*","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"fe6ac2081c630974662caeaa8715d435","type":"A","name":"localhost","value":"127.0.0.1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:37.307 +0000 UTC","modified":"2020-06-12 08:20:37.307 +0000 UTC"},{"id":"8e6b81a856d20f0c1802703b56d1b53d","type":"CNAME","name":"docs","value":"docs.example.com","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:38.743 +0000 UTC","modified":"2020-06-12 08:20:38.743 +0000 UTC"},{"id":"a5fc9854314c160019d9bd0fcaaf2e2a","type":"TXT","name":"_acme-challenge.fqdn","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:40.141 +0000 UTC","modified":"2020-06-12 08:20:40.141 +0000 UTC"},{"id":"101296724cdf3710d18ea43a06b39e6c","type":"TXT","name":"_acme-challenge.full","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:41.421 +0000 UTC","modified":"2020-06-12 08:20:41.421 +0000 UTC"},{"id":"1c06fee6923324bc2727916d2157b3d8","type":"TXT","name":"_acme-challenge.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:43.363 +0000 UTC","modified":"2020-06-12 08:20:43.363 +0000 UTC"},{"id":"97dcfc7f529a65b944a11554e15dcdfb","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:44.557 +0000 UTC","modified":"2020-06-12 08:20:44.557 +0000 UTC"},{"id":"880d3713398b9301dda21a611cbd9ab0","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:45.499 +0000 UTC","modified":"2020-06-12 08:20:45.499 +0000 UTC"},{"id":"f794c3584778621edfa903a30a993f9b","type":"TXT","name":"_acme-challenge.noop","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:46.766 +0000 UTC","modified":"2020-06-12 08:20:46.766 +0000 UTC"},{"id":"fe7ddc85cc3c919385d8d2aabfa407eb","type":"TXT","name":"_acme-challenge.deleterecordinset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:58.928 +0000 UTC","modified":"2020-06-12 08:20:58.928 +0000 UTC"},{"id":"61efb963c73466f54f6bba592e9340d4","type":"TXT","name":"ttl.fqdn","value":"ttlshouldbe3600","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:05.618 +0000 UTC","modified":"2020-06-12 08:21:05.618 +0000 UTC"},{"id":"2d5abe2e3b1030903b6ededf674fb76a","type":"TXT","name":"_acme-challenge.listrecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:07.078 +0000 UTC","modified":"2020-06-12 08:21:07.078 +0000 UTC"},{"id":"50aaf8ab858357c3289d2a51d2ea04dc","type":"TXT","name":"_acme-challenge.listrecordset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:08.01 +0000 UTC","modified":"2020-06-12 08:21:08.01 +0000 UTC"},{"id":"b358c2b15c05b3315352ee2a149ce3bc","type":"TXT","name":"random.fqdntest","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:09.601 +0000 UTC","modified":"2020-06-12 08:21:09.601 +0000 UTC"},{"id":"9bf9fc6d8c2b7c277f2da14475d545b3","type":"TXT","name":"random.fulltest","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:11.083 +0000 UTC","modified":"2020-06-12 08:21:11.083 +0000 UTC"},{"id":"16667dd263f7667ae6d4deec7233b8b5","type":"TXT","name":"random.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:13.182 +0000 UTC","modified":"2020-06-12 08:21:13.182 +0000 UTC"}]}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Type:
+      content-length:
+      - '5736'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:36:42 GMT
-      Transfer-Encoding:
+      date:
+      - Fri, 12 Jun 2020 08:21:15 GMT
+      transfer-encoding:
       - chunked
-      Vary:
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
-      - '0'
-      X-Kong-Upstream-Latency:
-      - '3532'
+      x-kong-proxy-latency:
+      - '2'
+      x-kong-upstream-latency:
+      - '77'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"name": "orig.test.softwarekollektiv.de.", "type": "TXT", "value": "challengetoken",
-      "zone_id": "JkBqVJDW3PpqefBb274BCZ", "ttl": 3600}'
+    body: !!python/unicode '{"ttl": 3600, "type": "TXT", "name": "orig.test", "value":
+      "challengetoken", "zone_id": "hetznerapizoneid"}'
     headers:
       Accept:
       - '*/*'
@@ -119,43 +130,45 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '135'
+      - '113'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: POST
     uri: https://dns.hetzner.com/api/v1/records
   response:
     body:
-      string: '{"record":{"id":"XAZaCUS5e4bNjgcFWWCsB3","type":"TXT","name":"orig.test.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:36:43.156 +0000 UTC","modified":"2020-04-13 20:36:43.156 +0000 UTC"}}
+      string: !!python/unicode '{"record":{"id":"8bb7c37e2c1dead95f002c91dc46246c","type":"TXT","name":"orig.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:15.177 +0000 UTC","modified":"2020-06-12 08:21:15.177 +0000 UTC"}}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '261'
-      Content-Type:
+      content-length:
+      - '249'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:36:46 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:21:15 GMT
+      transfer-encoding:
+      - chunked
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
-      - '8'
-      X-Kong-Upstream-Latency:
-      - '3415'
+      x-kong-proxy-latency:
+      - '2'
+      x-kong-upstream-latency:
+      - '646'
     status:
       code: 200
       message: OK
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -166,59 +179,70 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
-    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=JkBqVJDW3PpqefBb274BCZ
+    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=hetznerapizoneid
   response:
     body:
-      string: '{"records":[{"id":"8jEciPwo7wF2obPTuBe3Yg","type":"SOA","name":"@","value":"ns1.your-server.de.
-        dns.hetzner.com. 2020041593 86400 7200 3600000 3600","zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        15:17:43.061 +0000 UTC","modified":"2020-04-13 20:36:45.816 +0000 UTC"},{"id":"ccLnXePkikrTK7MjNY2fqb","type":"A","name":"localhost.softwarekollektiv.de.","value":"127.0.0.1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:37.644 +0000 UTC","modified":"2020-04-13 20:32:37.644 +0000 UTC"},{"id":"JQmTbgVAzdx4AADJeLMM3X","type":"CNAME","name":"docs.softwarekollektiv.de.","value":"docs.example.com","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:43.98 +0000 UTC","modified":"2020-04-13 20:32:43.98 +0000 UTC"},{"id":"PJpHrVw6wqik5CTzECpacD","type":"TXT","name":"_acme-challenge.fqdn.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:51.209 +0000 UTC","modified":"2020-04-13 20:32:51.209 +0000 UTC"},{"id":"JB9a4EZrNKbRTLKKAmT6M4","type":"TXT","name":"_acme-challenge.full.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:59.487 +0000 UTC","modified":"2020-04-13 20:32:59.487 +0000 UTC"},{"id":"3KU7EYhoWvAzTENjVAsqwB","type":"TXT","name":"_acme-challenge.test.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:08.017 +0000 UTC","modified":"2020-04-13 20:33:08.017 +0000 UTC"},{"id":"JmFdAr7ZKkv3WFyxnEJL43","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:18.136 +0000 UTC","modified":"2020-04-13 20:33:18.136 +0000 UTC"},{"id":"XJBbqzDiukFE3f2YGcTokY","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:25.929 +0000 UTC","modified":"2020-04-13 20:33:25.929 +0000 UTC"},{"id":"fdSKTmeja8M8pc5vztxb64","type":"TXT","name":"_acme-challenge.noop.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:33.653 +0000 UTC","modified":"2020-04-13 20:33:33.653 +0000 UTC"},{"id":"uDPTMe8hikMxgVAGznkN5S","type":"TXT","name":"_acme-challenge.deleterecordinset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:34:55.913 +0000 UTC","modified":"2020-04-13 20:34:55.913 +0000 UTC"},{"id":"pwek8RBHdnTi2eS3NGEkCG","type":"TXT","name":"ttl.fqdn.softwarekollektiv.de.","value":"ttlshouldbe3600","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:35:33.676 +0000 UTC","modified":"2020-04-13 20:35:33.676 +0000 UTC"},{"id":"wei55NH2jLAWwwnmB6ZFjf","type":"TXT","name":"_acme-challenge.listrecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:35:43.97 +0000 UTC","modified":"2020-04-13 20:35:43.97 +0000 UTC"},{"id":"jGjWxzipctQH5C3oFV7NeJ","type":"TXT","name":"_acme-challenge.listrecordset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:35:51.62 +0000 UTC","modified":"2020-04-13 20:35:51.62 +0000 UTC"},{"id":"jRamHUs2Xyt4Gh3BP4UaCd","type":"TXT","name":"random.fqdntest.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:36:02.609 +0000 UTC","modified":"2020-04-13 20:36:02.609 +0000 UTC"},{"id":"SZspS6AU4CT7ux7M6LaDrG","type":"TXT","name":"random.fulltest.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:36:12.704 +0000 UTC","modified":"2020-04-13 20:36:12.704 +0000 UTC"},{"id":"drrxjb4ddap8EjFbQw9p8f","type":"TXT","name":"random.test.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:36:27.598 +0000 UTC","modified":"2020-04-13 20:36:27.598 +0000 UTC"},{"id":"XAZaCUS5e4bNjgcFWWCsB3","type":"TXT","name":"orig.test.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:36:43.156 +0000 UTC","modified":"2020-04-13 20:36:43.156 +0000 UTC"}]}
+      string: !!python/unicode '{"records":[{"id":"9720b5653ca6fd0517ec91a8c6104685","type":"SOA","name":"@","value":"ns1.first-ns.de.
+        dns.hetzner.com. 2020061230 14400 3600 1814400 3600","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:24:42 +0000 UTC","modified":"2020-06-12 08:21:15.288 +0000 UTC"},{"id":"5b378a7097bdb11e6cbb5f58db6bb101","type":"MX","name":"@","value":"10
+        mail.server-zugang.eu.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:12 +0000 UTC","modified":"2020-04-07 01:25:12 +0000 UTC"},{"id":"a26cfdd36217e559c14b305a558f2a3c","type":"AAAA","name":"@","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"7d6f741802597845b97713596e35eaa7","type":"AAAA","name":"*","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"993bafd3e3b110a6a3acde9fe874426a","type":"NS","name":"@","value":"ns1.first-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"cc3e8297060b7bd794fed5fdec3ed91b","type":"NS","name":"@","value":"robotns2.second-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"c4602b1239d9f0747016f551c52b5774","type":"NS","name":"@","value":"robotns3.second-ns.com.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"77ae87e42a04bace81119eb2280c8dca","type":"A","name":"@","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"faff62d59434c666bac4174a1d18a955","type":"A","name":"*","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"fe6ac2081c630974662caeaa8715d435","type":"A","name":"localhost","value":"127.0.0.1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:37.307 +0000 UTC","modified":"2020-06-12 08:20:37.307 +0000 UTC"},{"id":"8e6b81a856d20f0c1802703b56d1b53d","type":"CNAME","name":"docs","value":"docs.example.com","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:38.743 +0000 UTC","modified":"2020-06-12 08:20:38.743 +0000 UTC"},{"id":"a5fc9854314c160019d9bd0fcaaf2e2a","type":"TXT","name":"_acme-challenge.fqdn","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:40.141 +0000 UTC","modified":"2020-06-12 08:20:40.141 +0000 UTC"},{"id":"101296724cdf3710d18ea43a06b39e6c","type":"TXT","name":"_acme-challenge.full","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:41.421 +0000 UTC","modified":"2020-06-12 08:20:41.421 +0000 UTC"},{"id":"1c06fee6923324bc2727916d2157b3d8","type":"TXT","name":"_acme-challenge.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:43.363 +0000 UTC","modified":"2020-06-12 08:20:43.363 +0000 UTC"},{"id":"97dcfc7f529a65b944a11554e15dcdfb","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:44.557 +0000 UTC","modified":"2020-06-12 08:20:44.557 +0000 UTC"},{"id":"880d3713398b9301dda21a611cbd9ab0","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:45.499 +0000 UTC","modified":"2020-06-12 08:20:45.499 +0000 UTC"},{"id":"f794c3584778621edfa903a30a993f9b","type":"TXT","name":"_acme-challenge.noop","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:46.766 +0000 UTC","modified":"2020-06-12 08:20:46.766 +0000 UTC"},{"id":"fe7ddc85cc3c919385d8d2aabfa407eb","type":"TXT","name":"_acme-challenge.deleterecordinset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:58.928 +0000 UTC","modified":"2020-06-12 08:20:58.928 +0000 UTC"},{"id":"61efb963c73466f54f6bba592e9340d4","type":"TXT","name":"ttl.fqdn","value":"ttlshouldbe3600","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:05.618 +0000 UTC","modified":"2020-06-12 08:21:05.618 +0000 UTC"},{"id":"2d5abe2e3b1030903b6ededf674fb76a","type":"TXT","name":"_acme-challenge.listrecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:07.078 +0000 UTC","modified":"2020-06-12 08:21:07.078 +0000 UTC"},{"id":"50aaf8ab858357c3289d2a51d2ea04dc","type":"TXT","name":"_acme-challenge.listrecordset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:08.01 +0000 UTC","modified":"2020-06-12 08:21:08.01 +0000 UTC"},{"id":"b358c2b15c05b3315352ee2a149ce3bc","type":"TXT","name":"random.fqdntest","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:09.601 +0000 UTC","modified":"2020-06-12 08:21:09.601 +0000 UTC"},{"id":"9bf9fc6d8c2b7c277f2da14475d545b3","type":"TXT","name":"random.fulltest","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:11.083 +0000 UTC","modified":"2020-06-12 08:21:11.083 +0000 UTC"},{"id":"16667dd263f7667ae6d4deec7233b8b5","type":"TXT","name":"random.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:13.182 +0000 UTC","modified":"2020-06-12 08:21:13.182 +0000 UTC"},{"id":"8bb7c37e2c1dead95f002c91dc46246c","type":"TXT","name":"orig.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:15.177 +0000 UTC","modified":"2020-06-12 08:21:15.177 +0000 UTC"}]}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Type:
+      content-length:
+      - '5974'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:36:50 GMT
-      Transfer-Encoding:
+      date:
+      - Fri, 12 Jun 2020 08:21:15 GMT
+      transfer-encoding:
       - chunked
-      Vary:
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
+      x-kong-proxy-latency:
       - '2'
-      X-Kong-Upstream-Latency:
-      - '3490'
+      x-kong-upstream-latency:
+      - '75'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"type": "TXT", "name": "updated.test.softwarekollektiv.de", "value": "challengetoken",
-      "zone_id": "JkBqVJDW3PpqefBb274BCZ", "ttl": 3600}'
+    body: !!python/unicode '{"ttl": 3600, "type": "TXT", "name": "updated.test", "value":
+      "challengetoken", "zone_id": "hetznerapizoneid"}'
     headers:
       Accept:
       - '*/*'
@@ -227,38 +251,40 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '137'
+      - '116'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: PUT
-    uri: https://dns.hetzner.com/api/v1/records/XAZaCUS5e4bNjgcFWWCsB3
+    uri: https://dns.hetzner.com/api/v1/records/8bb7c37e2c1dead95f002c91dc46246c
   response:
     body:
-      string: '{"record":{"id":"XAZaCUS5e4bNjgcFWWCsB3","type":"TXT","name":"updated.test.softwarekollektiv.de","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:36:43.156 +0000 UTC","modified":"2020-04-13 20:36:50.487 +0000 UTC"}}
+      string: !!python/unicode '{"record":{"id":"8bb7c37e2c1dead95f002c91dc46246c","type":"TXT","name":"updated.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:15.177 +0000 UTC","modified":"2020-06-12 08:21:16.167 +0000 UTC"}}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '263'
-      Content-Type:
+      content-length:
+      - '252'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:36:53 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:21:16 GMT
+      transfer-encoding:
+      - chunked
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
-      - '1'
-      X-Kong-Upstream-Latency:
-      - '2897'
+      x-kong-proxy-latency:
+      - '2'
+      x-kong-upstream-latency:
+      - '772'
     status:
       code: 200
       message: OK

--- a/tests/fixtures/cassettes/hetzner/IntegrationTests/test_provider_when_calling_update_record_should_modify_record_name_specified.yaml
+++ b/tests/fixtures/cassettes/hetzner/IntegrationTests/test_provider_when_calling_update_record_should_modify_record_name_specified.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -11,44 +11,44 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
     uri: https://dns.hetzner.com/api/v1/zones
   response:
     body:
-      string: '{"zones":[{"id":"xyncsydKx5x44qDZQCzpNM","name":"alt.coop","ttl":300,"registrar":"","legacy_dns_host":"","legacy_ns":["oxygen.ns.hetzner.com.","hydrogen.ns.hetzner.com.","helium.ns.hetzner.com."],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-07
-        01:23:59 +0000 UTC","verified":"2020-04-07 01:53:05.934062806 +0000 UTC m=+578.060435172","modified":"2020-04-08
-        10:38:16.278 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":75},{"id":"JkBqVJDW3PpqefBb274BCZ","name":"softwarekollektiv.de","ttl":86400,"registrar":"","legacy_dns_host":"","legacy_ns":[],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-08
-        18:53:25.589 +0000 UTC","verified":"2020-04-08T18:53:27Z","modified":"2020-04-13
-        15:17:43.767 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":17}],"meta":{"pagination":{"page":1,"per_page":100,"previous_page":1,"next_page":1,"last_page":1,"total_entries":2}}}
+      string: !!python/unicode '{"zones":[{"id":"hetznerapizoneid","name":"hetzner-api-test.de","ttl":3600,"registrar":"","legacy_dns_host":"","legacy_ns":["ns1.first-ns.de.","robotns2.second-ns.de.","robotns3.second-ns.com."],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-07
+        01:24:00 +0000 UTC","verified":"2020-04-07 01:51:26.114056422 +0000 UTC m=+478.240428717","modified":"2020-06-11
+        07:02:20.999 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":9}],"meta":{"pagination":{"page":1,"per_page":100,"previous_page":1,"next_page":1,"last_page":1,"total_entries":12}}}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '1330'
-      Content-Type:
+      content-length:
+      - '7887'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:36:53 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:21:17 GMT
+      transfer-encoding:
+      - chunked
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
+      x-kong-proxy-latency:
       - '2'
-      X-Kong-Upstream-Latency:
-      - '216'
+      x-kong-upstream-latency:
+      - '255'
     status:
       code: 200
       message: OK
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -59,59 +59,70 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
-    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=JkBqVJDW3PpqefBb274BCZ
+    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=hetznerapizoneid
   response:
     body:
-      string: '{"records":[{"id":"8jEciPwo7wF2obPTuBe3Yg","type":"SOA","name":"@","value":"ns1.your-server.de.
-        dns.hetzner.com. 2020041594 86400 7200 3600000 3600","zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        15:17:43.061 +0000 UTC","modified":"2020-04-13 20:36:52.589 +0000 UTC"},{"id":"ccLnXePkikrTK7MjNY2fqb","type":"A","name":"localhost.softwarekollektiv.de.","value":"127.0.0.1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:37.644 +0000 UTC","modified":"2020-04-13 20:32:37.644 +0000 UTC"},{"id":"JQmTbgVAzdx4AADJeLMM3X","type":"CNAME","name":"docs.softwarekollektiv.de.","value":"docs.example.com","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:43.98 +0000 UTC","modified":"2020-04-13 20:32:43.98 +0000 UTC"},{"id":"PJpHrVw6wqik5CTzECpacD","type":"TXT","name":"_acme-challenge.fqdn.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:51.209 +0000 UTC","modified":"2020-04-13 20:32:51.209 +0000 UTC"},{"id":"JB9a4EZrNKbRTLKKAmT6M4","type":"TXT","name":"_acme-challenge.full.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:59.487 +0000 UTC","modified":"2020-04-13 20:32:59.487 +0000 UTC"},{"id":"3KU7EYhoWvAzTENjVAsqwB","type":"TXT","name":"_acme-challenge.test.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:08.017 +0000 UTC","modified":"2020-04-13 20:33:08.017 +0000 UTC"},{"id":"JmFdAr7ZKkv3WFyxnEJL43","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:18.136 +0000 UTC","modified":"2020-04-13 20:33:18.136 +0000 UTC"},{"id":"XJBbqzDiukFE3f2YGcTokY","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:25.929 +0000 UTC","modified":"2020-04-13 20:33:25.929 +0000 UTC"},{"id":"fdSKTmeja8M8pc5vztxb64","type":"TXT","name":"_acme-challenge.noop.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:33.653 +0000 UTC","modified":"2020-04-13 20:33:33.653 +0000 UTC"},{"id":"uDPTMe8hikMxgVAGznkN5S","type":"TXT","name":"_acme-challenge.deleterecordinset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:34:55.913 +0000 UTC","modified":"2020-04-13 20:34:55.913 +0000 UTC"},{"id":"pwek8RBHdnTi2eS3NGEkCG","type":"TXT","name":"ttl.fqdn.softwarekollektiv.de.","value":"ttlshouldbe3600","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:35:33.676 +0000 UTC","modified":"2020-04-13 20:35:33.676 +0000 UTC"},{"id":"wei55NH2jLAWwwnmB6ZFjf","type":"TXT","name":"_acme-challenge.listrecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:35:43.97 +0000 UTC","modified":"2020-04-13 20:35:43.97 +0000 UTC"},{"id":"jGjWxzipctQH5C3oFV7NeJ","type":"TXT","name":"_acme-challenge.listrecordset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:35:51.62 +0000 UTC","modified":"2020-04-13 20:35:51.62 +0000 UTC"},{"id":"jRamHUs2Xyt4Gh3BP4UaCd","type":"TXT","name":"random.fqdntest.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:36:02.609 +0000 UTC","modified":"2020-04-13 20:36:02.609 +0000 UTC"},{"id":"SZspS6AU4CT7ux7M6LaDrG","type":"TXT","name":"random.fulltest.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:36:12.704 +0000 UTC","modified":"2020-04-13 20:36:12.704 +0000 UTC"},{"id":"drrxjb4ddap8EjFbQw9p8f","type":"TXT","name":"random.test.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:36:27.598 +0000 UTC","modified":"2020-04-13 20:36:27.598 +0000 UTC"},{"id":"XAZaCUS5e4bNjgcFWWCsB3","type":"TXT","name":"updated.test.softwarekollektiv.de","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:36:43.156 +0000 UTC","modified":"2020-04-13 20:36:50.487 +0000 UTC"}]}
+      string: !!python/unicode '{"records":[{"id":"9720b5653ca6fd0517ec91a8c6104685","type":"SOA","name":"@","value":"ns1.first-ns.de.
+        dns.hetzner.com. 2020061231 14400 3600 1814400 3600","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:24:42 +0000 UTC","modified":"2020-06-12 08:21:16.281 +0000 UTC"},{"id":"5b378a7097bdb11e6cbb5f58db6bb101","type":"MX","name":"@","value":"10
+        mail.server-zugang.eu.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:12 +0000 UTC","modified":"2020-04-07 01:25:12 +0000 UTC"},{"id":"a26cfdd36217e559c14b305a558f2a3c","type":"AAAA","name":"@","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"7d6f741802597845b97713596e35eaa7","type":"AAAA","name":"*","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"993bafd3e3b110a6a3acde9fe874426a","type":"NS","name":"@","value":"ns1.first-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"cc3e8297060b7bd794fed5fdec3ed91b","type":"NS","name":"@","value":"robotns2.second-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"c4602b1239d9f0747016f551c52b5774","type":"NS","name":"@","value":"robotns3.second-ns.com.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"77ae87e42a04bace81119eb2280c8dca","type":"A","name":"@","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"faff62d59434c666bac4174a1d18a955","type":"A","name":"*","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"fe6ac2081c630974662caeaa8715d435","type":"A","name":"localhost","value":"127.0.0.1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:37.307 +0000 UTC","modified":"2020-06-12 08:20:37.307 +0000 UTC"},{"id":"8e6b81a856d20f0c1802703b56d1b53d","type":"CNAME","name":"docs","value":"docs.example.com","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:38.743 +0000 UTC","modified":"2020-06-12 08:20:38.743 +0000 UTC"},{"id":"a5fc9854314c160019d9bd0fcaaf2e2a","type":"TXT","name":"_acme-challenge.fqdn","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:40.141 +0000 UTC","modified":"2020-06-12 08:20:40.141 +0000 UTC"},{"id":"101296724cdf3710d18ea43a06b39e6c","type":"TXT","name":"_acme-challenge.full","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:41.421 +0000 UTC","modified":"2020-06-12 08:20:41.421 +0000 UTC"},{"id":"1c06fee6923324bc2727916d2157b3d8","type":"TXT","name":"_acme-challenge.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:43.363 +0000 UTC","modified":"2020-06-12 08:20:43.363 +0000 UTC"},{"id":"97dcfc7f529a65b944a11554e15dcdfb","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:44.557 +0000 UTC","modified":"2020-06-12 08:20:44.557 +0000 UTC"},{"id":"880d3713398b9301dda21a611cbd9ab0","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:45.499 +0000 UTC","modified":"2020-06-12 08:20:45.499 +0000 UTC"},{"id":"f794c3584778621edfa903a30a993f9b","type":"TXT","name":"_acme-challenge.noop","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:46.766 +0000 UTC","modified":"2020-06-12 08:20:46.766 +0000 UTC"},{"id":"fe7ddc85cc3c919385d8d2aabfa407eb","type":"TXT","name":"_acme-challenge.deleterecordinset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:58.928 +0000 UTC","modified":"2020-06-12 08:20:58.928 +0000 UTC"},{"id":"61efb963c73466f54f6bba592e9340d4","type":"TXT","name":"ttl.fqdn","value":"ttlshouldbe3600","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:05.618 +0000 UTC","modified":"2020-06-12 08:21:05.618 +0000 UTC"},{"id":"2d5abe2e3b1030903b6ededf674fb76a","type":"TXT","name":"_acme-challenge.listrecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:07.078 +0000 UTC","modified":"2020-06-12 08:21:07.078 +0000 UTC"},{"id":"50aaf8ab858357c3289d2a51d2ea04dc","type":"TXT","name":"_acme-challenge.listrecordset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:08.01 +0000 UTC","modified":"2020-06-12 08:21:08.01 +0000 UTC"},{"id":"b358c2b15c05b3315352ee2a149ce3bc","type":"TXT","name":"random.fqdntest","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:09.601 +0000 UTC","modified":"2020-06-12 08:21:09.601 +0000 UTC"},{"id":"9bf9fc6d8c2b7c277f2da14475d545b3","type":"TXT","name":"random.fulltest","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:11.083 +0000 UTC","modified":"2020-06-12 08:21:11.083 +0000 UTC"},{"id":"16667dd263f7667ae6d4deec7233b8b5","type":"TXT","name":"random.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:13.182 +0000 UTC","modified":"2020-06-12 08:21:13.182 +0000 UTC"},{"id":"8bb7c37e2c1dead95f002c91dc46246c","type":"TXT","name":"updated.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:15.177 +0000 UTC","modified":"2020-06-12 08:21:16.167 +0000 UTC"}]}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Type:
+      content-length:
+      - '5977'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:36:56 GMT
-      Transfer-Encoding:
+      date:
+      - Fri, 12 Jun 2020 08:21:17 GMT
+      transfer-encoding:
       - chunked
-      Vary:
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
+      x-kong-proxy-latency:
       - '1'
-      X-Kong-Upstream-Latency:
-      - '2598'
+      x-kong-upstream-latency:
+      - '80'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"name": "orig.nameonly.test.softwarekollektiv.de.", "type": "TXT", "value":
-      "challengetoken", "zone_id": "JkBqVJDW3PpqefBb274BCZ", "ttl": 3600}'
+    body: !!python/unicode '{"ttl": 3600, "type": "TXT", "name": "orig.nameonly.test",
+      "value": "challengetoken", "zone_id": "hetznerapizoneid"}'
     headers:
       Accept:
       - '*/*'
@@ -120,43 +131,45 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '144'
+      - '122'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: POST
     uri: https://dns.hetzner.com/api/v1/records
   response:
     body:
-      string: '{"record":{"id":"924FPSQ4VPhK99joGoXGqV","type":"TXT","name":"orig.nameonly.test.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:36:56.665 +0000 UTC","modified":"2020-04-13 20:36:56.665 +0000 UTC"}}
+      string: !!python/unicode '{"record":{"id":"9060cea8bf140aca542442191ef9b51c","type":"TXT","name":"orig.nameonly.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:17.525 +0000 UTC","modified":"2020-06-12 08:21:17.525 +0000 UTC"}}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '270'
-      Content-Type:
+      content-length:
+      - '258'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:36:59 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:21:18 GMT
+      transfer-encoding:
+      - chunked
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
-      - '1'
-      X-Kong-Upstream-Latency:
-      - '2754'
+      x-kong-proxy-latency:
+      - '2'
+      x-kong-upstream-latency:
+      - '590'
     status:
       code: 200
       message: OK
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -167,60 +180,71 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
-    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=JkBqVJDW3PpqefBb274BCZ
+    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=hetznerapizoneid
   response:
     body:
-      string: '{"records":[{"id":"8jEciPwo7wF2obPTuBe3Yg","type":"SOA","name":"@","value":"ns1.your-server.de.
-        dns.hetzner.com. 2020041595 86400 7200 3600000 3600","zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        15:17:43.061 +0000 UTC","modified":"2020-04-13 20:36:58.694 +0000 UTC"},{"id":"ccLnXePkikrTK7MjNY2fqb","type":"A","name":"localhost.softwarekollektiv.de.","value":"127.0.0.1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:37.644 +0000 UTC","modified":"2020-04-13 20:32:37.644 +0000 UTC"},{"id":"JQmTbgVAzdx4AADJeLMM3X","type":"CNAME","name":"docs.softwarekollektiv.de.","value":"docs.example.com","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:43.98 +0000 UTC","modified":"2020-04-13 20:32:43.98 +0000 UTC"},{"id":"PJpHrVw6wqik5CTzECpacD","type":"TXT","name":"_acme-challenge.fqdn.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:51.209 +0000 UTC","modified":"2020-04-13 20:32:51.209 +0000 UTC"},{"id":"JB9a4EZrNKbRTLKKAmT6M4","type":"TXT","name":"_acme-challenge.full.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:59.487 +0000 UTC","modified":"2020-04-13 20:32:59.487 +0000 UTC"},{"id":"3KU7EYhoWvAzTENjVAsqwB","type":"TXT","name":"_acme-challenge.test.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:08.017 +0000 UTC","modified":"2020-04-13 20:33:08.017 +0000 UTC"},{"id":"JmFdAr7ZKkv3WFyxnEJL43","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:18.136 +0000 UTC","modified":"2020-04-13 20:33:18.136 +0000 UTC"},{"id":"XJBbqzDiukFE3f2YGcTokY","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:25.929 +0000 UTC","modified":"2020-04-13 20:33:25.929 +0000 UTC"},{"id":"fdSKTmeja8M8pc5vztxb64","type":"TXT","name":"_acme-challenge.noop.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:33.653 +0000 UTC","modified":"2020-04-13 20:33:33.653 +0000 UTC"},{"id":"uDPTMe8hikMxgVAGznkN5S","type":"TXT","name":"_acme-challenge.deleterecordinset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:34:55.913 +0000 UTC","modified":"2020-04-13 20:34:55.913 +0000 UTC"},{"id":"pwek8RBHdnTi2eS3NGEkCG","type":"TXT","name":"ttl.fqdn.softwarekollektiv.de.","value":"ttlshouldbe3600","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:35:33.676 +0000 UTC","modified":"2020-04-13 20:35:33.676 +0000 UTC"},{"id":"wei55NH2jLAWwwnmB6ZFjf","type":"TXT","name":"_acme-challenge.listrecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:35:43.97 +0000 UTC","modified":"2020-04-13 20:35:43.97 +0000 UTC"},{"id":"jGjWxzipctQH5C3oFV7NeJ","type":"TXT","name":"_acme-challenge.listrecordset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:35:51.62 +0000 UTC","modified":"2020-04-13 20:35:51.62 +0000 UTC"},{"id":"jRamHUs2Xyt4Gh3BP4UaCd","type":"TXT","name":"random.fqdntest.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:36:02.609 +0000 UTC","modified":"2020-04-13 20:36:02.609 +0000 UTC"},{"id":"SZspS6AU4CT7ux7M6LaDrG","type":"TXT","name":"random.fulltest.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:36:12.704 +0000 UTC","modified":"2020-04-13 20:36:12.704 +0000 UTC"},{"id":"drrxjb4ddap8EjFbQw9p8f","type":"TXT","name":"random.test.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:36:27.598 +0000 UTC","modified":"2020-04-13 20:36:27.598 +0000 UTC"},{"id":"XAZaCUS5e4bNjgcFWWCsB3","type":"TXT","name":"updated.test.softwarekollektiv.de","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:36:43.156 +0000 UTC","modified":"2020-04-13 20:36:50.487 +0000 UTC"},{"id":"924FPSQ4VPhK99joGoXGqV","type":"TXT","name":"orig.nameonly.test.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:36:56.665 +0000 UTC","modified":"2020-04-13 20:36:56.665 +0000 UTC"}]}
+      string: !!python/unicode '{"records":[{"id":"9720b5653ca6fd0517ec91a8c6104685","type":"SOA","name":"@","value":"ns1.first-ns.de.
+        dns.hetzner.com. 2020061232 14400 3600 1814400 3600","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:24:42 +0000 UTC","modified":"2020-06-12 08:21:17.609 +0000 UTC"},{"id":"5b378a7097bdb11e6cbb5f58db6bb101","type":"MX","name":"@","value":"10
+        mail.server-zugang.eu.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:12 +0000 UTC","modified":"2020-04-07 01:25:12 +0000 UTC"},{"id":"a26cfdd36217e559c14b305a558f2a3c","type":"AAAA","name":"@","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"7d6f741802597845b97713596e35eaa7","type":"AAAA","name":"*","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"993bafd3e3b110a6a3acde9fe874426a","type":"NS","name":"@","value":"ns1.first-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"cc3e8297060b7bd794fed5fdec3ed91b","type":"NS","name":"@","value":"robotns2.second-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"c4602b1239d9f0747016f551c52b5774","type":"NS","name":"@","value":"robotns3.second-ns.com.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"77ae87e42a04bace81119eb2280c8dca","type":"A","name":"@","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"faff62d59434c666bac4174a1d18a955","type":"A","name":"*","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"fe6ac2081c630974662caeaa8715d435","type":"A","name":"localhost","value":"127.0.0.1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:37.307 +0000 UTC","modified":"2020-06-12 08:20:37.307 +0000 UTC"},{"id":"8e6b81a856d20f0c1802703b56d1b53d","type":"CNAME","name":"docs","value":"docs.example.com","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:38.743 +0000 UTC","modified":"2020-06-12 08:20:38.743 +0000 UTC"},{"id":"a5fc9854314c160019d9bd0fcaaf2e2a","type":"TXT","name":"_acme-challenge.fqdn","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:40.141 +0000 UTC","modified":"2020-06-12 08:20:40.141 +0000 UTC"},{"id":"101296724cdf3710d18ea43a06b39e6c","type":"TXT","name":"_acme-challenge.full","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:41.421 +0000 UTC","modified":"2020-06-12 08:20:41.421 +0000 UTC"},{"id":"1c06fee6923324bc2727916d2157b3d8","type":"TXT","name":"_acme-challenge.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:43.363 +0000 UTC","modified":"2020-06-12 08:20:43.363 +0000 UTC"},{"id":"97dcfc7f529a65b944a11554e15dcdfb","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:44.557 +0000 UTC","modified":"2020-06-12 08:20:44.557 +0000 UTC"},{"id":"880d3713398b9301dda21a611cbd9ab0","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:45.499 +0000 UTC","modified":"2020-06-12 08:20:45.499 +0000 UTC"},{"id":"f794c3584778621edfa903a30a993f9b","type":"TXT","name":"_acme-challenge.noop","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:46.766 +0000 UTC","modified":"2020-06-12 08:20:46.766 +0000 UTC"},{"id":"fe7ddc85cc3c919385d8d2aabfa407eb","type":"TXT","name":"_acme-challenge.deleterecordinset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:58.928 +0000 UTC","modified":"2020-06-12 08:20:58.928 +0000 UTC"},{"id":"61efb963c73466f54f6bba592e9340d4","type":"TXT","name":"ttl.fqdn","value":"ttlshouldbe3600","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:05.618 +0000 UTC","modified":"2020-06-12 08:21:05.618 +0000 UTC"},{"id":"2d5abe2e3b1030903b6ededf674fb76a","type":"TXT","name":"_acme-challenge.listrecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:07.078 +0000 UTC","modified":"2020-06-12 08:21:07.078 +0000 UTC"},{"id":"50aaf8ab858357c3289d2a51d2ea04dc","type":"TXT","name":"_acme-challenge.listrecordset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:08.01 +0000 UTC","modified":"2020-06-12 08:21:08.01 +0000 UTC"},{"id":"b358c2b15c05b3315352ee2a149ce3bc","type":"TXT","name":"random.fqdntest","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:09.601 +0000 UTC","modified":"2020-06-12 08:21:09.601 +0000 UTC"},{"id":"9bf9fc6d8c2b7c277f2da14475d545b3","type":"TXT","name":"random.fulltest","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:11.083 +0000 UTC","modified":"2020-06-12 08:21:11.083 +0000 UTC"},{"id":"16667dd263f7667ae6d4deec7233b8b5","type":"TXT","name":"random.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:13.182 +0000 UTC","modified":"2020-06-12 08:21:13.182 +0000 UTC"},{"id":"8bb7c37e2c1dead95f002c91dc46246c","type":"TXT","name":"updated.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:15.177 +0000 UTC","modified":"2020-06-12 08:21:16.167 +0000 UTC"},{"id":"9060cea8bf140aca542442191ef9b51c","type":"TXT","name":"orig.nameonly.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:17.525 +0000 UTC","modified":"2020-06-12 08:21:17.525 +0000 UTC"}]}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Type:
+      content-length:
+      - '6224'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:37:02 GMT
-      Transfer-Encoding:
+      date:
+      - Fri, 12 Jun 2020 08:21:18 GMT
+      transfer-encoding:
       - chunked
-      Vary:
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
-      - '2'
-      X-Kong-Upstream-Latency:
-      - '2584'
+      x-kong-proxy-latency:
+      - '1'
+      x-kong-upstream-latency:
+      - '155'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"type": "TXT", "name": "orig.nameonly.test.softwarekollektiv.de", "value":
-      "updated", "zone_id": "JkBqVJDW3PpqefBb274BCZ", "ttl": 3600}'
+    body: !!python/unicode '{"ttl": 3600, "type": "TXT", "name": "orig.nameonly.test",
+      "value": "updated", "zone_id": "hetznerapizoneid"}'
     headers:
       Accept:
       - '*/*'
@@ -229,38 +253,40 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '136'
+      - '115'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: PUT
-    uri: https://dns.hetzner.com/api/v1/records/924FPSQ4VPhK99joGoXGqV
+    uri: https://dns.hetzner.com/api/v1/records/9060cea8bf140aca542442191ef9b51c
   response:
     body:
-      string: '{"record":{"id":"924FPSQ4VPhK99joGoXGqV","type":"TXT","name":"orig.nameonly.test.softwarekollektiv.de","value":"updated","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:36:56.665 +0000 UTC","modified":"2020-04-13 20:37:02.386 +0000 UTC"}}
+      string: !!python/unicode '{"record":{"id":"9060cea8bf140aca542442191ef9b51c","type":"TXT","name":"orig.nameonly.test","value":"updated","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:17.525 +0000 UTC","modified":"2020-06-12 08:21:18.52 +0000 UTC"}}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '262'
-      Content-Type:
+      content-length:
+      - '250'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:37:05 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:21:19 GMT
+      transfer-encoding:
+      - chunked
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
-      - '1'
-      X-Kong-Upstream-Latency:
-      - '3538'
+      x-kong-proxy-latency:
+      - '2'
+      x-kong-upstream-latency:
+      - '682'
     status:
       code: 200
       message: OK

--- a/tests/fixtures/cassettes/hetzner/IntegrationTests/test_provider_when_calling_update_record_with_fqdn_name_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/hetzner/IntegrationTests/test_provider_when_calling_update_record_with_fqdn_name_should_modify_record.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -11,44 +11,44 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
     uri: https://dns.hetzner.com/api/v1/zones
   response:
     body:
-      string: '{"zones":[{"id":"xyncsydKx5x44qDZQCzpNM","name":"alt.coop","ttl":300,"registrar":"","legacy_dns_host":"","legacy_ns":["helium.ns.hetzner.com.","oxygen.ns.hetzner.com.","hydrogen.ns.hetzner.com."],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-07
-        01:23:59 +0000 UTC","verified":"2020-04-07 01:53:05.934062806 +0000 UTC m=+578.060435172","modified":"2020-04-08
-        10:38:16.278 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":75},{"id":"JkBqVJDW3PpqefBb274BCZ","name":"softwarekollektiv.de","ttl":86400,"registrar":"","legacy_dns_host":"","legacy_ns":[],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-08
-        18:53:25.589 +0000 UTC","verified":"2020-04-08T18:53:27Z","modified":"2020-04-13
-        15:17:43.767 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":18}],"meta":{"pagination":{"page":1,"per_page":100,"previous_page":1,"next_page":1,"last_page":1,"total_entries":2}}}
+      string: !!python/unicode '{"zones":[{"id":"hetznerapizoneid","name":"hetzner-api-test.de","ttl":3600,"registrar":"","legacy_dns_host":"","legacy_ns":["ns1.first-ns.de.","robotns2.second-ns.de.","robotns3.second-ns.com."],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-07
+        01:24:00 +0000 UTC","verified":"2020-04-07 01:51:26.114056422 +0000 UTC m=+478.240428717","modified":"2020-06-11
+        07:02:20.999 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":9}],"meta":{"pagination":{"page":1,"per_page":100,"previous_page":1,"next_page":1,"last_page":1,"total_entries":12}}}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '1330'
-      Content-Type:
+      content-length:
+      - '7887'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:37:06 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:21:19 GMT
+      transfer-encoding:
+      - chunked
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
-      - '1'
-      X-Kong-Upstream-Latency:
-      - '199'
+      x-kong-proxy-latency:
+      - '2'
+      x-kong-upstream-latency:
+      - '249'
     status:
       code: 200
       message: OK
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -59,60 +59,71 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
-    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=JkBqVJDW3PpqefBb274BCZ
+    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=hetznerapizoneid
   response:
     body:
-      string: '{"records":[{"id":"8jEciPwo7wF2obPTuBe3Yg","type":"SOA","name":"@","value":"ns1.your-server.de.
-        dns.hetzner.com. 2020041596 86400 7200 3600000 3600","zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        15:17:43.061 +0000 UTC","modified":"2020-04-13 20:37:05.119 +0000 UTC"},{"id":"ccLnXePkikrTK7MjNY2fqb","type":"A","name":"localhost.softwarekollektiv.de.","value":"127.0.0.1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:37.644 +0000 UTC","modified":"2020-04-13 20:32:37.644 +0000 UTC"},{"id":"JQmTbgVAzdx4AADJeLMM3X","type":"CNAME","name":"docs.softwarekollektiv.de.","value":"docs.example.com","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:43.98 +0000 UTC","modified":"2020-04-13 20:32:43.98 +0000 UTC"},{"id":"PJpHrVw6wqik5CTzECpacD","type":"TXT","name":"_acme-challenge.fqdn.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:51.209 +0000 UTC","modified":"2020-04-13 20:32:51.209 +0000 UTC"},{"id":"JB9a4EZrNKbRTLKKAmT6M4","type":"TXT","name":"_acme-challenge.full.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:59.487 +0000 UTC","modified":"2020-04-13 20:32:59.487 +0000 UTC"},{"id":"3KU7EYhoWvAzTENjVAsqwB","type":"TXT","name":"_acme-challenge.test.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:08.017 +0000 UTC","modified":"2020-04-13 20:33:08.017 +0000 UTC"},{"id":"JmFdAr7ZKkv3WFyxnEJL43","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:18.136 +0000 UTC","modified":"2020-04-13 20:33:18.136 +0000 UTC"},{"id":"XJBbqzDiukFE3f2YGcTokY","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:25.929 +0000 UTC","modified":"2020-04-13 20:33:25.929 +0000 UTC"},{"id":"fdSKTmeja8M8pc5vztxb64","type":"TXT","name":"_acme-challenge.noop.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:33.653 +0000 UTC","modified":"2020-04-13 20:33:33.653 +0000 UTC"},{"id":"uDPTMe8hikMxgVAGznkN5S","type":"TXT","name":"_acme-challenge.deleterecordinset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:34:55.913 +0000 UTC","modified":"2020-04-13 20:34:55.913 +0000 UTC"},{"id":"pwek8RBHdnTi2eS3NGEkCG","type":"TXT","name":"ttl.fqdn.softwarekollektiv.de.","value":"ttlshouldbe3600","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:35:33.676 +0000 UTC","modified":"2020-04-13 20:35:33.676 +0000 UTC"},{"id":"wei55NH2jLAWwwnmB6ZFjf","type":"TXT","name":"_acme-challenge.listrecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:35:43.97 +0000 UTC","modified":"2020-04-13 20:35:43.97 +0000 UTC"},{"id":"jGjWxzipctQH5C3oFV7NeJ","type":"TXT","name":"_acme-challenge.listrecordset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:35:51.62 +0000 UTC","modified":"2020-04-13 20:35:51.62 +0000 UTC"},{"id":"jRamHUs2Xyt4Gh3BP4UaCd","type":"TXT","name":"random.fqdntest.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:36:02.609 +0000 UTC","modified":"2020-04-13 20:36:02.609 +0000 UTC"},{"id":"SZspS6AU4CT7ux7M6LaDrG","type":"TXT","name":"random.fulltest.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:36:12.704 +0000 UTC","modified":"2020-04-13 20:36:12.704 +0000 UTC"},{"id":"drrxjb4ddap8EjFbQw9p8f","type":"TXT","name":"random.test.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:36:27.598 +0000 UTC","modified":"2020-04-13 20:36:27.598 +0000 UTC"},{"id":"XAZaCUS5e4bNjgcFWWCsB3","type":"TXT","name":"updated.test.softwarekollektiv.de","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:36:43.156 +0000 UTC","modified":"2020-04-13 20:36:50.487 +0000 UTC"},{"id":"924FPSQ4VPhK99joGoXGqV","type":"TXT","name":"orig.nameonly.test.softwarekollektiv.de","value":"updated","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:36:56.665 +0000 UTC","modified":"2020-04-13 20:37:02.386 +0000 UTC"}]}
+      string: !!python/unicode '{"records":[{"id":"9720b5653ca6fd0517ec91a8c6104685","type":"SOA","name":"@","value":"ns1.first-ns.de.
+        dns.hetzner.com. 2020061233 14400 3600 1814400 3600","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:24:42 +0000 UTC","modified":"2020-06-12 08:21:18.623 +0000 UTC"},{"id":"5b378a7097bdb11e6cbb5f58db6bb101","type":"MX","name":"@","value":"10
+        mail.server-zugang.eu.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:12 +0000 UTC","modified":"2020-04-07 01:25:12 +0000 UTC"},{"id":"a26cfdd36217e559c14b305a558f2a3c","type":"AAAA","name":"@","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"7d6f741802597845b97713596e35eaa7","type":"AAAA","name":"*","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"993bafd3e3b110a6a3acde9fe874426a","type":"NS","name":"@","value":"ns1.first-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"cc3e8297060b7bd794fed5fdec3ed91b","type":"NS","name":"@","value":"robotns2.second-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"c4602b1239d9f0747016f551c52b5774","type":"NS","name":"@","value":"robotns3.second-ns.com.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"77ae87e42a04bace81119eb2280c8dca","type":"A","name":"@","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"faff62d59434c666bac4174a1d18a955","type":"A","name":"*","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"fe6ac2081c630974662caeaa8715d435","type":"A","name":"localhost","value":"127.0.0.1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:37.307 +0000 UTC","modified":"2020-06-12 08:20:37.307 +0000 UTC"},{"id":"8e6b81a856d20f0c1802703b56d1b53d","type":"CNAME","name":"docs","value":"docs.example.com","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:38.743 +0000 UTC","modified":"2020-06-12 08:20:38.743 +0000 UTC"},{"id":"a5fc9854314c160019d9bd0fcaaf2e2a","type":"TXT","name":"_acme-challenge.fqdn","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:40.141 +0000 UTC","modified":"2020-06-12 08:20:40.141 +0000 UTC"},{"id":"101296724cdf3710d18ea43a06b39e6c","type":"TXT","name":"_acme-challenge.full","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:41.421 +0000 UTC","modified":"2020-06-12 08:20:41.421 +0000 UTC"},{"id":"1c06fee6923324bc2727916d2157b3d8","type":"TXT","name":"_acme-challenge.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:43.363 +0000 UTC","modified":"2020-06-12 08:20:43.363 +0000 UTC"},{"id":"97dcfc7f529a65b944a11554e15dcdfb","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:44.557 +0000 UTC","modified":"2020-06-12 08:20:44.557 +0000 UTC"},{"id":"880d3713398b9301dda21a611cbd9ab0","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:45.499 +0000 UTC","modified":"2020-06-12 08:20:45.499 +0000 UTC"},{"id":"f794c3584778621edfa903a30a993f9b","type":"TXT","name":"_acme-challenge.noop","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:46.766 +0000 UTC","modified":"2020-06-12 08:20:46.766 +0000 UTC"},{"id":"fe7ddc85cc3c919385d8d2aabfa407eb","type":"TXT","name":"_acme-challenge.deleterecordinset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:58.928 +0000 UTC","modified":"2020-06-12 08:20:58.928 +0000 UTC"},{"id":"61efb963c73466f54f6bba592e9340d4","type":"TXT","name":"ttl.fqdn","value":"ttlshouldbe3600","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:05.618 +0000 UTC","modified":"2020-06-12 08:21:05.618 +0000 UTC"},{"id":"2d5abe2e3b1030903b6ededf674fb76a","type":"TXT","name":"_acme-challenge.listrecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:07.078 +0000 UTC","modified":"2020-06-12 08:21:07.078 +0000 UTC"},{"id":"50aaf8ab858357c3289d2a51d2ea04dc","type":"TXT","name":"_acme-challenge.listrecordset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:08.01 +0000 UTC","modified":"2020-06-12 08:21:08.01 +0000 UTC"},{"id":"b358c2b15c05b3315352ee2a149ce3bc","type":"TXT","name":"random.fqdntest","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:09.601 +0000 UTC","modified":"2020-06-12 08:21:09.601 +0000 UTC"},{"id":"9bf9fc6d8c2b7c277f2da14475d545b3","type":"TXT","name":"random.fulltest","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:11.083 +0000 UTC","modified":"2020-06-12 08:21:11.083 +0000 UTC"},{"id":"16667dd263f7667ae6d4deec7233b8b5","type":"TXT","name":"random.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:13.182 +0000 UTC","modified":"2020-06-12 08:21:13.182 +0000 UTC"},{"id":"8bb7c37e2c1dead95f002c91dc46246c","type":"TXT","name":"updated.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:15.177 +0000 UTC","modified":"2020-06-12 08:21:16.167 +0000 UTC"},{"id":"9060cea8bf140aca542442191ef9b51c","type":"TXT","name":"orig.nameonly.test","value":"updated","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:17.525 +0000 UTC","modified":"2020-06-12 08:21:18.52 +0000 UTC"}]}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Type:
+      content-length:
+      - '6216'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:37:09 GMT
-      Transfer-Encoding:
+      date:
+      - Fri, 12 Jun 2020 08:21:19 GMT
+      transfer-encoding:
       - chunked
-      Vary:
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
-      - '0'
-      X-Kong-Upstream-Latency:
-      - '2851'
+      x-kong-proxy-latency:
+      - '2'
+      x-kong-upstream-latency:
+      - '77'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"name": "orig.testfqdn.softwarekollektiv.de.", "type": "TXT", "value":
-      "challengetoken", "zone_id": "JkBqVJDW3PpqefBb274BCZ", "ttl": 3600}'
+    body: !!python/unicode '{"ttl": 3600, "type": "TXT", "name": "orig.testfqdn",
+      "value": "challengetoken", "zone_id": "hetznerapizoneid"}'
     headers:
       Accept:
       - '*/*'
@@ -121,43 +132,45 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '139'
+      - '117'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: POST
     uri: https://dns.hetzner.com/api/v1/records
   response:
     body:
-      string: '{"record":{"id":"mQChejFbPusauaoMKgHYkf","type":"TXT","name":"orig.testfqdn.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:37:09.374 +0000 UTC","modified":"2020-04-13 20:37:09.374 +0000 UTC"}}
+      string: !!python/unicode '{"record":{"id":"0e0ee3c283da73027bb5181c96fd1e77","type":"TXT","name":"orig.testfqdn","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:19.844 +0000 UTC","modified":"2020-06-12 08:21:19.844 +0000 UTC"}}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '265'
-      Content-Type:
+      content-length:
+      - '253'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:37:13 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:21:20 GMT
+      transfer-encoding:
+      - chunked
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
+      x-kong-proxy-latency:
       - '1'
-      X-Kong-Upstream-Latency:
-      - '3725'
+      x-kong-upstream-latency:
+      - '616'
     status:
       code: 200
       message: OK
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -168,61 +181,72 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
-    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=JkBqVJDW3PpqefBb274BCZ
+    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=hetznerapizoneid
   response:
     body:
-      string: '{"records":[{"id":"8jEciPwo7wF2obPTuBe3Yg","type":"SOA","name":"@","value":"ns1.your-server.de.
-        dns.hetzner.com. 2020041597 86400 7200 3600000 3600","zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        15:17:43.061 +0000 UTC","modified":"2020-04-13 20:37:12.383 +0000 UTC"},{"id":"ccLnXePkikrTK7MjNY2fqb","type":"A","name":"localhost.softwarekollektiv.de.","value":"127.0.0.1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:37.644 +0000 UTC","modified":"2020-04-13 20:32:37.644 +0000 UTC"},{"id":"JQmTbgVAzdx4AADJeLMM3X","type":"CNAME","name":"docs.softwarekollektiv.de.","value":"docs.example.com","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:43.98 +0000 UTC","modified":"2020-04-13 20:32:43.98 +0000 UTC"},{"id":"PJpHrVw6wqik5CTzECpacD","type":"TXT","name":"_acme-challenge.fqdn.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:51.209 +0000 UTC","modified":"2020-04-13 20:32:51.209 +0000 UTC"},{"id":"JB9a4EZrNKbRTLKKAmT6M4","type":"TXT","name":"_acme-challenge.full.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:59.487 +0000 UTC","modified":"2020-04-13 20:32:59.487 +0000 UTC"},{"id":"3KU7EYhoWvAzTENjVAsqwB","type":"TXT","name":"_acme-challenge.test.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:08.017 +0000 UTC","modified":"2020-04-13 20:33:08.017 +0000 UTC"},{"id":"JmFdAr7ZKkv3WFyxnEJL43","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:18.136 +0000 UTC","modified":"2020-04-13 20:33:18.136 +0000 UTC"},{"id":"XJBbqzDiukFE3f2YGcTokY","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:25.929 +0000 UTC","modified":"2020-04-13 20:33:25.929 +0000 UTC"},{"id":"fdSKTmeja8M8pc5vztxb64","type":"TXT","name":"_acme-challenge.noop.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:33.653 +0000 UTC","modified":"2020-04-13 20:33:33.653 +0000 UTC"},{"id":"uDPTMe8hikMxgVAGznkN5S","type":"TXT","name":"_acme-challenge.deleterecordinset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:34:55.913 +0000 UTC","modified":"2020-04-13 20:34:55.913 +0000 UTC"},{"id":"pwek8RBHdnTi2eS3NGEkCG","type":"TXT","name":"ttl.fqdn.softwarekollektiv.de.","value":"ttlshouldbe3600","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:35:33.676 +0000 UTC","modified":"2020-04-13 20:35:33.676 +0000 UTC"},{"id":"wei55NH2jLAWwwnmB6ZFjf","type":"TXT","name":"_acme-challenge.listrecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:35:43.97 +0000 UTC","modified":"2020-04-13 20:35:43.97 +0000 UTC"},{"id":"jGjWxzipctQH5C3oFV7NeJ","type":"TXT","name":"_acme-challenge.listrecordset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:35:51.62 +0000 UTC","modified":"2020-04-13 20:35:51.62 +0000 UTC"},{"id":"jRamHUs2Xyt4Gh3BP4UaCd","type":"TXT","name":"random.fqdntest.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:36:02.609 +0000 UTC","modified":"2020-04-13 20:36:02.609 +0000 UTC"},{"id":"SZspS6AU4CT7ux7M6LaDrG","type":"TXT","name":"random.fulltest.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:36:12.704 +0000 UTC","modified":"2020-04-13 20:36:12.704 +0000 UTC"},{"id":"drrxjb4ddap8EjFbQw9p8f","type":"TXT","name":"random.test.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:36:27.598 +0000 UTC","modified":"2020-04-13 20:36:27.598 +0000 UTC"},{"id":"XAZaCUS5e4bNjgcFWWCsB3","type":"TXT","name":"updated.test.softwarekollektiv.de","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:36:43.156 +0000 UTC","modified":"2020-04-13 20:36:50.487 +0000 UTC"},{"id":"924FPSQ4VPhK99joGoXGqV","type":"TXT","name":"orig.nameonly.test.softwarekollektiv.de","value":"updated","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:36:56.665 +0000 UTC","modified":"2020-04-13 20:37:02.386 +0000 UTC"},{"id":"mQChejFbPusauaoMKgHYkf","type":"TXT","name":"orig.testfqdn.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:37:09.374 +0000 UTC","modified":"2020-04-13 20:37:09.374 +0000 UTC"}]}
+      string: !!python/unicode '{"records":[{"id":"9720b5653ca6fd0517ec91a8c6104685","type":"SOA","name":"@","value":"ns1.first-ns.de.
+        dns.hetzner.com. 2020061234 14400 3600 1814400 3600","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:24:42 +0000 UTC","modified":"2020-06-12 08:21:19.949 +0000 UTC"},{"id":"5b378a7097bdb11e6cbb5f58db6bb101","type":"MX","name":"@","value":"10
+        mail.server-zugang.eu.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:12 +0000 UTC","modified":"2020-04-07 01:25:12 +0000 UTC"},{"id":"a26cfdd36217e559c14b305a558f2a3c","type":"AAAA","name":"@","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"7d6f741802597845b97713596e35eaa7","type":"AAAA","name":"*","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"993bafd3e3b110a6a3acde9fe874426a","type":"NS","name":"@","value":"ns1.first-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"cc3e8297060b7bd794fed5fdec3ed91b","type":"NS","name":"@","value":"robotns2.second-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"c4602b1239d9f0747016f551c52b5774","type":"NS","name":"@","value":"robotns3.second-ns.com.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"77ae87e42a04bace81119eb2280c8dca","type":"A","name":"@","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"faff62d59434c666bac4174a1d18a955","type":"A","name":"*","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"fe6ac2081c630974662caeaa8715d435","type":"A","name":"localhost","value":"127.0.0.1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:37.307 +0000 UTC","modified":"2020-06-12 08:20:37.307 +0000 UTC"},{"id":"8e6b81a856d20f0c1802703b56d1b53d","type":"CNAME","name":"docs","value":"docs.example.com","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:38.743 +0000 UTC","modified":"2020-06-12 08:20:38.743 +0000 UTC"},{"id":"a5fc9854314c160019d9bd0fcaaf2e2a","type":"TXT","name":"_acme-challenge.fqdn","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:40.141 +0000 UTC","modified":"2020-06-12 08:20:40.141 +0000 UTC"},{"id":"101296724cdf3710d18ea43a06b39e6c","type":"TXT","name":"_acme-challenge.full","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:41.421 +0000 UTC","modified":"2020-06-12 08:20:41.421 +0000 UTC"},{"id":"1c06fee6923324bc2727916d2157b3d8","type":"TXT","name":"_acme-challenge.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:43.363 +0000 UTC","modified":"2020-06-12 08:20:43.363 +0000 UTC"},{"id":"97dcfc7f529a65b944a11554e15dcdfb","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:44.557 +0000 UTC","modified":"2020-06-12 08:20:44.557 +0000 UTC"},{"id":"880d3713398b9301dda21a611cbd9ab0","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:45.499 +0000 UTC","modified":"2020-06-12 08:20:45.499 +0000 UTC"},{"id":"f794c3584778621edfa903a30a993f9b","type":"TXT","name":"_acme-challenge.noop","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:46.766 +0000 UTC","modified":"2020-06-12 08:20:46.766 +0000 UTC"},{"id":"fe7ddc85cc3c919385d8d2aabfa407eb","type":"TXT","name":"_acme-challenge.deleterecordinset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:58.928 +0000 UTC","modified":"2020-06-12 08:20:58.928 +0000 UTC"},{"id":"61efb963c73466f54f6bba592e9340d4","type":"TXT","name":"ttl.fqdn","value":"ttlshouldbe3600","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:05.618 +0000 UTC","modified":"2020-06-12 08:21:05.618 +0000 UTC"},{"id":"2d5abe2e3b1030903b6ededf674fb76a","type":"TXT","name":"_acme-challenge.listrecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:07.078 +0000 UTC","modified":"2020-06-12 08:21:07.078 +0000 UTC"},{"id":"50aaf8ab858357c3289d2a51d2ea04dc","type":"TXT","name":"_acme-challenge.listrecordset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:08.01 +0000 UTC","modified":"2020-06-12 08:21:08.01 +0000 UTC"},{"id":"b358c2b15c05b3315352ee2a149ce3bc","type":"TXT","name":"random.fqdntest","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:09.601 +0000 UTC","modified":"2020-06-12 08:21:09.601 +0000 UTC"},{"id":"9bf9fc6d8c2b7c277f2da14475d545b3","type":"TXT","name":"random.fulltest","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:11.083 +0000 UTC","modified":"2020-06-12 08:21:11.083 +0000 UTC"},{"id":"16667dd263f7667ae6d4deec7233b8b5","type":"TXT","name":"random.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:13.182 +0000 UTC","modified":"2020-06-12 08:21:13.182 +0000 UTC"},{"id":"8bb7c37e2c1dead95f002c91dc46246c","type":"TXT","name":"updated.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:15.177 +0000 UTC","modified":"2020-06-12 08:21:16.167 +0000 UTC"},{"id":"9060cea8bf140aca542442191ef9b51c","type":"TXT","name":"orig.nameonly.test","value":"updated","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:17.525 +0000 UTC","modified":"2020-06-12 08:21:18.52 +0000 UTC"},{"id":"0e0ee3c283da73027bb5181c96fd1e77","type":"TXT","name":"orig.testfqdn","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:19.844 +0000 UTC","modified":"2020-06-12 08:21:19.844 +0000 UTC"}]}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Type:
+      content-length:
+      - '6458'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:37:16 GMT
-      Transfer-Encoding:
+      date:
+      - Fri, 12 Jun 2020 08:21:20 GMT
+      transfer-encoding:
       - chunked
-      Vary:
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
-      - '1'
-      X-Kong-Upstream-Latency:
-      - '3589'
+      x-kong-proxy-latency:
+      - '2'
+      x-kong-upstream-latency:
+      - '152'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"type": "TXT", "name": "updated.testfqdn.softwarekollektiv.de", "value":
-      "challengetoken", "zone_id": "JkBqVJDW3PpqefBb274BCZ", "ttl": 3600}'
+    body: !!python/unicode '{"ttl": 3600, "type": "TXT", "name": "updated.testfqdn",
+      "value": "challengetoken", "zone_id": "hetznerapizoneid"}'
     headers:
       Accept:
       - '*/*'
@@ -231,38 +255,40 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '141'
+      - '120'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: PUT
-    uri: https://dns.hetzner.com/api/v1/records/mQChejFbPusauaoMKgHYkf
+    uri: https://dns.hetzner.com/api/v1/records/0e0ee3c283da73027bb5181c96fd1e77
   response:
     body:
-      string: '{"record":{"id":"mQChejFbPusauaoMKgHYkf","type":"TXT","name":"updated.testfqdn.softwarekollektiv.de","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:37:09.374 +0000 UTC","modified":"2020-04-13 20:37:17.026 +0000 UTC"}}
+      string: !!python/unicode '{"record":{"id":"0e0ee3c283da73027bb5181c96fd1e77","type":"TXT","name":"updated.testfqdn","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:19.844 +0000 UTC","modified":"2020-06-12 08:21:20.85 +0000 UTC"}}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '267'
-      Content-Type:
+      content-length:
+      - '255'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:37:20 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:21:21 GMT
+      transfer-encoding:
+      - chunked
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
-      - '1'
-      X-Kong-Upstream-Latency:
-      - '3633'
+      x-kong-proxy-latency:
+      - '2'
+      x-kong-upstream-latency:
+      - '566'
     status:
       code: 200
       message: OK

--- a/tests/fixtures/cassettes/hetzner/IntegrationTests/test_provider_when_calling_update_record_with_full_name_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/hetzner/IntegrationTests/test_provider_when_calling_update_record_with_full_name_should_modify_record.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -11,44 +11,44 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
     uri: https://dns.hetzner.com/api/v1/zones
   response:
     body:
-      string: '{"zones":[{"id":"xyncsydKx5x44qDZQCzpNM","name":"alt.coop","ttl":300,"registrar":"","legacy_dns_host":"","legacy_ns":["hydrogen.ns.hetzner.com.","helium.ns.hetzner.com.","oxygen.ns.hetzner.com."],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-07
-        01:23:59 +0000 UTC","verified":"2020-04-07 01:53:05.934062806 +0000 UTC m=+578.060435172","modified":"2020-04-08
-        10:38:16.278 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":75},{"id":"JkBqVJDW3PpqefBb274BCZ","name":"softwarekollektiv.de","ttl":86400,"registrar":"","legacy_dns_host":"","legacy_ns":[],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-08
-        18:53:25.589 +0000 UTC","verified":"2020-04-08T18:53:27Z","modified":"2020-04-13
-        15:17:43.767 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":19}],"meta":{"pagination":{"page":1,"per_page":100,"previous_page":1,"next_page":1,"last_page":1,"total_entries":2}}}
+      string: !!python/unicode '{"zones":[{"id":"hetznerapizoneid","name":"hetzner-api-test.de","ttl":3600,"registrar":"","legacy_dns_host":"","legacy_ns":["ns1.first-ns.de.","robotns2.second-ns.de.","robotns3.second-ns.com."],"ns":["hydrogen.ns.hetzner.com","oxygen.ns.hetzner.com","helium.ns.hetzner.de"],"created":"2020-04-07
+        01:24:00 +0000 UTC","verified":"2020-04-07 01:51:26.114056422 +0000 UTC m=+478.240428717","modified":"2020-06-11
+        07:02:20.999 +0000 UTC","project":"","owner":"","permission":"","zone_type":{"id":"","name":"","description":"","prices":null},"status":"verified","paused":false,"is_secondary_dns":false,"txt_verification":{"name":"","token":""},"records_count":9}],"meta":{"pagination":{"page":1,"per_page":100,"previous_page":1,"next_page":1,"last_page":1,"total_entries":12}}}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '1330'
-      Content-Type:
+      content-length:
+      - '7887'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:37:20 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:21:21 GMT
+      transfer-encoding:
+      - chunked
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
+      x-kong-proxy-latency:
       - '1'
-      X-Kong-Upstream-Latency:
-      - '186'
+      x-kong-upstream-latency:
+      - '227'
     status:
       code: 200
       message: OK
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -59,61 +59,72 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
-    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=JkBqVJDW3PpqefBb274BCZ
+    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=hetznerapizoneid
   response:
     body:
-      string: '{"records":[{"id":"8jEciPwo7wF2obPTuBe3Yg","type":"SOA","name":"@","value":"ns1.your-server.de.
-        dns.hetzner.com. 2020041598 86400 7200 3600000 3600","zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        15:17:43.061 +0000 UTC","modified":"2020-04-13 20:37:19.969 +0000 UTC"},{"id":"ccLnXePkikrTK7MjNY2fqb","type":"A","name":"localhost.softwarekollektiv.de.","value":"127.0.0.1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:37.644 +0000 UTC","modified":"2020-04-13 20:32:37.644 +0000 UTC"},{"id":"JQmTbgVAzdx4AADJeLMM3X","type":"CNAME","name":"docs.softwarekollektiv.de.","value":"docs.example.com","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:43.98 +0000 UTC","modified":"2020-04-13 20:32:43.98 +0000 UTC"},{"id":"PJpHrVw6wqik5CTzECpacD","type":"TXT","name":"_acme-challenge.fqdn.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:51.209 +0000 UTC","modified":"2020-04-13 20:32:51.209 +0000 UTC"},{"id":"JB9a4EZrNKbRTLKKAmT6M4","type":"TXT","name":"_acme-challenge.full.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:59.487 +0000 UTC","modified":"2020-04-13 20:32:59.487 +0000 UTC"},{"id":"3KU7EYhoWvAzTENjVAsqwB","type":"TXT","name":"_acme-challenge.test.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:08.017 +0000 UTC","modified":"2020-04-13 20:33:08.017 +0000 UTC"},{"id":"JmFdAr7ZKkv3WFyxnEJL43","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:18.136 +0000 UTC","modified":"2020-04-13 20:33:18.136 +0000 UTC"},{"id":"XJBbqzDiukFE3f2YGcTokY","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:25.929 +0000 UTC","modified":"2020-04-13 20:33:25.929 +0000 UTC"},{"id":"fdSKTmeja8M8pc5vztxb64","type":"TXT","name":"_acme-challenge.noop.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:33.653 +0000 UTC","modified":"2020-04-13 20:33:33.653 +0000 UTC"},{"id":"uDPTMe8hikMxgVAGznkN5S","type":"TXT","name":"_acme-challenge.deleterecordinset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:34:55.913 +0000 UTC","modified":"2020-04-13 20:34:55.913 +0000 UTC"},{"id":"pwek8RBHdnTi2eS3NGEkCG","type":"TXT","name":"ttl.fqdn.softwarekollektiv.de.","value":"ttlshouldbe3600","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:35:33.676 +0000 UTC","modified":"2020-04-13 20:35:33.676 +0000 UTC"},{"id":"wei55NH2jLAWwwnmB6ZFjf","type":"TXT","name":"_acme-challenge.listrecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:35:43.97 +0000 UTC","modified":"2020-04-13 20:35:43.97 +0000 UTC"},{"id":"jGjWxzipctQH5C3oFV7NeJ","type":"TXT","name":"_acme-challenge.listrecordset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:35:51.62 +0000 UTC","modified":"2020-04-13 20:35:51.62 +0000 UTC"},{"id":"jRamHUs2Xyt4Gh3BP4UaCd","type":"TXT","name":"random.fqdntest.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:36:02.609 +0000 UTC","modified":"2020-04-13 20:36:02.609 +0000 UTC"},{"id":"SZspS6AU4CT7ux7M6LaDrG","type":"TXT","name":"random.fulltest.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:36:12.704 +0000 UTC","modified":"2020-04-13 20:36:12.704 +0000 UTC"},{"id":"drrxjb4ddap8EjFbQw9p8f","type":"TXT","name":"random.test.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:36:27.598 +0000 UTC","modified":"2020-04-13 20:36:27.598 +0000 UTC"},{"id":"XAZaCUS5e4bNjgcFWWCsB3","type":"TXT","name":"updated.test.softwarekollektiv.de","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:36:43.156 +0000 UTC","modified":"2020-04-13 20:36:50.487 +0000 UTC"},{"id":"924FPSQ4VPhK99joGoXGqV","type":"TXT","name":"orig.nameonly.test.softwarekollektiv.de","value":"updated","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:36:56.665 +0000 UTC","modified":"2020-04-13 20:37:02.386 +0000 UTC"},{"id":"mQChejFbPusauaoMKgHYkf","type":"TXT","name":"updated.testfqdn.softwarekollektiv.de","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:37:09.374 +0000 UTC","modified":"2020-04-13 20:37:17.026 +0000 UTC"}]}
+      string: !!python/unicode '{"records":[{"id":"9720b5653ca6fd0517ec91a8c6104685","type":"SOA","name":"@","value":"ns1.first-ns.de.
+        dns.hetzner.com. 2020061235 14400 3600 1814400 3600","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:24:42 +0000 UTC","modified":"2020-06-12 08:21:20.924 +0000 UTC"},{"id":"5b378a7097bdb11e6cbb5f58db6bb101","type":"MX","name":"@","value":"10
+        mail.server-zugang.eu.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:12 +0000 UTC","modified":"2020-04-07 01:25:12 +0000 UTC"},{"id":"a26cfdd36217e559c14b305a558f2a3c","type":"AAAA","name":"@","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"7d6f741802597845b97713596e35eaa7","type":"AAAA","name":"*","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"993bafd3e3b110a6a3acde9fe874426a","type":"NS","name":"@","value":"ns1.first-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"cc3e8297060b7bd794fed5fdec3ed91b","type":"NS","name":"@","value":"robotns2.second-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"c4602b1239d9f0747016f551c52b5774","type":"NS","name":"@","value":"robotns3.second-ns.com.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"77ae87e42a04bace81119eb2280c8dca","type":"A","name":"@","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"faff62d59434c666bac4174a1d18a955","type":"A","name":"*","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"fe6ac2081c630974662caeaa8715d435","type":"A","name":"localhost","value":"127.0.0.1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:37.307 +0000 UTC","modified":"2020-06-12 08:20:37.307 +0000 UTC"},{"id":"8e6b81a856d20f0c1802703b56d1b53d","type":"CNAME","name":"docs","value":"docs.example.com","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:38.743 +0000 UTC","modified":"2020-06-12 08:20:38.743 +0000 UTC"},{"id":"a5fc9854314c160019d9bd0fcaaf2e2a","type":"TXT","name":"_acme-challenge.fqdn","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:40.141 +0000 UTC","modified":"2020-06-12 08:20:40.141 +0000 UTC"},{"id":"101296724cdf3710d18ea43a06b39e6c","type":"TXT","name":"_acme-challenge.full","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:41.421 +0000 UTC","modified":"2020-06-12 08:20:41.421 +0000 UTC"},{"id":"1c06fee6923324bc2727916d2157b3d8","type":"TXT","name":"_acme-challenge.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:43.363 +0000 UTC","modified":"2020-06-12 08:20:43.363 +0000 UTC"},{"id":"97dcfc7f529a65b944a11554e15dcdfb","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:44.557 +0000 UTC","modified":"2020-06-12 08:20:44.557 +0000 UTC"},{"id":"880d3713398b9301dda21a611cbd9ab0","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:45.499 +0000 UTC","modified":"2020-06-12 08:20:45.499 +0000 UTC"},{"id":"f794c3584778621edfa903a30a993f9b","type":"TXT","name":"_acme-challenge.noop","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:46.766 +0000 UTC","modified":"2020-06-12 08:20:46.766 +0000 UTC"},{"id":"fe7ddc85cc3c919385d8d2aabfa407eb","type":"TXT","name":"_acme-challenge.deleterecordinset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:58.928 +0000 UTC","modified":"2020-06-12 08:20:58.928 +0000 UTC"},{"id":"61efb963c73466f54f6bba592e9340d4","type":"TXT","name":"ttl.fqdn","value":"ttlshouldbe3600","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:05.618 +0000 UTC","modified":"2020-06-12 08:21:05.618 +0000 UTC"},{"id":"2d5abe2e3b1030903b6ededf674fb76a","type":"TXT","name":"_acme-challenge.listrecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:07.078 +0000 UTC","modified":"2020-06-12 08:21:07.078 +0000 UTC"},{"id":"50aaf8ab858357c3289d2a51d2ea04dc","type":"TXT","name":"_acme-challenge.listrecordset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:08.01 +0000 UTC","modified":"2020-06-12 08:21:08.01 +0000 UTC"},{"id":"b358c2b15c05b3315352ee2a149ce3bc","type":"TXT","name":"random.fqdntest","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:09.601 +0000 UTC","modified":"2020-06-12 08:21:09.601 +0000 UTC"},{"id":"9bf9fc6d8c2b7c277f2da14475d545b3","type":"TXT","name":"random.fulltest","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:11.083 +0000 UTC","modified":"2020-06-12 08:21:11.083 +0000 UTC"},{"id":"16667dd263f7667ae6d4deec7233b8b5","type":"TXT","name":"random.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:13.182 +0000 UTC","modified":"2020-06-12 08:21:13.182 +0000 UTC"},{"id":"8bb7c37e2c1dead95f002c91dc46246c","type":"TXT","name":"updated.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:15.177 +0000 UTC","modified":"2020-06-12 08:21:16.167 +0000 UTC"},{"id":"9060cea8bf140aca542442191ef9b51c","type":"TXT","name":"orig.nameonly.test","value":"updated","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:17.525 +0000 UTC","modified":"2020-06-12 08:21:18.52 +0000 UTC"},{"id":"0e0ee3c283da73027bb5181c96fd1e77","type":"TXT","name":"updated.testfqdn","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:19.844 +0000 UTC","modified":"2020-06-12 08:21:20.85 +0000 UTC"}]}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Type:
+      content-length:
+      - '6460'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:37:24 GMT
-      Transfer-Encoding:
+      date:
+      - Fri, 12 Jun 2020 08:21:21 GMT
+      transfer-encoding:
       - chunked
-      Vary:
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
-      - '2'
-      X-Kong-Upstream-Latency:
-      - '3023'
+      x-kong-proxy-latency:
+      - '1'
+      x-kong-upstream-latency:
+      - '58'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"name": "orig.testfull.softwarekollektiv.de.", "type": "TXT", "value":
-      "challengetoken", "zone_id": "JkBqVJDW3PpqefBb274BCZ", "ttl": 3600}'
+    body: !!python/unicode '{"ttl": 3600, "type": "TXT", "name": "orig.testfull",
+      "value": "challengetoken", "zone_id": "hetznerapizoneid"}'
     headers:
       Accept:
       - '*/*'
@@ -122,43 +133,45 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '139'
+      - '117'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: POST
     uri: https://dns.hetzner.com/api/v1/records
   response:
     body:
-      string: '{"record":{"id":"8GJKcvVU7NTnJCmaZSWhTg","type":"TXT","name":"orig.testfull.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:37:24.358 +0000 UTC","modified":"2020-04-13 20:37:24.358 +0000 UTC"}}
+      string: !!python/unicode '{"record":{"id":"5bf58062ea7af5abcc7eddfa4bef80e0","type":"TXT","name":"orig.testfull","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:22.01 +0000 UTC","modified":"2020-06-12 08:21:22.01 +0000 UTC"}}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '265'
-      Content-Type:
+      content-length:
+      - '251'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:37:27 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:21:22 GMT
+      transfer-encoding:
+      - chunked
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
+      x-kong-proxy-latency:
       - '1'
-      X-Kong-Upstream-Latency:
-      - '3408'
+      x-kong-upstream-latency:
+      - '662'
     status:
       code: 200
       message: OK
 - request:
-    body: '{}'
+    body: !!python/unicode '{}'
     headers:
       Accept:
       - '*/*'
@@ -169,62 +182,73 @@ interactions:
       Content-Length:
       - '2'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: GET
-    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=JkBqVJDW3PpqefBb274BCZ
+    uri: https://dns.hetzner.com/api/v1/records?per_page=100&zone_id=hetznerapizoneid
   response:
     body:
-      string: '{"records":[{"id":"8jEciPwo7wF2obPTuBe3Yg","type":"SOA","name":"@","value":"ns1.your-server.de.
-        dns.hetzner.com. 2020041599 86400 7200 3600000 3600","zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        15:17:43.061 +0000 UTC","modified":"2020-04-13 20:37:27.035 +0000 UTC"},{"id":"ccLnXePkikrTK7MjNY2fqb","type":"A","name":"localhost.softwarekollektiv.de.","value":"127.0.0.1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:37.644 +0000 UTC","modified":"2020-04-13 20:32:37.644 +0000 UTC"},{"id":"JQmTbgVAzdx4AADJeLMM3X","type":"CNAME","name":"docs.softwarekollektiv.de.","value":"docs.example.com","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:43.98 +0000 UTC","modified":"2020-04-13 20:32:43.98 +0000 UTC"},{"id":"PJpHrVw6wqik5CTzECpacD","type":"TXT","name":"_acme-challenge.fqdn.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:51.209 +0000 UTC","modified":"2020-04-13 20:32:51.209 +0000 UTC"},{"id":"JB9a4EZrNKbRTLKKAmT6M4","type":"TXT","name":"_acme-challenge.full.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:32:59.487 +0000 UTC","modified":"2020-04-13 20:32:59.487 +0000 UTC"},{"id":"3KU7EYhoWvAzTENjVAsqwB","type":"TXT","name":"_acme-challenge.test.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:08.017 +0000 UTC","modified":"2020-04-13 20:33:08.017 +0000 UTC"},{"id":"JmFdAr7ZKkv3WFyxnEJL43","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:18.136 +0000 UTC","modified":"2020-04-13 20:33:18.136 +0000 UTC"},{"id":"XJBbqzDiukFE3f2YGcTokY","type":"TXT","name":"_acme-challenge.createrecordset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:25.929 +0000 UTC","modified":"2020-04-13 20:33:25.929 +0000 UTC"},{"id":"fdSKTmeja8M8pc5vztxb64","type":"TXT","name":"_acme-challenge.noop.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:33:33.653 +0000 UTC","modified":"2020-04-13 20:33:33.653 +0000 UTC"},{"id":"uDPTMe8hikMxgVAGznkN5S","type":"TXT","name":"_acme-challenge.deleterecordinset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:34:55.913 +0000 UTC","modified":"2020-04-13 20:34:55.913 +0000 UTC"},{"id":"pwek8RBHdnTi2eS3NGEkCG","type":"TXT","name":"ttl.fqdn.softwarekollektiv.de.","value":"ttlshouldbe3600","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:35:33.676 +0000 UTC","modified":"2020-04-13 20:35:33.676 +0000 UTC"},{"id":"wei55NH2jLAWwwnmB6ZFjf","type":"TXT","name":"_acme-challenge.listrecordset.softwarekollektiv.de.","value":"challengetoken1","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:35:43.97 +0000 UTC","modified":"2020-04-13 20:35:43.97 +0000 UTC"},{"id":"jGjWxzipctQH5C3oFV7NeJ","type":"TXT","name":"_acme-challenge.listrecordset.softwarekollektiv.de.","value":"challengetoken2","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:35:51.62 +0000 UTC","modified":"2020-04-13 20:35:51.62 +0000 UTC"},{"id":"jRamHUs2Xyt4Gh3BP4UaCd","type":"TXT","name":"random.fqdntest.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:36:02.609 +0000 UTC","modified":"2020-04-13 20:36:02.609 +0000 UTC"},{"id":"SZspS6AU4CT7ux7M6LaDrG","type":"TXT","name":"random.fulltest.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:36:12.704 +0000 UTC","modified":"2020-04-13 20:36:12.704 +0000 UTC"},{"id":"drrxjb4ddap8EjFbQw9p8f","type":"TXT","name":"random.test.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:36:27.598 +0000 UTC","modified":"2020-04-13 20:36:27.598 +0000 UTC"},{"id":"XAZaCUS5e4bNjgcFWWCsB3","type":"TXT","name":"updated.test.softwarekollektiv.de","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:36:43.156 +0000 UTC","modified":"2020-04-13 20:36:50.487 +0000 UTC"},{"id":"924FPSQ4VPhK99joGoXGqV","type":"TXT","name":"orig.nameonly.test.softwarekollektiv.de","value":"updated","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:36:56.665 +0000 UTC","modified":"2020-04-13 20:37:02.386 +0000 UTC"},{"id":"mQChejFbPusauaoMKgHYkf","type":"TXT","name":"updated.testfqdn.softwarekollektiv.de","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:37:09.374 +0000 UTC","modified":"2020-04-13 20:37:17.026 +0000 UTC"},{"id":"8GJKcvVU7NTnJCmaZSWhTg","type":"TXT","name":"orig.testfull.softwarekollektiv.de.","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:37:24.358 +0000 UTC","modified":"2020-04-13 20:37:24.358 +0000 UTC"}]}
+      string: !!python/unicode '{"records":[{"id":"9720b5653ca6fd0517ec91a8c6104685","type":"SOA","name":"@","value":"ns1.first-ns.de.
+        dns.hetzner.com. 2020061236 14400 3600 1814400 3600","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:24:42 +0000 UTC","modified":"2020-06-12 08:21:22.127 +0000 UTC"},{"id":"5b378a7097bdb11e6cbb5f58db6bb101","type":"MX","name":"@","value":"10
+        mail.server-zugang.eu.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:12 +0000 UTC","modified":"2020-04-07 01:25:12 +0000 UTC"},{"id":"a26cfdd36217e559c14b305a558f2a3c","type":"AAAA","name":"@","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"7d6f741802597845b97713596e35eaa7","type":"AAAA","name":"*","value":"2a01:4f8:121:31ec::b","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:37 +0000 UTC","modified":"2020-04-07 01:25:37 +0000 UTC"},{"id":"993bafd3e3b110a6a3acde9fe874426a","type":"NS","name":"@","value":"ns1.first-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"cc3e8297060b7bd794fed5fdec3ed91b","type":"NS","name":"@","value":"robotns2.second-ns.de.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"c4602b1239d9f0747016f551c52b5774","type":"NS","name":"@","value":"robotns3.second-ns.com.","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"77ae87e42a04bace81119eb2280c8dca","type":"A","name":"@","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"faff62d59434c666bac4174a1d18a955","type":"A","name":"*","value":"178.63.80.254","zone_id":"hetznerapizoneid","created":"2020-04-07
+        01:25:41 +0000 UTC","modified":"2020-04-07 01:25:41 +0000 UTC"},{"id":"fe6ac2081c630974662caeaa8715d435","type":"A","name":"localhost","value":"127.0.0.1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:37.307 +0000 UTC","modified":"2020-06-12 08:20:37.307 +0000 UTC"},{"id":"8e6b81a856d20f0c1802703b56d1b53d","type":"CNAME","name":"docs","value":"docs.example.com","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:38.743 +0000 UTC","modified":"2020-06-12 08:20:38.743 +0000 UTC"},{"id":"a5fc9854314c160019d9bd0fcaaf2e2a","type":"TXT","name":"_acme-challenge.fqdn","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:40.141 +0000 UTC","modified":"2020-06-12 08:20:40.141 +0000 UTC"},{"id":"101296724cdf3710d18ea43a06b39e6c","type":"TXT","name":"_acme-challenge.full","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:41.421 +0000 UTC","modified":"2020-06-12 08:20:41.421 +0000 UTC"},{"id":"1c06fee6923324bc2727916d2157b3d8","type":"TXT","name":"_acme-challenge.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:43.363 +0000 UTC","modified":"2020-06-12 08:20:43.363 +0000 UTC"},{"id":"97dcfc7f529a65b944a11554e15dcdfb","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:44.557 +0000 UTC","modified":"2020-06-12 08:20:44.557 +0000 UTC"},{"id":"880d3713398b9301dda21a611cbd9ab0","type":"TXT","name":"_acme-challenge.createrecordset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:45.499 +0000 UTC","modified":"2020-06-12 08:20:45.499 +0000 UTC"},{"id":"f794c3584778621edfa903a30a993f9b","type":"TXT","name":"_acme-challenge.noop","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:46.766 +0000 UTC","modified":"2020-06-12 08:20:46.766 +0000 UTC"},{"id":"fe7ddc85cc3c919385d8d2aabfa407eb","type":"TXT","name":"_acme-challenge.deleterecordinset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:20:58.928 +0000 UTC","modified":"2020-06-12 08:20:58.928 +0000 UTC"},{"id":"61efb963c73466f54f6bba592e9340d4","type":"TXT","name":"ttl.fqdn","value":"ttlshouldbe3600","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:05.618 +0000 UTC","modified":"2020-06-12 08:21:05.618 +0000 UTC"},{"id":"2d5abe2e3b1030903b6ededf674fb76a","type":"TXT","name":"_acme-challenge.listrecordset","value":"challengetoken1","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:07.078 +0000 UTC","modified":"2020-06-12 08:21:07.078 +0000 UTC"},{"id":"50aaf8ab858357c3289d2a51d2ea04dc","type":"TXT","name":"_acme-challenge.listrecordset","value":"challengetoken2","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:08.01 +0000 UTC","modified":"2020-06-12 08:21:08.01 +0000 UTC"},{"id":"b358c2b15c05b3315352ee2a149ce3bc","type":"TXT","name":"random.fqdntest","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:09.601 +0000 UTC","modified":"2020-06-12 08:21:09.601 +0000 UTC"},{"id":"9bf9fc6d8c2b7c277f2da14475d545b3","type":"TXT","name":"random.fulltest","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:11.083 +0000 UTC","modified":"2020-06-12 08:21:11.083 +0000 UTC"},{"id":"16667dd263f7667ae6d4deec7233b8b5","type":"TXT","name":"random.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:13.182 +0000 UTC","modified":"2020-06-12 08:21:13.182 +0000 UTC"},{"id":"8bb7c37e2c1dead95f002c91dc46246c","type":"TXT","name":"updated.test","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:15.177 +0000 UTC","modified":"2020-06-12 08:21:16.167 +0000 UTC"},{"id":"9060cea8bf140aca542442191ef9b51c","type":"TXT","name":"orig.nameonly.test","value":"updated","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:17.525 +0000 UTC","modified":"2020-06-12 08:21:18.52 +0000 UTC"},{"id":"0e0ee3c283da73027bb5181c96fd1e77","type":"TXT","name":"updated.testfqdn","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:19.844 +0000 UTC","modified":"2020-06-12 08:21:20.85 +0000 UTC"},{"id":"5bf58062ea7af5abcc7eddfa4bef80e0","type":"TXT","name":"orig.testfull","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:22.01 +0000 UTC","modified":"2020-06-12 08:21:22.01 +0000 UTC"}]}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Type:
+      content-length:
+      - '6700'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:37:31 GMT
-      Transfer-Encoding:
+      date:
+      - Fri, 12 Jun 2020 08:21:22 GMT
+      transfer-encoding:
       - chunked
-      Vary:
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
-      - '1'
-      X-Kong-Upstream-Latency:
-      - '3440'
+      x-kong-proxy-latency:
+      - '2'
+      x-kong-upstream-latency:
+      - '77'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"type": "TXT", "name": "updated.testfull.softwarekollektiv.de", "value":
-      "challengetoken", "zone_id": "JkBqVJDW3PpqefBb274BCZ", "ttl": 3600}'
+    body: !!python/unicode '{"ttl": 3600, "type": "TXT", "name": "updated.testfull",
+      "value": "challengetoken", "zone_id": "hetznerapizoneid"}'
     headers:
       Accept:
       - '*/*'
@@ -233,38 +257,40 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '141'
+      - '120'
       Content-Type:
-      - application/json
+      - !!python/unicode application/json
       User-Agent:
       - python-requests/2.23.0
     method: PUT
-    uri: https://dns.hetzner.com/api/v1/records/8GJKcvVU7NTnJCmaZSWhTg
+    uri: https://dns.hetzner.com/api/v1/records/5bf58062ea7af5abcc7eddfa4bef80e0
   response:
     body:
-      string: '{"record":{"id":"8GJKcvVU7NTnJCmaZSWhTg","type":"TXT","name":"updated.testfull.softwarekollektiv.de","value":"challengetoken","ttl":3600,"zone_id":"JkBqVJDW3PpqefBb274BCZ","created":"2020-04-13
-        20:37:24.358 +0000 UTC","modified":"2020-04-13 20:37:31.652 +0000 UTC"}}
+      string: !!python/unicode '{"record":{"id":"5bf58062ea7af5abcc7eddfa4bef80e0","type":"TXT","name":"updated.testfull","value":"challengetoken","ttl":3600,"zone_id":"hetznerapizoneid","created":"2020-06-12
+        08:21:22.01 +0000 UTC","modified":"2020-06-12 08:21:22.992 +0000 UTC"}}
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-origin:
       - '*'
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '267'
-      Content-Type:
+      content-length:
+      - '255'
+      content-type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 13 Apr 2020 20:37:35 GMT
-      Vary:
+      date:
+      - Fri, 12 Jun 2020 08:21:23 GMT
+      transfer-encoding:
+      - chunked
+      vary:
       - Origin
-      Via:
+      via:
       - kong/2.0.2
-      X-Kong-Proxy-Latency:
-      - '5'
-      X-Kong-Upstream-Latency:
-      - '3830'
+      x-kong-proxy-latency:
+      - '2'
+      x-kong-upstream-latency:
+      - '651'
     status:
       code: 200
       message: OK


### PR DESCRIPTION
The main fix is, that hetzner does not need the fqdn as record name. This leads to major errors like:

record name=sub1.my-fqdn.tld --> record created with final name sub1.my-fqdn.tld.my-fqdn.tld

Tested against my own hetzner account. Recorded new cassettes with it.