### PR TITLE
[TASK] Update Gandi API URL

### DIFF
--- a/lexicon/providers/gandi.py
+++ b/lexicon/providers/gandi.py
@@ -80,7 +80,7 @@ class Provider(BaseProvider):
                 self._full_name,
             )
         else:
-            self.api_endpoint = "https://dns.api.gandi.net/api/v5"
+            self.api_endpoint = "https://api.gandi.net/v5/livedns"
 
     def _authenticate(self):
         if self.protocol == "rpc":
@@ -110,13 +110,13 @@ class Provider(BaseProvider):
             if current_values:
                 record = {"rrset_values": current_values + [content]}
                 if self._get_lexicon_option("ttl"):
-                    record["rrset_ttl"] = self._get_lexicon_option("ttl")
+                    record["rrset_ttl"] = self._get_lexicon_option("ttl") if self._get_lexicon_option("ttl") >= 300 else 300
                 self._put(url, record)
             else:
                 record = {"rrset_values": [content]}
                 # add the ttl, if this is a new record
                 if self._get_lexicon_option("ttl"):
-                    record["rrset_ttl"] = self._get_lexicon_option("ttl")
+                    record["rrset_ttl"] = self._get_lexicon_option("ttl") if self._get_lexicon_option("ttl") >= 300 else 300
                 self._post(url, record)
         LOGGER.debug("create_record: %s", True)
         return True
@@ -267,7 +267,7 @@ class Provider(BaseProvider):
         default_headers = {
             "Accept": "application/json",
             "Content-Type": "application/json",
-            "X-Api-Key": self._get_provider_option("auth_token"),
+            "Authorization": "Apikey " + self._get_provider_option("auth_token"),
         }
         if not url.startswith(self.api_endpoint):
             url = self.api_endpoint + url

--- a/lexicon/tests/providers/test_gandi.py
+++ b/lexicon/tests/providers/test_gandi.py
@@ -26,7 +26,7 @@ class GandiRESTProviderTests(TestCase, IntegrationTestsV2):
     provider_variant = "REST"
 
     def _filter_headers(self):
-        return ["X-Api-Key"]
+        return ["Authorization"]
 
     def _test_parameters_overrides(self):
         return {"api_protocol": "rest"}

--- a/tests/fixtures/cassettes/gandi/REST-IntegrationTests/test_provider_authenticate.yaml
+++ b/tests/fixtures/cassettes/gandi/REST-IntegrationTests/test_provider_authenticate.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -13,53 +13,52 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr
   response:
     body:
-      string: !!python/unicode '{"zone_uuid": "4fd93cb0-5c6c-11e8-b297-00163ee24379",
-        "domain_keys_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/keys",
-        "fqdn": "t18s.fr", "zone_href": "https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379",
-        "zone_records_href": "https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379/records",
-        "domain_records_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records",
-        "domain_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr"}'
+      string: '{"domain_keys_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/keys","fqdn":"t18s.fr","automatic_snapshots":true,"domain_records_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/records","domain_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr"}'
     headers:
-      accept-ranges:
+      Accept-Ranges:
       - bytes
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '499'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:17 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:17 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:17 GMT
-      pragma:
+      Content-Length:
+      - '274'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:11 GMT
+      ETag:
+      - W/"112-tyQllSkZqMzGHTaisDLSgpwZtfY"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:11 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:11 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
     status:
       code: 200

--- a/tests/fixtures/cassettes/gandi/REST-IntegrationTests/test_provider_authenticate_with_unmanaged_domain_should_fail.yaml
+++ b/tests/fixtures/cassettes/gandi/REST-IntegrationTests/test_provider_authenticate_with_unmanaged_domain_should_fail.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -13,39 +13,39 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/thisisadomainidonotown.com
+    uri: https://api.gandi.net/v5/livedns/domains/thisisadomainidonotown.com
   response:
     body:
-      string: !!python/unicode '{"code": 404, "message": "The resource could not be
-        found.", "object": "HTTPNotFound", "cause": "Not Found"}'
+      string: '{"code": 404, "message": "The resource could not be found.", "object":
+        "HTTPNotFound", "cause": "Not Found"}'
     headers:
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
+      Content-Length:
       - '108'
-      content-type:
+      Content-Type:
       - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:18 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:18 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:18 GMT
-      pragma:
+      Date:
+      - Thu, 22 Oct 2020 21:23:11 GMT
+      Expires:
+      - Thu, 22 Oct 2020 21:23:11 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:11 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      via:
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
     status:
       code: 404

--- a/tests/fixtures/cassettes/gandi/REST-IntegrationTests/test_provider_when_calling_create_record_for_A_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/gandi/REST-IntegrationTests/test_provider_when_calling_create_record_for_A_with_valid_name_and_content.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -13,59 +13,58 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr
   response:
     body:
-      string: !!python/unicode '{"zone_uuid": "4fd93cb0-5c6c-11e8-b297-00163ee24379",
-        "domain_keys_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/keys",
-        "fqdn": "t18s.fr", "zone_href": "https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379",
-        "zone_records_href": "https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379/records",
-        "domain_records_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records",
-        "domain_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr"}'
+      string: '{"domain_keys_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/keys","fqdn":"t18s.fr","automatic_snapshots":true,"domain_records_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/records","domain_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr"}'
     headers:
-      accept-ranges:
+      Accept-Ranges:
       - bytes
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '499'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:18 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:18 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:18 GMT
-      pragma:
+      Content-Length:
+      - '274'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:11 GMT
+      ETag:
+      - W/"112-tyQllSkZqMzGHTaisDLSgpwZtfY"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:11 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:11 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -78,45 +77,45 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/localhost/A
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/localhost/A
   response:
     body:
-      string: !!python/unicode '{"code": 404, "message": "Can''t find the DNS record
-        localhost/A in the zone", "object": "dns-record", "cause": "Not Found"}'
+      string: '{"code": 404, "message": "Can''t find the DNS record localhost/A in
+        the zone", "object": "dns-record", "cause": "Not Found"}'
     headers:
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
+      Content-Length:
       - '123'
-      content-type:
+      Content-Type:
       - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:19 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:19 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:19 GMT
-      pragma:
+      Date:
+      - Thu, 22 Oct 2020 21:23:11 GMT
+      Expires:
+      - Thu, 22 Oct 2020 21:23:11 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:11 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      via:
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
     status:
       code: 404
       message: Not Found
 - request:
-    body: !!python/unicode '{"rrset_values": ["127.0.0.1"], "rrset_ttl": 3600}'
+    body: '{"rrset_values": ["127.0.0.1"], "rrset_ttl": 3600}'
     headers:
       Accept:
       - application/json
@@ -129,49 +128,53 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: POST
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/localhost/A
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/localhost/A
   response:
     body:
-      string: !!python/unicode '{"message": "DNS Record Created"}'
+      string: '{"message":"DNS Record Created"}'
     headers:
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '33'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:19 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:19 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:19 GMT
-      location:
-      - https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379/records/localhost/A
-      pragma:
+      Content-Length:
+      - '32'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:12 GMT
+      ETag:
+      - W/"20-8GzTjxqNVdrkc6ay0Gf8zJRLVdc"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:12 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:12 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
+      location:
+      - https://api.gandi.net/v5/livedns/domains/t18s.fr/records/localhost/A
     status:
       code: 201
       message: Created

--- a/tests/fixtures/cassettes/gandi/REST-IntegrationTests/test_provider_when_calling_create_record_for_CNAME_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/gandi/REST-IntegrationTests/test_provider_when_calling_create_record_for_CNAME_with_valid_name_and_content.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -13,59 +13,58 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr
   response:
     body:
-      string: !!python/unicode '{"zone_uuid": "4fd93cb0-5c6c-11e8-b297-00163ee24379",
-        "domain_keys_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/keys",
-        "fqdn": "t18s.fr", "zone_href": "https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379",
-        "zone_records_href": "https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379/records",
-        "domain_records_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records",
-        "domain_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr"}'
+      string: '{"domain_keys_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/keys","fqdn":"t18s.fr","automatic_snapshots":true,"domain_records_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/records","domain_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr"}'
     headers:
-      accept-ranges:
+      Accept-Ranges:
       - bytes
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '499'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:20 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:20 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:20 GMT
-      pragma:
+      Content-Length:
+      - '274'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:13 GMT
+      ETag:
+      - W/"112-tyQllSkZqMzGHTaisDLSgpwZtfY"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:13 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:13 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -78,45 +77,45 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/docs/CNAME
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/docs/CNAME
   response:
     body:
-      string: !!python/unicode '{"code": 404, "message": "Can''t find the DNS record
-        docs/CNAME in the zone", "object": "dns-record", "cause": "Not Found"}'
+      string: '{"code": 404, "message": "Can''t find the DNS record docs/CNAME in
+        the zone", "object": "dns-record", "cause": "Not Found"}'
     headers:
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
+      Content-Length:
       - '122'
-      content-type:
+      Content-Type:
       - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:20 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:20 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:20 GMT
-      pragma:
+      Date:
+      - Thu, 22 Oct 2020 21:23:13 GMT
+      Expires:
+      - Thu, 22 Oct 2020 21:23:13 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:13 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      via:
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
     status:
       code: 404
       message: Not Found
 - request:
-    body: !!python/unicode '{"rrset_values": ["docs.example.com"], "rrset_ttl": 3600}'
+    body: '{"rrset_values": ["docs.example.com"], "rrset_ttl": 3600}'
     headers:
       Accept:
       - application/json
@@ -129,49 +128,53 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: POST
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/docs/CNAME
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/docs/CNAME
   response:
     body:
-      string: !!python/unicode '{"message": "DNS Record Created"}'
+      string: '{"message":"DNS Record Created"}'
     headers:
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '33'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:21 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:21 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:21 GMT
-      location:
-      - https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379/records/docs/CNAME
-      pragma:
+      Content-Length:
+      - '32'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:14 GMT
+      ETag:
+      - W/"20-8GzTjxqNVdrkc6ay0Gf8zJRLVdc"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:14 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:14 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
+      location:
+      - https://api.gandi.net/v5/livedns/domains/t18s.fr/records/docs/CNAME
     status:
       code: 201
       message: Created

--- a/tests/fixtures/cassettes/gandi/REST-IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_fqdn_name_and_content.yaml
+++ b/tests/fixtures/cassettes/gandi/REST-IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_fqdn_name_and_content.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -13,59 +13,58 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr
   response:
     body:
-      string: !!python/unicode '{"zone_uuid": "4fd93cb0-5c6c-11e8-b297-00163ee24379",
-        "domain_keys_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/keys",
-        "fqdn": "t18s.fr", "zone_href": "https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379",
-        "zone_records_href": "https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379/records",
-        "domain_records_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records",
-        "domain_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr"}'
+      string: '{"domain_keys_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/keys","fqdn":"t18s.fr","automatic_snapshots":true,"domain_records_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/records","domain_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr"}'
     headers:
-      accept-ranges:
+      Accept-Ranges:
       - bytes
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '499'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:21 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:21 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:21 GMT
-      pragma:
+      Content-Length:
+      - '274'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:14 GMT
+      ETag:
+      - W/"112-tyQllSkZqMzGHTaisDLSgpwZtfY"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:14 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:14 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -78,46 +77,45 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/_acme-challenge.fqdn/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/_acme-challenge.fqdn/TXT
   response:
     body:
-      string: !!python/unicode '{"code": 404, "message": "Can''t find the DNS record
-        _acme-challenge.fqdn/TXT in the zone", "object": "dns-record", "cause": "Not
-        Found"}'
+      string: '{"code": 404, "message": "Can''t find the DNS record _acme-challenge.fqdn/TXT
+        in the zone", "object": "dns-record", "cause": "Not Found"}'
     headers:
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
+      Content-Length:
       - '136'
-      content-type:
+      Content-Type:
       - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:22 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:22 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:22 GMT
-      pragma:
+      Date:
+      - Thu, 22 Oct 2020 21:23:15 GMT
+      Expires:
+      - Thu, 22 Oct 2020 21:23:15 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:15 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      via:
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
     status:
       code: 404
       message: Not Found
 - request:
-    body: !!python/unicode '{"rrset_values": ["challengetoken"], "rrset_ttl": 3600}'
+    body: '{"rrset_values": ["challengetoken"], "rrset_ttl": 3600}'
     headers:
       Accept:
       - application/json
@@ -130,49 +128,53 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: POST
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/_acme-challenge.fqdn/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/_acme-challenge.fqdn/TXT
   response:
     body:
-      string: !!python/unicode '{"message": "DNS Record Created"}'
+      string: '{"message":"DNS Record Created"}'
     headers:
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '33'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:22 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:22 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:22 GMT
-      location:
-      - https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379/records/_acme-challenge.fqdn/TXT
-      pragma:
+      Content-Length:
+      - '32'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:15 GMT
+      ETag:
+      - W/"20-8GzTjxqNVdrkc6ay0Gf8zJRLVdc"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:15 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:15 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
+      location:
+      - https://api.gandi.net/v5/livedns/domains/t18s.fr/records/_acme-challenge.fqdn/TXT
     status:
       code: 201
       message: Created

--- a/tests/fixtures/cassettes/gandi/REST-IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_full_name_and_content.yaml
+++ b/tests/fixtures/cassettes/gandi/REST-IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_full_name_and_content.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -13,59 +13,58 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr
   response:
     body:
-      string: !!python/unicode '{"zone_uuid": "4fd93cb0-5c6c-11e8-b297-00163ee24379",
-        "domain_keys_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/keys",
-        "fqdn": "t18s.fr", "zone_href": "https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379",
-        "zone_records_href": "https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379/records",
-        "domain_records_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records",
-        "domain_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr"}'
+      string: '{"domain_keys_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/keys","fqdn":"t18s.fr","automatic_snapshots":true,"domain_records_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/records","domain_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr"}'
     headers:
-      accept-ranges:
+      Accept-Ranges:
       - bytes
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '499'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:23 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:23 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:23 GMT
-      pragma:
+      Content-Length:
+      - '274'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:16 GMT
+      ETag:
+      - W/"112-tyQllSkZqMzGHTaisDLSgpwZtfY"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:16 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:16 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -78,46 +77,45 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/_acme-challenge.full/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/_acme-challenge.full/TXT
   response:
     body:
-      string: !!python/unicode '{"code": 404, "message": "Can''t find the DNS record
-        _acme-challenge.full/TXT in the zone", "object": "dns-record", "cause": "Not
-        Found"}'
+      string: '{"code": 404, "message": "Can''t find the DNS record _acme-challenge.full/TXT
+        in the zone", "object": "dns-record", "cause": "Not Found"}'
     headers:
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
+      Content-Length:
       - '136'
-      content-type:
+      Content-Type:
       - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:24 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:24 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:24 GMT
-      pragma:
+      Date:
+      - Thu, 22 Oct 2020 21:23:16 GMT
+      Expires:
+      - Thu, 22 Oct 2020 21:23:16 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:16 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      via:
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
     status:
       code: 404
       message: Not Found
 - request:
-    body: !!python/unicode '{"rrset_values": ["challengetoken"], "rrset_ttl": 3600}'
+    body: '{"rrset_values": ["challengetoken"], "rrset_ttl": 3600}'
     headers:
       Accept:
       - application/json
@@ -130,49 +128,53 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: POST
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/_acme-challenge.full/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/_acme-challenge.full/TXT
   response:
     body:
-      string: !!python/unicode '{"message": "DNS Record Created"}'
+      string: '{"message":"DNS Record Created"}'
     headers:
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '33'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:24 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:24 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:24 GMT
-      location:
-      - https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379/records/_acme-challenge.full/TXT
-      pragma:
+      Content-Length:
+      - '32'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:16 GMT
+      ETag:
+      - W/"20-8GzTjxqNVdrkc6ay0Gf8zJRLVdc"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:16 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:16 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
+      location:
+      - https://api.gandi.net/v5/livedns/domains/t18s.fr/records/_acme-challenge.full/TXT
     status:
       code: 201
       message: Created

--- a/tests/fixtures/cassettes/gandi/REST-IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/gandi/REST-IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_valid_name_and_content.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -13,59 +13,58 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr
   response:
     body:
-      string: !!python/unicode '{"zone_uuid": "4fd93cb0-5c6c-11e8-b297-00163ee24379",
-        "domain_keys_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/keys",
-        "fqdn": "t18s.fr", "zone_href": "https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379",
-        "zone_records_href": "https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379/records",
-        "domain_records_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records",
-        "domain_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr"}'
+      string: '{"domain_keys_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/keys","fqdn":"t18s.fr","automatic_snapshots":true,"domain_records_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/records","domain_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr"}'
     headers:
-      accept-ranges:
+      Accept-Ranges:
       - bytes
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '499'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:25 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:25 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:25 GMT
-      pragma:
+      Content-Length:
+      - '274'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:17 GMT
+      ETag:
+      - W/"112-tyQllSkZqMzGHTaisDLSgpwZtfY"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:17 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:17 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -78,46 +77,45 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/_acme-challenge.test/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/_acme-challenge.test/TXT
   response:
     body:
-      string: !!python/unicode '{"code": 404, "message": "Can''t find the DNS record
-        _acme-challenge.test/TXT in the zone", "object": "dns-record", "cause": "Not
-        Found"}'
+      string: '{"code": 404, "message": "Can''t find the DNS record _acme-challenge.test/TXT
+        in the zone", "object": "dns-record", "cause": "Not Found"}'
     headers:
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
+      Content-Length:
       - '136'
-      content-type:
+      Content-Type:
       - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:25 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:25 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:25 GMT
-      pragma:
+      Date:
+      - Thu, 22 Oct 2020 21:23:18 GMT
+      Expires:
+      - Thu, 22 Oct 2020 21:23:18 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:18 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      via:
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
     status:
       code: 404
       message: Not Found
 - request:
-    body: !!python/unicode '{"rrset_values": ["challengetoken"], "rrset_ttl": 3600}'
+    body: '{"rrset_values": ["challengetoken"], "rrset_ttl": 3600}'
     headers:
       Accept:
       - application/json
@@ -130,49 +128,53 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: POST
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/_acme-challenge.test/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/_acme-challenge.test/TXT
   response:
     body:
-      string: !!python/unicode '{"message": "DNS Record Created"}'
+      string: '{"message":"DNS Record Created"}'
     headers:
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '33'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:26 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:26 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:26 GMT
-      location:
-      - https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379/records/_acme-challenge.test/TXT
-      pragma:
+      Content-Length:
+      - '32'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:18 GMT
+      ETag:
+      - W/"20-8GzTjxqNVdrkc6ay0Gf8zJRLVdc"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:18 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:18 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
+      location:
+      - https://api.gandi.net/v5/livedns/domains/t18s.fr/records/_acme-challenge.test/TXT
     status:
       code: 201
       message: Created

--- a/tests/fixtures/cassettes/gandi/REST-IntegrationTests/test_provider_when_calling_create_record_multiple_times_should_create_record_set.yaml
+++ b/tests/fixtures/cassettes/gandi/REST-IntegrationTests/test_provider_when_calling_create_record_multiple_times_should_create_record_set.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -13,59 +13,58 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr
   response:
     body:
-      string: !!python/unicode '{"zone_uuid": "4fd93cb0-5c6c-11e8-b297-00163ee24379",
-        "domain_keys_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/keys",
-        "fqdn": "t18s.fr", "zone_href": "https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379",
-        "zone_records_href": "https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379/records",
-        "domain_records_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records",
-        "domain_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr"}'
+      string: '{"domain_keys_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/keys","fqdn":"t18s.fr","automatic_snapshots":true,"domain_records_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/records","domain_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr"}'
     headers:
-      accept-ranges:
+      Accept-Ranges:
       - bytes
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '499'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:26 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:26 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:26 GMT
-      pragma:
+      Content-Length:
+      - '274'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:18 GMT
+      ETag:
+      - W/"112-tyQllSkZqMzGHTaisDLSgpwZtfY"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:18 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:18 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -78,46 +77,45 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/_acme-challenge.createrecordset/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/_acme-challenge.createrecordset/TXT
   response:
     body:
-      string: !!python/unicode '{"code": 404, "message": "Can''t find the DNS record
-        _acme-challenge.createrecordset/TXT in the zone", "object": "dns-record",
-        "cause": "Not Found"}'
+      string: '{"code": 404, "message": "Can''t find the DNS record _acme-challenge.createrecordset/TXT
+        in the zone", "object": "dns-record", "cause": "Not Found"}'
     headers:
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
+      Content-Length:
       - '147'
-      content-type:
+      Content-Type:
       - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:27 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:27 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:27 GMT
-      pragma:
+      Date:
+      - Thu, 22 Oct 2020 21:23:19 GMT
+      Expires:
+      - Thu, 22 Oct 2020 21:23:19 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:19 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      via:
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
     status:
       code: 404
       message: Not Found
 - request:
-    body: !!python/unicode '{"rrset_values": ["challengetoken1"], "rrset_ttl": 3600}'
+    body: '{"rrset_values": ["challengetoken1"], "rrset_ttl": 3600}'
     headers:
       Accept:
       - application/json
@@ -130,54 +128,58 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: POST
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/_acme-challenge.createrecordset/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/_acme-challenge.createrecordset/TXT
   response:
     body:
-      string: !!python/unicode '{"message": "DNS Record Created"}'
+      string: '{"message":"DNS Record Created"}'
     headers:
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '33'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:28 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:28 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:28 GMT
-      location:
-      - https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379/records/_acme-challenge.createrecordset/TXT
-      pragma:
+      Content-Length:
+      - '32'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:20 GMT
+      ETag:
+      - W/"20-8GzTjxqNVdrkc6ay0Gf8zJRLVdc"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:20 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:20 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
+      location:
+      - https://api.gandi.net/v5/livedns/domains/t18s.fr/records/_acme-challenge.createrecordset/TXT
     status:
       code: 201
       message: Created
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -190,56 +192,58 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/_acme-challenge.createrecordset/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/_acme-challenge.createrecordset/TXT
   response:
     body:
-      string: !!python/unicode '{"rrset_type": "TXT", "rrset_ttl": 3600, "rrset_name":
-        "_acme-challenge.createrecordset", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/_acme-challenge.createrecordset/TXT",
-        "rrset_values": ["\"challengetoken1\""]}'
+      string: '{"rrset_type":"TXT","rrset_ttl":3600,"rrset_name":"_acme-challenge.createrecordset","rrset_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/records/_acme-challenge.createrecordset/TXT","rrset_values":["\"challengetoken1\""]}'
     headers:
-      accept-ranges:
+      Accept-Ranges:
       - bytes
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '240'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:28 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:28 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:28 GMT
-      pragma:
+      Content-Length:
+      - '233'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:20 GMT
+      ETag:
+      - W/"e9-s7TFKt+Rd2dhebI51NBsV+qAN/Q"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:20 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:20 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: !!python/unicode '{"rrset_values": ["challengetoken1", "challengetoken2"]}'
+    body: '{"rrset_values": ["challengetoken1", "challengetoken2"], "rrset_ttl": 3600}'
     headers:
       Accept:
       - application/json
@@ -248,53 +252,57 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '56'
+      - '75'
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: PUT
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/_acme-challenge.createrecordset/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/_acme-challenge.createrecordset/TXT
   response:
     body:
-      string: !!python/unicode '{"message": "DNS Record Created"}'
+      string: '{"message":"DNS Record Created"}'
     headers:
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '33'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:29 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:29 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:29 GMT
-      location:
-      - https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379/records/_acme-challenge.createrecordset/TXT
-      pragma:
+      Content-Length:
+      - '32'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:20 GMT
+      ETag:
+      - W/"20-8GzTjxqNVdrkc6ay0Gf8zJRLVdc"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:20 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:20 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
+      location:
+      - https://api.gandi.net/v5/livedns/domains/t18s.fr/records/_acme-challenge.createrecordset/TXT
     status:
       code: 201
       message: Created

--- a/tests/fixtures/cassettes/gandi/REST-IntegrationTests/test_provider_when_calling_create_record_with_duplicate_records_should_be_noop.yaml
+++ b/tests/fixtures/cassettes/gandi/REST-IntegrationTests/test_provider_when_calling_create_record_with_duplicate_records_should_be_noop.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -13,59 +13,58 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr
   response:
     body:
-      string: !!python/unicode '{"zone_uuid": "4fd93cb0-5c6c-11e8-b297-00163ee24379",
-        "domain_keys_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/keys",
-        "fqdn": "t18s.fr", "zone_href": "https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379",
-        "zone_records_href": "https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379/records",
-        "domain_records_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records",
-        "domain_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr"}'
+      string: '{"domain_keys_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/keys","fqdn":"t18s.fr","automatic_snapshots":true,"domain_records_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/records","domain_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr"}'
     headers:
-      accept-ranges:
+      Accept-Ranges:
       - bytes
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '499'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:29 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:29 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:29 GMT
-      pragma:
+      Content-Length:
+      - '274'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:20 GMT
+      ETag:
+      - W/"112-tyQllSkZqMzGHTaisDLSgpwZtfY"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:20 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:20 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -78,46 +77,45 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/_acme-challenge.noop/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/_acme-challenge.noop/TXT
   response:
     body:
-      string: !!python/unicode '{"code": 404, "message": "Can''t find the DNS record
-        _acme-challenge.noop/TXT in the zone", "object": "dns-record", "cause": "Not
-        Found"}'
+      string: '{"code": 404, "message": "Can''t find the DNS record _acme-challenge.noop/TXT
+        in the zone", "object": "dns-record", "cause": "Not Found"}'
     headers:
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
+      Content-Length:
       - '136'
-      content-type:
+      Content-Type:
       - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:30 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:30 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:30 GMT
-      pragma:
+      Date:
+      - Thu, 22 Oct 2020 21:23:21 GMT
+      Expires:
+      - Thu, 22 Oct 2020 21:23:21 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:21 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      via:
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
     status:
       code: 404
       message: Not Found
 - request:
-    body: !!python/unicode '{"rrset_values": ["challengetoken"], "rrset_ttl": 3600}'
+    body: '{"rrset_values": ["challengetoken"], "rrset_ttl": 3600}'
     headers:
       Accept:
       - application/json
@@ -130,54 +128,58 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: POST
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/_acme-challenge.noop/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/_acme-challenge.noop/TXT
   response:
     body:
-      string: !!python/unicode '{"message": "DNS Record Created"}'
+      string: '{"message":"DNS Record Created"}'
     headers:
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '33'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:31 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:31 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:31 GMT
-      location:
-      - https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379/records/_acme-challenge.noop/TXT
-      pragma:
+      Content-Length:
+      - '32'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:21 GMT
+      ETag:
+      - W/"20-8GzTjxqNVdrkc6ay0Gf8zJRLVdc"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:21 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:21 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
+      location:
+      - https://api.gandi.net/v5/livedns/domains/t18s.fr/records/_acme-challenge.noop/TXT
     status:
       code: 201
       message: Created
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -190,56 +192,58 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/_acme-challenge.noop/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/_acme-challenge.noop/TXT
   response:
     body:
-      string: !!python/unicode '{"rrset_type": "TXT", "rrset_ttl": 3600, "rrset_name":
-        "_acme-challenge.noop", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/_acme-challenge.noop/TXT",
-        "rrset_values": ["\"challengetoken\""]}'
+      string: '{"rrset_type":"TXT","rrset_ttl":3600,"rrset_name":"_acme-challenge.noop","rrset_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/records/_acme-challenge.noop/TXT","rrset_values":["\"challengetoken\""]}'
     headers:
-      accept-ranges:
+      Accept-Ranges:
       - bytes
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '217'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:31 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:31 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:31 GMT
-      pragma:
+      Content-Length:
+      - '210'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:22 GMT
+      ETag:
+      - W/"d2-Oj3sMSmReSrP+eeHLEWPg5vhT+M"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:22 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:22 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -252,50 +256,52 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/_acme-challenge.noop/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/_acme-challenge.noop/TXT
   response:
     body:
-      string: !!python/unicode '{"rrset_type": "TXT", "rrset_ttl": 3600, "rrset_name":
-        "_acme-challenge.noop", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/_acme-challenge.noop/TXT",
-        "rrset_values": ["\"challengetoken\""]}'
+      string: '{"rrset_type":"TXT","rrset_ttl":3600,"rrset_name":"_acme-challenge.noop","rrset_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/records/_acme-challenge.noop/TXT","rrset_values":["\"challengetoken\""]}'
     headers:
-      accept-ranges:
+      Accept-Ranges:
       - bytes
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '217'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:32 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:32 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:32 GMT
-      pragma:
+      Content-Length:
+      - '210'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:22 GMT
+      ETag:
+      - W/"d2-Oj3sMSmReSrP+eeHLEWPg5vhT+M"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:22 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:22 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
     status:
       code: 200

--- a/tests/fixtures/cassettes/gandi/REST-IntegrationTests/test_provider_when_calling_delete_record_by_filter_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/gandi/REST-IntegrationTests/test_provider_when_calling_delete_record_by_filter_should_remove_record.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -13,59 +13,58 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr
   response:
     body:
-      string: !!python/unicode '{"zone_uuid": "4fd93cb0-5c6c-11e8-b297-00163ee24379",
-        "domain_keys_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/keys",
-        "fqdn": "t18s.fr", "zone_href": "https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379",
-        "zone_records_href": "https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379/records",
-        "domain_records_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records",
-        "domain_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr"}'
+      string: '{"domain_keys_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/keys","fqdn":"t18s.fr","automatic_snapshots":true,"domain_records_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/records","domain_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr"}'
     headers:
-      accept-ranges:
+      Accept-Ranges:
       - bytes
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '499'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:32 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:32 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:32 GMT
-      pragma:
+      Content-Length:
+      - '274'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:22 GMT
+      ETag:
+      - W/"112-tyQllSkZqMzGHTaisDLSgpwZtfY"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:22 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:22 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -78,45 +77,45 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/delete.testfilt/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/delete.testfilt/TXT
   response:
     body:
-      string: !!python/unicode '{"code": 404, "message": "Can''t find the DNS record
-        delete.testfilt/TXT in the zone", "object": "dns-record", "cause": "Not Found"}'
+      string: '{"code": 404, "message": "Can''t find the DNS record delete.testfilt/TXT
+        in the zone", "object": "dns-record", "cause": "Not Found"}'
     headers:
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
+      Content-Length:
       - '131'
-      content-type:
+      Content-Type:
       - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:33 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:33 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:33 GMT
-      pragma:
+      Date:
+      - Thu, 22 Oct 2020 21:23:23 GMT
+      Expires:
+      - Thu, 22 Oct 2020 21:23:23 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:23 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      via:
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
     status:
       code: 404
       message: Not Found
 - request:
-    body: !!python/unicode '{"rrset_values": ["challengetoken"], "rrset_ttl": 3600}'
+    body: '{"rrset_values": ["challengetoken"], "rrset_ttl": 3600}'
     headers:
       Accept:
       - application/json
@@ -129,54 +128,58 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: POST
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/delete.testfilt/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/delete.testfilt/TXT
   response:
     body:
-      string: !!python/unicode '{"message": "DNS Record Created"}'
+      string: '{"message":"DNS Record Created"}'
     headers:
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '33'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:33 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:33 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:33 GMT
-      location:
-      - https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379/records/delete.testfilt/TXT
-      pragma:
+      Content-Length:
+      - '32'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:24 GMT
+      ETag:
+      - W/"20-8GzTjxqNVdrkc6ay0Gf8zJRLVdc"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:24 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:24 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
+      location:
+      - https://api.gandi.net/v5/livedns/domains/t18s.fr/records/delete.testfilt/TXT
     status:
       code: 201
       message: Created
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -189,56 +192,58 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/delete.testfilt/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/delete.testfilt/TXT
   response:
     body:
-      string: !!python/unicode '{"rrset_type": "TXT", "rrset_ttl": 3600, "rrset_name":
-        "delete.testfilt", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/delete.testfilt/TXT",
-        "rrset_values": ["\"challengetoken\""]}'
+      string: '{"rrset_type":"TXT","rrset_ttl":3600,"rrset_name":"delete.testfilt","rrset_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/records/delete.testfilt/TXT","rrset_values":["\"challengetoken\""]}'
     headers:
-      accept-ranges:
+      Accept-Ranges:
       - bytes
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '207'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:34 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:34 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:34 GMT
-      pragma:
+      Content-Length:
+      - '200'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:25 GMT
+      ETag:
+      - W/"c8-sLHRkRDNnpv/RWzojJe7lPQ2ufc"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:25 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:25 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -251,48 +256,50 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: DELETE
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/delete.testfilt/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/delete.testfilt/TXT
   response:
     body:
-      string: !!python/unicode ''
+      string: ''
     headers:
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      date:
-      - Fri, 29 Mar 2019 20:34:34 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:34 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:34 GMT
-      pragma:
+      Date:
+      - Thu, 22 Oct 2020 21:23:26 GMT
+      Expires:
+      - Thu, 22 Oct 2020 21:23:26 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:26 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
     status:
       code: 204
       message: No Content
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -305,39 +312,39 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/delete.testfilt/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/delete.testfilt/TXT
   response:
     body:
-      string: !!python/unicode '{"code": 404, "message": "Can''t find the DNS record
-        delete.testfilt/TXT in the zone", "object": "dns-record", "cause": "Not Found"}'
+      string: '{"code": 404, "message": "Can''t find the DNS record delete.testfilt/TXT
+        in the zone", "object": "dns-record", "cause": "Not Found"}'
     headers:
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
+      Content-Length:
       - '131'
-      content-type:
+      Content-Type:
       - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:35 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:35 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:35 GMT
-      pragma:
+      Date:
+      - Thu, 22 Oct 2020 21:23:26 GMT
+      Expires:
+      - Thu, 22 Oct 2020 21:23:26 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:26 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      via:
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
     status:
       code: 404

--- a/tests/fixtures/cassettes/gandi/REST-IntegrationTests/test_provider_when_calling_delete_record_by_filter_with_fqdn_name_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/gandi/REST-IntegrationTests/test_provider_when_calling_delete_record_by_filter_with_fqdn_name_should_remove_record.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -13,59 +13,58 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr
   response:
     body:
-      string: !!python/unicode '{"zone_uuid": "4fd93cb0-5c6c-11e8-b297-00163ee24379",
-        "domain_keys_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/keys",
-        "fqdn": "t18s.fr", "zone_href": "https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379",
-        "zone_records_href": "https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379/records",
-        "domain_records_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records",
-        "domain_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr"}'
+      string: '{"domain_keys_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/keys","fqdn":"t18s.fr","automatic_snapshots":true,"domain_records_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/records","domain_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr"}'
     headers:
-      accept-ranges:
+      Accept-Ranges:
       - bytes
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '499'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:35 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:35 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:35 GMT
-      pragma:
+      Content-Length:
+      - '274'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:26 GMT
+      ETag:
+      - W/"112-tyQllSkZqMzGHTaisDLSgpwZtfY"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:26 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:26 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -78,45 +77,45 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/delete.testfqdn/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/delete.testfqdn/TXT
   response:
     body:
-      string: !!python/unicode '{"code": 404, "message": "Can''t find the DNS record
-        delete.testfqdn/TXT in the zone", "object": "dns-record", "cause": "Not Found"}'
+      string: '{"code": 404, "message": "Can''t find the DNS record delete.testfqdn/TXT
+        in the zone", "object": "dns-record", "cause": "Not Found"}'
     headers:
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
+      Content-Length:
       - '131'
-      content-type:
+      Content-Type:
       - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:36 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:36 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:36 GMT
-      pragma:
+      Date:
+      - Thu, 22 Oct 2020 21:23:26 GMT
+      Expires:
+      - Thu, 22 Oct 2020 21:23:26 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:26 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      via:
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
     status:
       code: 404
       message: Not Found
 - request:
-    body: !!python/unicode '{"rrset_values": ["challengetoken"], "rrset_ttl": 3600}'
+    body: '{"rrset_values": ["challengetoken"], "rrset_ttl": 3600}'
     headers:
       Accept:
       - application/json
@@ -129,54 +128,58 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: POST
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/delete.testfqdn/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/delete.testfqdn/TXT
   response:
     body:
-      string: !!python/unicode '{"message": "DNS Record Created"}'
+      string: '{"message":"DNS Record Created"}'
     headers:
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '33'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:36 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:36 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:36 GMT
-      location:
-      - https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379/records/delete.testfqdn/TXT
-      pragma:
+      Content-Length:
+      - '32'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:27 GMT
+      ETag:
+      - W/"20-8GzTjxqNVdrkc6ay0Gf8zJRLVdc"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:27 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:27 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
+      location:
+      - https://api.gandi.net/v5/livedns/domains/t18s.fr/records/delete.testfqdn/TXT
     status:
       code: 201
       message: Created
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -189,56 +192,58 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/delete.testfqdn/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/delete.testfqdn/TXT
   response:
     body:
-      string: !!python/unicode '{"rrset_type": "TXT", "rrset_ttl": 3600, "rrset_name":
-        "delete.testfqdn", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/delete.testfqdn/TXT",
-        "rrset_values": ["\"challengetoken\""]}'
+      string: '{"rrset_type":"TXT","rrset_ttl":3600,"rrset_name":"delete.testfqdn","rrset_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/records/delete.testfqdn/TXT","rrset_values":["\"challengetoken\""]}'
     headers:
-      accept-ranges:
+      Accept-Ranges:
       - bytes
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '207'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:36 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:36 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:36 GMT
-      pragma:
+      Content-Length:
+      - '200'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:27 GMT
+      ETag:
+      - W/"c8-F0DEG0FusxQOLtZr3ALSRwkco3k"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:27 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:27 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -251,48 +256,50 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: DELETE
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/delete.testfqdn/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/delete.testfqdn/TXT
   response:
     body:
-      string: !!python/unicode ''
+      string: ''
     headers:
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      date:
-      - Fri, 29 Mar 2019 20:34:37 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:37 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:37 GMT
-      pragma:
+      Date:
+      - Thu, 22 Oct 2020 21:23:28 GMT
+      Expires:
+      - Thu, 22 Oct 2020 21:23:28 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:28 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
     status:
       code: 204
       message: No Content
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -305,39 +312,39 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/delete.testfqdn/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/delete.testfqdn/TXT
   response:
     body:
-      string: !!python/unicode '{"code": 404, "message": "Can''t find the DNS record
-        delete.testfqdn/TXT in the zone", "object": "dns-record", "cause": "Not Found"}'
+      string: '{"code": 404, "message": "Can''t find the DNS record delete.testfqdn/TXT
+        in the zone", "object": "dns-record", "cause": "Not Found"}'
     headers:
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
+      Content-Length:
       - '131'
-      content-type:
+      Content-Type:
       - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:37 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:37 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:37 GMT
-      pragma:
+      Date:
+      - Thu, 22 Oct 2020 21:23:28 GMT
+      Expires:
+      - Thu, 22 Oct 2020 21:23:28 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:28 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      via:
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
     status:
       code: 404

--- a/tests/fixtures/cassettes/gandi/REST-IntegrationTests/test_provider_when_calling_delete_record_by_filter_with_full_name_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/gandi/REST-IntegrationTests/test_provider_when_calling_delete_record_by_filter_with_full_name_should_remove_record.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -13,59 +13,58 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr
   response:
     body:
-      string: !!python/unicode '{"zone_uuid": "4fd93cb0-5c6c-11e8-b297-00163ee24379",
-        "domain_keys_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/keys",
-        "fqdn": "t18s.fr", "zone_href": "https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379",
-        "zone_records_href": "https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379/records",
-        "domain_records_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records",
-        "domain_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr"}'
+      string: '{"domain_keys_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/keys","fqdn":"t18s.fr","automatic_snapshots":true,"domain_records_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/records","domain_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr"}'
     headers:
-      accept-ranges:
+      Accept-Ranges:
       - bytes
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '499'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:38 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:38 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:38 GMT
-      pragma:
+      Content-Length:
+      - '274'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:28 GMT
+      ETag:
+      - W/"112-tyQllSkZqMzGHTaisDLSgpwZtfY"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:28 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:28 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -78,45 +77,45 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/delete.testfull/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/delete.testfull/TXT
   response:
     body:
-      string: !!python/unicode '{"code": 404, "message": "Can''t find the DNS record
-        delete.testfull/TXT in the zone", "object": "dns-record", "cause": "Not Found"}'
+      string: '{"code": 404, "message": "Can''t find the DNS record delete.testfull/TXT
+        in the zone", "object": "dns-record", "cause": "Not Found"}'
     headers:
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
+      Content-Length:
       - '131'
-      content-type:
+      Content-Type:
       - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:38 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:38 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:38 GMT
-      pragma:
+      Date:
+      - Thu, 22 Oct 2020 21:23:29 GMT
+      Expires:
+      - Thu, 22 Oct 2020 21:23:29 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:29 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      via:
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
     status:
       code: 404
       message: Not Found
 - request:
-    body: !!python/unicode '{"rrset_values": ["challengetoken"], "rrset_ttl": 3600}'
+    body: '{"rrset_values": ["challengetoken"], "rrset_ttl": 3600}'
     headers:
       Accept:
       - application/json
@@ -129,54 +128,58 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: POST
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/delete.testfull/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/delete.testfull/TXT
   response:
     body:
-      string: !!python/unicode '{"message": "DNS Record Created"}'
+      string: '{"message":"DNS Record Created"}'
     headers:
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '33'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:39 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:39 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:39 GMT
-      location:
-      - https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379/records/delete.testfull/TXT
-      pragma:
+      Content-Length:
+      - '32'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:29 GMT
+      ETag:
+      - W/"20-8GzTjxqNVdrkc6ay0Gf8zJRLVdc"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:29 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:29 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
+      location:
+      - https://api.gandi.net/v5/livedns/domains/t18s.fr/records/delete.testfull/TXT
     status:
       code: 201
       message: Created
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -189,56 +192,58 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/delete.testfull/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/delete.testfull/TXT
   response:
     body:
-      string: !!python/unicode '{"rrset_type": "TXT", "rrset_ttl": 3600, "rrset_name":
-        "delete.testfull", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/delete.testfull/TXT",
-        "rrset_values": ["\"challengetoken\""]}'
+      string: '{"rrset_type":"TXT","rrset_ttl":3600,"rrset_name":"delete.testfull","rrset_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/records/delete.testfull/TXT","rrset_values":["\"challengetoken\""]}'
     headers:
-      accept-ranges:
+      Accept-Ranges:
       - bytes
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '207'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:39 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:39 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:39 GMT
-      pragma:
+      Content-Length:
+      - '200'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:30 GMT
+      ETag:
+      - W/"c8-wQZ7GUaswtvAbLvqAjX13QrbBTg"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:30 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:30 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -251,48 +256,50 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: DELETE
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/delete.testfull/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/delete.testfull/TXT
   response:
     body:
-      string: !!python/unicode ''
+      string: ''
     headers:
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      date:
-      - Fri, 29 Mar 2019 20:34:40 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:40 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:40 GMT
-      pragma:
+      Date:
+      - Thu, 22 Oct 2020 21:23:30 GMT
+      Expires:
+      - Thu, 22 Oct 2020 21:23:30 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:30 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
     status:
       code: 204
       message: No Content
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -305,39 +312,39 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/delete.testfull/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/delete.testfull/TXT
   response:
     body:
-      string: !!python/unicode '{"code": 404, "message": "Can''t find the DNS record
-        delete.testfull/TXT in the zone", "object": "dns-record", "cause": "Not Found"}'
+      string: '{"code": 404, "message": "Can''t find the DNS record delete.testfull/TXT
+        in the zone", "object": "dns-record", "cause": "Not Found"}'
     headers:
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
+      Content-Length:
       - '131'
-      content-type:
+      Content-Type:
       - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:40 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:40 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:40 GMT
-      pragma:
+      Date:
+      - Thu, 22 Oct 2020 21:23:30 GMT
+      Expires:
+      - Thu, 22 Oct 2020 21:23:30 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:30 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      via:
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
     status:
       code: 404

--- a/tests/fixtures/cassettes/gandi/REST-IntegrationTests/test_provider_when_calling_delete_record_by_identifier_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/gandi/REST-IntegrationTests/test_provider_when_calling_delete_record_by_identifier_should_remove_record.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -13,59 +13,58 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr
   response:
     body:
-      string: !!python/unicode '{"zone_uuid": "4fd93cb0-5c6c-11e8-b297-00163ee24379",
-        "domain_keys_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/keys",
-        "fqdn": "t18s.fr", "zone_href": "https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379",
-        "zone_records_href": "https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379/records",
-        "domain_records_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records",
-        "domain_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr"}'
+      string: '{"domain_keys_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/keys","fqdn":"t18s.fr","automatic_snapshots":true,"domain_records_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/records","domain_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr"}'
     headers:
-      accept-ranges:
+      Accept-Ranges:
       - bytes
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '499'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:41 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:41 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:41 GMT
-      pragma:
+      Content-Length:
+      - '274'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:31 GMT
+      ETag:
+      - W/"112-tyQllSkZqMzGHTaisDLSgpwZtfY"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:31 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:31 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -78,45 +77,45 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/delete.testid/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/delete.testid/TXT
   response:
     body:
-      string: !!python/unicode '{"code": 404, "message": "Can''t find the DNS record
-        delete.testid/TXT in the zone", "object": "dns-record", "cause": "Not Found"}'
+      string: '{"code": 404, "message": "Can''t find the DNS record delete.testid/TXT
+        in the zone", "object": "dns-record", "cause": "Not Found"}'
     headers:
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
+      Content-Length:
       - '129'
-      content-type:
+      Content-Type:
       - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:41 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:41 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:41 GMT
-      pragma:
+      Date:
+      - Thu, 22 Oct 2020 21:23:31 GMT
+      Expires:
+      - Thu, 22 Oct 2020 21:23:31 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:31 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      via:
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
     status:
       code: 404
       message: Not Found
 - request:
-    body: !!python/unicode '{"rrset_values": ["challengetoken"], "rrset_ttl": 3600}'
+    body: '{"rrset_values": ["challengetoken"], "rrset_ttl": 3600}'
     headers:
       Accept:
       - application/json
@@ -129,54 +128,58 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: POST
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/delete.testid/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/delete.testid/TXT
   response:
     body:
-      string: !!python/unicode '{"message": "DNS Record Created"}'
+      string: '{"message":"DNS Record Created"}'
     headers:
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '33'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:42 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:42 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:42 GMT
-      location:
-      - https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379/records/delete.testid/TXT
-      pragma:
+      Content-Length:
+      - '32'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:32 GMT
+      ETag:
+      - W/"20-8GzTjxqNVdrkc6ay0Gf8zJRLVdc"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:32 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:32 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
+      location:
+      - https://api.gandi.net/v5/livedns/domains/t18s.fr/records/delete.testid/TXT
     status:
       code: 201
       message: Created
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -189,56 +192,58 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/delete.testid/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/delete.testid/TXT
   response:
     body:
-      string: !!python/unicode '{"rrset_type": "TXT", "rrset_ttl": 3600, "rrset_name":
-        "delete.testid", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/delete.testid/TXT",
-        "rrset_values": ["\"challengetoken\""]}'
+      string: '{"rrset_type":"TXT","rrset_ttl":3600,"rrset_name":"delete.testid","rrset_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/records/delete.testid/TXT","rrset_values":["\"challengetoken\""]}'
     headers:
-      accept-ranges:
+      Accept-Ranges:
       - bytes
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '203'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:42 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:42 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:42 GMT
-      pragma:
+      Content-Length:
+      - '196'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:32 GMT
+      ETag:
+      - W/"c4-l2/SHYBCjjnP+qDFNtqvHnZJIvk"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:32 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:32 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -251,48 +256,50 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: DELETE
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/delete.testid
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/delete.testid
   response:
     body:
-      string: !!python/unicode ''
+      string: ''
     headers:
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      date:
-      - Fri, 29 Mar 2019 20:34:43 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:43 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:43 GMT
-      pragma:
+      Date:
+      - Thu, 22 Oct 2020 21:23:32 GMT
+      Expires:
+      - Thu, 22 Oct 2020 21:23:32 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:32 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
     status:
       code: 204
       message: No Content
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -305,39 +312,39 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/delete.testid/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/delete.testid/TXT
   response:
     body:
-      string: !!python/unicode '{"code": 404, "message": "Can''t find the DNS record
-        delete.testid/TXT in the zone", "object": "dns-record", "cause": "Not Found"}'
+      string: '{"code": 404, "message": "Can''t find the DNS record delete.testid/TXT
+        in the zone", "object": "dns-record", "cause": "Not Found"}'
     headers:
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
+      Content-Length:
       - '129'
-      content-type:
+      Content-Type:
       - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:43 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:43 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:43 GMT
-      pragma:
+      Date:
+      - Thu, 22 Oct 2020 21:23:33 GMT
+      Expires:
+      - Thu, 22 Oct 2020 21:23:33 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:33 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      via:
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
     status:
       code: 404

--- a/tests/fixtures/cassettes/gandi/REST-IntegrationTests/test_provider_when_calling_delete_record_with_record_set_by_content_should_leave_others_untouched.yaml
+++ b/tests/fixtures/cassettes/gandi/REST-IntegrationTests/test_provider_when_calling_delete_record_with_record_set_by_content_should_leave_others_untouched.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -13,59 +13,58 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr
   response:
     body:
-      string: !!python/unicode '{"zone_uuid": "4fd93cb0-5c6c-11e8-b297-00163ee24379",
-        "domain_keys_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/keys",
-        "fqdn": "t18s.fr", "zone_href": "https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379",
-        "zone_records_href": "https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379/records",
-        "domain_records_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records",
-        "domain_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr"}'
+      string: '{"domain_keys_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/keys","fqdn":"t18s.fr","automatic_snapshots":true,"domain_records_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/records","domain_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr"}'
     headers:
-      accept-ranges:
+      Accept-Ranges:
       - bytes
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '499'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:44 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:44 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:44 GMT
-      pragma:
+      Content-Length:
+      - '274'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:33 GMT
+      ETag:
+      - W/"112-tyQllSkZqMzGHTaisDLSgpwZtfY"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:33 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:33 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -78,46 +77,45 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/_acme-challenge.deleterecordinset/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/_acme-challenge.deleterecordinset/TXT
   response:
     body:
-      string: !!python/unicode '{"code": 404, "message": "Can''t find the DNS record
-        _acme-challenge.deleterecordinset/TXT in the zone", "object": "dns-record",
-        "cause": "Not Found"}'
+      string: '{"code": 404, "message": "Can''t find the DNS record _acme-challenge.deleterecordinset/TXT
+        in the zone", "object": "dns-record", "cause": "Not Found"}'
     headers:
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
+      Content-Length:
       - '149'
-      content-type:
+      Content-Type:
       - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:44 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:44 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:44 GMT
-      pragma:
+      Date:
+      - Thu, 22 Oct 2020 21:23:34 GMT
+      Expires:
+      - Thu, 22 Oct 2020 21:23:34 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:34 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      via:
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
     status:
       code: 404
       message: Not Found
 - request:
-    body: !!python/unicode '{"rrset_values": ["challengetoken1"], "rrset_ttl": 3600}'
+    body: '{"rrset_values": ["challengetoken1"], "rrset_ttl": 3600}'
     headers:
       Accept:
       - application/json
@@ -130,54 +128,58 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: POST
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/_acme-challenge.deleterecordinset/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/_acme-challenge.deleterecordinset/TXT
   response:
     body:
-      string: !!python/unicode '{"message": "DNS Record Created"}'
+      string: '{"message":"DNS Record Created"}'
     headers:
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '33'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:45 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:45 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:45 GMT
-      location:
-      - https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379/records/_acme-challenge.deleterecordinset/TXT
-      pragma:
+      Content-Length:
+      - '32'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:34 GMT
+      ETag:
+      - W/"20-8GzTjxqNVdrkc6ay0Gf8zJRLVdc"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:34 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:34 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
+      location:
+      - https://api.gandi.net/v5/livedns/domains/t18s.fr/records/_acme-challenge.deleterecordinset/TXT
     status:
       code: 201
       message: Created
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -190,56 +192,58 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/_acme-challenge.deleterecordinset/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/_acme-challenge.deleterecordinset/TXT
   response:
     body:
-      string: !!python/unicode '{"rrset_type": "TXT", "rrset_ttl": 3600, "rrset_name":
-        "_acme-challenge.deleterecordinset", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/_acme-challenge.deleterecordinset/TXT",
-        "rrset_values": ["\"challengetoken1\""]}'
+      string: '{"rrset_type":"TXT","rrset_ttl":3600,"rrset_name":"_acme-challenge.deleterecordinset","rrset_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/records/_acme-challenge.deleterecordinset/TXT","rrset_values":["\"challengetoken1\""]}'
     headers:
-      accept-ranges:
+      Accept-Ranges:
       - bytes
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '244'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:45 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:45 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:45 GMT
-      pragma:
+      Content-Length:
+      - '237'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:34 GMT
+      ETag:
+      - W/"ed-G4NdXXozdEKGk0r1aiTlmeK08C0"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:34 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:34 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: !!python/unicode '{"rrset_values": ["challengetoken1", "challengetoken2"]}'
+    body: '{"rrset_values": ["challengetoken1", "challengetoken2"], "rrset_ttl": 3600}'
     headers:
       Accept:
       - application/json
@@ -248,58 +252,62 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '56'
+      - '75'
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: PUT
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/_acme-challenge.deleterecordinset/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/_acme-challenge.deleterecordinset/TXT
   response:
     body:
-      string: !!python/unicode '{"message": "DNS Record Created"}'
+      string: '{"message":"DNS Record Created"}'
     headers:
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '33'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:46 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:46 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:46 GMT
-      location:
-      - https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379/records/_acme-challenge.deleterecordinset/TXT
-      pragma:
+      Content-Length:
+      - '32'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:35 GMT
+      ETag:
+      - W/"20-8GzTjxqNVdrkc6ay0Gf8zJRLVdc"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:35 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:35 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
+      location:
+      - https://api.gandi.net/v5/livedns/domains/t18s.fr/records/_acme-challenge.deleterecordinset/TXT
     status:
       code: 201
       message: Created
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -312,56 +320,58 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/_acme-challenge.deleterecordinset/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/_acme-challenge.deleterecordinset/TXT
   response:
     body:
-      string: !!python/unicode '{"rrset_type": "TXT", "rrset_ttl": 10800, "rrset_name":
-        "_acme-challenge.deleterecordinset", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/_acme-challenge.deleterecordinset/TXT",
-        "rrset_values": ["\"challengetoken1\"", "\"challengetoken2\""]}'
+      string: '{"rrset_type":"TXT","rrset_ttl":3600,"rrset_name":"_acme-challenge.deleterecordinset","rrset_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/records/_acme-challenge.deleterecordinset/TXT","rrset_values":["\"challengetoken1\"","\"challengetoken2\""]}'
     headers:
-      accept-ranges:
+      Accept-Ranges:
       - bytes
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '268'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:47 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:47 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:47 GMT
-      pragma:
+      Content-Length:
+      - '259'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:35 GMT
+      ETag:
+      - W/"103-tkP+gn7HthelwtqmUr6l/sBQl+A"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:35 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:35 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: !!python/unicode '{"rrset_values": ["challengetoken2"]}'
+    body: '{"rrset_values": ["challengetoken2"]}'
     headers:
       Accept:
       - application/json
@@ -374,54 +384,58 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: PUT
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/_acme-challenge.deleterecordinset/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/_acme-challenge.deleterecordinset/TXT
   response:
     body:
-      string: !!python/unicode '{"message": "DNS Record Created"}'
+      string: '{"message":"DNS Record Created"}'
     headers:
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '33'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:47 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:47 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:47 GMT
-      location:
-      - https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379/records/_acme-challenge.deleterecordinset/TXT
-      pragma:
+      Content-Length:
+      - '32'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:36 GMT
+      ETag:
+      - W/"20-8GzTjxqNVdrkc6ay0Gf8zJRLVdc"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:36 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:36 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
+      location:
+      - https://api.gandi.net/v5/livedns/domains/t18s.fr/records/_acme-challenge.deleterecordinset/TXT
     status:
       code: 201
       message: Created
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -434,50 +448,52 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/_acme-challenge.deleterecordinset/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/_acme-challenge.deleterecordinset/TXT
   response:
     body:
-      string: !!python/unicode '{"rrset_type": "TXT", "rrset_ttl": 10800, "rrset_name":
-        "_acme-challenge.deleterecordinset", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/_acme-challenge.deleterecordinset/TXT",
-        "rrset_values": ["\"challengetoken2\""]}'
+      string: '{"rrset_type":"TXT","rrset_ttl":10800,"rrset_name":"_acme-challenge.deleterecordinset","rrset_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/records/_acme-challenge.deleterecordinset/TXT","rrset_values":["\"challengetoken2\""]}'
     headers:
-      accept-ranges:
+      Accept-Ranges:
       - bytes
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '245'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:48 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:48 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:48 GMT
-      pragma:
+      Content-Length:
+      - '238'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:36 GMT
+      ETag:
+      - W/"ee-ZMs5JqBYpowpbI8aCz6uw7Ktsgo"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:36 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:36 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
     status:
       code: 200

--- a/tests/fixtures/cassettes/gandi/REST-IntegrationTests/test_provider_when_calling_delete_record_with_record_set_name_remove_all.yaml
+++ b/tests/fixtures/cassettes/gandi/REST-IntegrationTests/test_provider_when_calling_delete_record_with_record_set_name_remove_all.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -13,59 +13,58 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr
   response:
     body:
-      string: !!python/unicode '{"zone_uuid": "4fd93cb0-5c6c-11e8-b297-00163ee24379",
-        "domain_keys_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/keys",
-        "fqdn": "t18s.fr", "zone_href": "https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379",
-        "zone_records_href": "https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379/records",
-        "domain_records_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records",
-        "domain_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr"}'
+      string: '{"domain_keys_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/keys","fqdn":"t18s.fr","automatic_snapshots":true,"domain_records_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/records","domain_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr"}'
     headers:
-      accept-ranges:
+      Accept-Ranges:
       - bytes
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '499'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:48 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:48 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:48 GMT
-      pragma:
+      Content-Length:
+      - '274'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:36 GMT
+      ETag:
+      - W/"112-tyQllSkZqMzGHTaisDLSgpwZtfY"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:36 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:36 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -78,46 +77,45 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/_acme-challenge.deleterecordset/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/_acme-challenge.deleterecordset/TXT
   response:
     body:
-      string: !!python/unicode '{"code": 404, "message": "Can''t find the DNS record
-        _acme-challenge.deleterecordset/TXT in the zone", "object": "dns-record",
-        "cause": "Not Found"}'
+      string: '{"code": 404, "message": "Can''t find the DNS record _acme-challenge.deleterecordset/TXT
+        in the zone", "object": "dns-record", "cause": "Not Found"}'
     headers:
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
+      Content-Length:
       - '147'
-      content-type:
+      Content-Type:
       - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:49 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:49 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:49 GMT
-      pragma:
+      Date:
+      - Thu, 22 Oct 2020 21:23:37 GMT
+      Expires:
+      - Thu, 22 Oct 2020 21:23:37 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:37 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      via:
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
     status:
       code: 404
       message: Not Found
 - request:
-    body: !!python/unicode '{"rrset_values": ["challengetoken1"], "rrset_ttl": 3600}'
+    body: '{"rrset_values": ["challengetoken1"], "rrset_ttl": 3600}'
     headers:
       Accept:
       - application/json
@@ -130,54 +128,58 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: POST
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/_acme-challenge.deleterecordset/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/_acme-challenge.deleterecordset/TXT
   response:
     body:
-      string: !!python/unicode '{"message": "DNS Record Created"}'
+      string: '{"message":"DNS Record Created"}'
     headers:
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '33'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:49 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:49 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:49 GMT
-      location:
-      - https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379/records/_acme-challenge.deleterecordset/TXT
-      pragma:
+      Content-Length:
+      - '32'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:38 GMT
+      ETag:
+      - W/"20-8GzTjxqNVdrkc6ay0Gf8zJRLVdc"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:38 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:38 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
+      location:
+      - https://api.gandi.net/v5/livedns/domains/t18s.fr/records/_acme-challenge.deleterecordset/TXT
     status:
       code: 201
       message: Created
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -190,56 +192,58 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/_acme-challenge.deleterecordset/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/_acme-challenge.deleterecordset/TXT
   response:
     body:
-      string: !!python/unicode '{"rrset_type": "TXT", "rrset_ttl": 3600, "rrset_name":
-        "_acme-challenge.deleterecordset", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/_acme-challenge.deleterecordset/TXT",
-        "rrset_values": ["\"challengetoken1\""]}'
+      string: '{"rrset_type":"TXT","rrset_ttl":3600,"rrset_name":"_acme-challenge.deleterecordset","rrset_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/records/_acme-challenge.deleterecordset/TXT","rrset_values":["\"challengetoken1\""]}'
     headers:
-      accept-ranges:
+      Accept-Ranges:
       - bytes
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '240'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:50 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:50 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:50 GMT
-      pragma:
+      Content-Length:
+      - '233'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:38 GMT
+      ETag:
+      - W/"e9-fJq8PPKAEjf1dx3Y+OmyEh2kMS4"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:38 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:38 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: !!python/unicode '{"rrset_values": ["challengetoken1", "challengetoken2"]}'
+    body: '{"rrset_values": ["challengetoken1", "challengetoken2"], "rrset_ttl": 3600}'
     headers:
       Accept:
       - application/json
@@ -248,58 +252,62 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '56'
+      - '75'
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: PUT
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/_acme-challenge.deleterecordset/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/_acme-challenge.deleterecordset/TXT
   response:
     body:
-      string: !!python/unicode '{"message": "DNS Record Created"}'
+      string: '{"message":"DNS Record Created"}'
     headers:
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '33'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:50 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:50 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:50 GMT
-      location:
-      - https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379/records/_acme-challenge.deleterecordset/TXT
-      pragma:
+      Content-Length:
+      - '32'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:38 GMT
+      ETag:
+      - W/"20-8GzTjxqNVdrkc6ay0Gf8zJRLVdc"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:38 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:38 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
+      location:
+      - https://api.gandi.net/v5/livedns/domains/t18s.fr/records/_acme-challenge.deleterecordset/TXT
     status:
       code: 201
       message: Created
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -312,56 +320,58 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/_acme-challenge.deleterecordset/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/_acme-challenge.deleterecordset/TXT
   response:
     body:
-      string: !!python/unicode '{"rrset_type": "TXT", "rrset_ttl": 10800, "rrset_name":
-        "_acme-challenge.deleterecordset", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/_acme-challenge.deleterecordset/TXT",
-        "rrset_values": ["\"challengetoken1\"", "\"challengetoken2\""]}'
+      string: '{"rrset_type":"TXT","rrset_ttl":3600,"rrset_name":"_acme-challenge.deleterecordset","rrset_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/records/_acme-challenge.deleterecordset/TXT","rrset_values":["\"challengetoken1\"","\"challengetoken2\""]}'
     headers:
-      accept-ranges:
+      Accept-Ranges:
       - bytes
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '264'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:51 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:51 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:51 GMT
-      pragma:
+      Content-Length:
+      - '255'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:38 GMT
+      ETag:
+      - W/"ff-83u7Fq3bGDeGA96hxlVHAj8oYHw"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:38 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:38 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -374,48 +384,50 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: DELETE
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/_acme-challenge.deleterecordset/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/_acme-challenge.deleterecordset/TXT
   response:
     body:
-      string: !!python/unicode ''
+      string: ''
     headers:
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      date:
-      - Fri, 29 Mar 2019 20:34:51 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:51 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:51 GMT
-      pragma:
+      Date:
+      - Thu, 22 Oct 2020 21:23:39 GMT
+      Expires:
+      - Thu, 22 Oct 2020 21:23:39 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:39 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
     status:
       code: 204
       message: No Content
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -428,40 +440,39 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/_acme-challenge.deleterecordset/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/_acme-challenge.deleterecordset/TXT
   response:
     body:
-      string: !!python/unicode '{"code": 404, "message": "Can''t find the DNS record
-        _acme-challenge.deleterecordset/TXT in the zone", "object": "dns-record",
-        "cause": "Not Found"}'
+      string: '{"code": 404, "message": "Can''t find the DNS record _acme-challenge.deleterecordset/TXT
+        in the zone", "object": "dns-record", "cause": "Not Found"}'
     headers:
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
+      Content-Length:
       - '147'
-      content-type:
+      Content-Type:
       - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:52 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:52 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:52 GMT
-      pragma:
+      Date:
+      - Thu, 22 Oct 2020 21:23:39 GMT
+      Expires:
+      - Thu, 22 Oct 2020 21:23:39 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:39 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      via:
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
     status:
       code: 404

--- a/tests/fixtures/cassettes/gandi/REST-IntegrationTests/test_provider_when_calling_list_records_after_setting_ttl.yaml
+++ b/tests/fixtures/cassettes/gandi/REST-IntegrationTests/test_provider_when_calling_list_records_after_setting_ttl.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -13,59 +13,58 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr
   response:
     body:
-      string: !!python/unicode '{"zone_uuid": "4fd93cb0-5c6c-11e8-b297-00163ee24379",
-        "domain_keys_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/keys",
-        "fqdn": "t18s.fr", "zone_href": "https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379",
-        "zone_records_href": "https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379/records",
-        "domain_records_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records",
-        "domain_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr"}'
+      string: '{"domain_keys_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/keys","fqdn":"t18s.fr","automatic_snapshots":true,"domain_records_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/records","domain_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr"}'
     headers:
-      accept-ranges:
+      Accept-Ranges:
       - bytes
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '499'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:52 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:52 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:52 GMT
-      pragma:
+      Content-Length:
+      - '274'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:40 GMT
+      ETag:
+      - W/"112-tyQllSkZqMzGHTaisDLSgpwZtfY"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:40 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:40 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -78,45 +77,45 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/ttl.fqdn/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/ttl.fqdn/TXT
   response:
     body:
-      string: !!python/unicode '{"code": 404, "message": "Can''t find the DNS record
-        ttl.fqdn/TXT in the zone", "object": "dns-record", "cause": "Not Found"}'
+      string: '{"code": 404, "message": "Can''t find the DNS record ttl.fqdn/TXT in
+        the zone", "object": "dns-record", "cause": "Not Found"}'
     headers:
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
+      Content-Length:
       - '124'
-      content-type:
+      Content-Type:
       - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:53 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:53 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:53 GMT
-      pragma:
+      Date:
+      - Thu, 22 Oct 2020 21:23:40 GMT
+      Expires:
+      - Thu, 22 Oct 2020 21:23:40 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:40 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      via:
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
     status:
       code: 404
       message: Not Found
 - request:
-    body: !!python/unicode '{"rrset_values": ["ttlshouldbe3600"], "rrset_ttl": 3600}'
+    body: '{"rrset_values": ["ttlshouldbe3600"], "rrset_ttl": 3600}'
     headers:
       Accept:
       - application/json
@@ -129,54 +128,58 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: POST
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/ttl.fqdn/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/ttl.fqdn/TXT
   response:
     body:
-      string: !!python/unicode '{"message": "DNS Record Created"}'
+      string: '{"message":"DNS Record Created"}'
     headers:
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '33'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:53 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:53 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:53 GMT
-      location:
-      - https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379/records/ttl.fqdn/TXT
-      pragma:
+      Content-Length:
+      - '32'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:40 GMT
+      ETag:
+      - W/"20-8GzTjxqNVdrkc6ay0Gf8zJRLVdc"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:40 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:40 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
+      location:
+      - https://api.gandi.net/v5/livedns/domains/t18s.fr/records/ttl.fqdn/TXT
     status:
       code: 201
       message: Created
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -189,50 +192,52 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/ttl.fqdn/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/ttl.fqdn/TXT
   response:
     body:
-      string: !!python/unicode '{"rrset_type": "TXT", "rrset_ttl": 3600, "rrset_name":
-        "ttl.fqdn", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/ttl.fqdn/TXT",
-        "rrset_values": ["\"ttlshouldbe3600\""]}'
+      string: '{"rrset_type":"TXT","rrset_ttl":3600,"rrset_name":"ttl.fqdn","rrset_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/records/ttl.fqdn/TXT","rrset_values":["\"ttlshouldbe3600\""]}'
     headers:
-      accept-ranges:
+      Accept-Ranges:
       - bytes
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '194'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:54 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:54 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:54 GMT
-      pragma:
+      Content-Length:
+      - '187'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:41 GMT
+      ETag:
+      - W/"bb-zRobgrI9fsJ5ziz2XhxVx9fXVYM"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:41 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:41 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
     status:
       code: 200

--- a/tests/fixtures/cassettes/gandi/REST-IntegrationTests/test_provider_when_calling_list_records_should_handle_record_sets.yaml
+++ b/tests/fixtures/cassettes/gandi/REST-IntegrationTests/test_provider_when_calling_list_records_should_handle_record_sets.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -13,59 +13,58 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr
   response:
     body:
-      string: !!python/unicode '{"zone_uuid": "4fd93cb0-5c6c-11e8-b297-00163ee24379",
-        "domain_keys_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/keys",
-        "fqdn": "t18s.fr", "zone_href": "https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379",
-        "zone_records_href": "https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379/records",
-        "domain_records_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records",
-        "domain_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr"}'
+      string: '{"domain_keys_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/keys","fqdn":"t18s.fr","automatic_snapshots":true,"domain_records_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/records","domain_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr"}'
     headers:
-      accept-ranges:
+      Accept-Ranges:
       - bytes
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '499'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:54 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:54 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:54 GMT
-      pragma:
+      Content-Length:
+      - '274'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:41 GMT
+      ETag:
+      - W/"112-tyQllSkZqMzGHTaisDLSgpwZtfY"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:41 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:41 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -78,46 +77,45 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/_acme-challenge.listrecordset/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/_acme-challenge.listrecordset/TXT
   response:
     body:
-      string: !!python/unicode '{"code": 404, "message": "Can''t find the DNS record
-        _acme-challenge.listrecordset/TXT in the zone", "object": "dns-record", "cause":
-        "Not Found"}'
+      string: '{"code": 404, "message": "Can''t find the DNS record _acme-challenge.listrecordset/TXT
+        in the zone", "object": "dns-record", "cause": "Not Found"}'
     headers:
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
+      Content-Length:
       - '145'
-      content-type:
+      Content-Type:
       - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:55 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:55 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:55 GMT
-      pragma:
+      Date:
+      - Thu, 22 Oct 2020 21:23:42 GMT
+      Expires:
+      - Thu, 22 Oct 2020 21:23:42 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:42 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      via:
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
     status:
       code: 404
       message: Not Found
 - request:
-    body: !!python/unicode '{"rrset_values": ["challengetoken1"], "rrset_ttl": 3600}'
+    body: '{"rrset_values": ["challengetoken1"], "rrset_ttl": 3600}'
     headers:
       Accept:
       - application/json
@@ -130,54 +128,58 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: POST
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/_acme-challenge.listrecordset/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/_acme-challenge.listrecordset/TXT
   response:
     body:
-      string: !!python/unicode '{"message": "DNS Record Created"}'
+      string: '{"message":"DNS Record Created"}'
     headers:
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '33'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:55 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:55 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:55 GMT
-      location:
-      - https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379/records/_acme-challenge.listrecordset/TXT
-      pragma:
+      Content-Length:
+      - '32'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:42 GMT
+      ETag:
+      - W/"20-8GzTjxqNVdrkc6ay0Gf8zJRLVdc"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:42 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:42 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
+      location:
+      - https://api.gandi.net/v5/livedns/domains/t18s.fr/records/_acme-challenge.listrecordset/TXT
     status:
       code: 201
       message: Created
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -190,56 +192,58 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/_acme-challenge.listrecordset/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/_acme-challenge.listrecordset/TXT
   response:
     body:
-      string: !!python/unicode '{"rrset_type": "TXT", "rrset_ttl": 3600, "rrset_name":
-        "_acme-challenge.listrecordset", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/_acme-challenge.listrecordset/TXT",
-        "rrset_values": ["\"challengetoken1\""]}'
+      string: '{"rrset_type":"TXT","rrset_ttl":3600,"rrset_name":"_acme-challenge.listrecordset","rrset_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/records/_acme-challenge.listrecordset/TXT","rrset_values":["\"challengetoken1\""]}'
     headers:
-      accept-ranges:
+      Accept-Ranges:
       - bytes
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '236'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:56 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:56 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:56 GMT
-      pragma:
+      Content-Length:
+      - '229'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:42 GMT
+      ETag:
+      - W/"e5-ci9f9DYv3SQJ2RJF8V+yNqSioWw"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:42 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:42 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: !!python/unicode '{"rrset_values": ["challengetoken1", "challengetoken2"]}'
+    body: '{"rrset_values": ["challengetoken1", "challengetoken2"], "rrset_ttl": 3600}'
     headers:
       Accept:
       - application/json
@@ -248,58 +252,62 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '56'
+      - '75'
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: PUT
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/_acme-challenge.listrecordset/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/_acme-challenge.listrecordset/TXT
   response:
     body:
-      string: !!python/unicode '{"message": "DNS Record Created"}'
+      string: '{"message":"DNS Record Created"}'
     headers:
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '33'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:56 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:56 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:56 GMT
-      location:
-      - https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379/records/_acme-challenge.listrecordset/TXT
-      pragma:
+      Content-Length:
+      - '32'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:43 GMT
+      ETag:
+      - W/"20-8GzTjxqNVdrkc6ay0Gf8zJRLVdc"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:43 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:43 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
+      location:
+      - https://api.gandi.net/v5/livedns/domains/t18s.fr/records/_acme-challenge.listrecordset/TXT
     status:
       code: 201
       message: Created
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -312,50 +320,52 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/_acme-challenge.listrecordset/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/_acme-challenge.listrecordset/TXT
   response:
     body:
-      string: !!python/unicode '{"rrset_type": "TXT", "rrset_ttl": 10800, "rrset_name":
-        "_acme-challenge.listrecordset", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/_acme-challenge.listrecordset/TXT",
-        "rrset_values": ["\"challengetoken1\"", "\"challengetoken2\""]}'
+      string: '{"rrset_type":"TXT","rrset_ttl":3600,"rrset_name":"_acme-challenge.listrecordset","rrset_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/records/_acme-challenge.listrecordset/TXT","rrset_values":["\"challengetoken1\"","\"challengetoken2\""]}'
     headers:
-      accept-ranges:
+      Accept-Ranges:
       - bytes
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '260'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:56 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:56 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:56 GMT
-      pragma:
+      Content-Length:
+      - '251'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:43 GMT
+      ETag:
+      - W/"fb-NjwZGjucQl2vnBQGENwj0kuCmJk"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:43 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:43 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
     status:
       code: 200

--- a/tests/fixtures/cassettes/gandi/REST-IntegrationTests/test_provider_when_calling_list_records_with_fqdn_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/gandi/REST-IntegrationTests/test_provider_when_calling_list_records_with_fqdn_name_filter_should_return_record.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -13,59 +13,58 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr
   response:
     body:
-      string: !!python/unicode '{"zone_uuid": "4fd93cb0-5c6c-11e8-b297-00163ee24379",
-        "domain_keys_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/keys",
-        "fqdn": "t18s.fr", "zone_href": "https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379",
-        "zone_records_href": "https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379/records",
-        "domain_records_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records",
-        "domain_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr"}'
+      string: '{"domain_keys_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/keys","fqdn":"t18s.fr","automatic_snapshots":true,"domain_records_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/records","domain_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr"}'
     headers:
-      accept-ranges:
+      Accept-Ranges:
       - bytes
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '499'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:57 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:57 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:57 GMT
-      pragma:
+      Content-Length:
+      - '274'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:44 GMT
+      ETag:
+      - W/"112-tyQllSkZqMzGHTaisDLSgpwZtfY"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:44 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:44 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -78,45 +77,45 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/random.fqdntest/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/random.fqdntest/TXT
   response:
     body:
-      string: !!python/unicode '{"code": 404, "message": "Can''t find the DNS record
-        random.fqdntest/TXT in the zone", "object": "dns-record", "cause": "Not Found"}'
+      string: '{"code": 404, "message": "Can''t find the DNS record random.fqdntest/TXT
+        in the zone", "object": "dns-record", "cause": "Not Found"}'
     headers:
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
+      Content-Length:
       - '131'
-      content-type:
+      Content-Type:
       - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:58 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:58 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:58 GMT
-      pragma:
+      Date:
+      - Thu, 22 Oct 2020 21:23:44 GMT
+      Expires:
+      - Thu, 22 Oct 2020 21:23:44 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:44 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      via:
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
     status:
       code: 404
       message: Not Found
 - request:
-    body: !!python/unicode '{"rrset_values": ["challengetoken"], "rrset_ttl": 3600}'
+    body: '{"rrset_values": ["challengetoken"], "rrset_ttl": 3600}'
     headers:
       Accept:
       - application/json
@@ -129,54 +128,58 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: POST
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/random.fqdntest/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/random.fqdntest/TXT
   response:
     body:
-      string: !!python/unicode '{"message": "DNS Record Created"}'
+      string: '{"message":"DNS Record Created"}'
     headers:
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '33'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:58 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:58 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:58 GMT
-      location:
-      - https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379/records/random.fqdntest/TXT
-      pragma:
+      Content-Length:
+      - '32'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:45 GMT
+      ETag:
+      - W/"20-8GzTjxqNVdrkc6ay0Gf8zJRLVdc"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:45 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:45 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
+      location:
+      - https://api.gandi.net/v5/livedns/domains/t18s.fr/records/random.fqdntest/TXT
     status:
       code: 201
       message: Created
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -189,50 +192,52 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/random.fqdntest/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/random.fqdntest/TXT
   response:
     body:
-      string: !!python/unicode '{"rrset_type": "TXT", "rrset_ttl": 3600, "rrset_name":
-        "random.fqdntest", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/random.fqdntest/TXT",
-        "rrset_values": ["\"challengetoken\""]}'
+      string: '{"rrset_type":"TXT","rrset_ttl":3600,"rrset_name":"random.fqdntest","rrset_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/records/random.fqdntest/TXT","rrset_values":["\"challengetoken\""]}'
     headers:
-      accept-ranges:
+      Accept-Ranges:
       - bytes
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '207'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:59 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:59 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:59 GMT
-      pragma:
+      Content-Length:
+      - '200'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:45 GMT
+      ETag:
+      - W/"c8-ovPXuEx9z0o3W41nk4AIYU0JPHE"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:45 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:45 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
     status:
       code: 200

--- a/tests/fixtures/cassettes/gandi/REST-IntegrationTests/test_provider_when_calling_list_records_with_full_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/gandi/REST-IntegrationTests/test_provider_when_calling_list_records_with_full_name_filter_should_return_record.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -13,59 +13,58 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr
   response:
     body:
-      string: !!python/unicode '{"zone_uuid": "4fd93cb0-5c6c-11e8-b297-00163ee24379",
-        "domain_keys_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/keys",
-        "fqdn": "t18s.fr", "zone_href": "https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379",
-        "zone_records_href": "https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379/records",
-        "domain_records_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records",
-        "domain_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr"}'
+      string: '{"domain_keys_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/keys","fqdn":"t18s.fr","automatic_snapshots":true,"domain_records_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/records","domain_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr"}'
     headers:
-      accept-ranges:
+      Accept-Ranges:
       - bytes
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '499'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:34:59 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:34:59 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:34:59 GMT
-      pragma:
+      Content-Length:
+      - '274'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:46 GMT
+      ETag:
+      - W/"112-tyQllSkZqMzGHTaisDLSgpwZtfY"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:46 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:46 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -78,45 +77,45 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/random.fulltest/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/random.fulltest/TXT
   response:
     body:
-      string: !!python/unicode '{"code": 404, "message": "Can''t find the DNS record
-        random.fulltest/TXT in the zone", "object": "dns-record", "cause": "Not Found"}'
+      string: '{"code": 404, "message": "Can''t find the DNS record random.fulltest/TXT
+        in the zone", "object": "dns-record", "cause": "Not Found"}'
     headers:
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
+      Content-Length:
       - '131'
-      content-type:
+      Content-Type:
       - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:35:00 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:35:00 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:35:00 GMT
-      pragma:
+      Date:
+      - Thu, 22 Oct 2020 21:23:46 GMT
+      Expires:
+      - Thu, 22 Oct 2020 21:23:46 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:46 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      via:
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
     status:
       code: 404
       message: Not Found
 - request:
-    body: !!python/unicode '{"rrset_values": ["challengetoken"], "rrset_ttl": 3600}'
+    body: '{"rrset_values": ["challengetoken"], "rrset_ttl": 3600}'
     headers:
       Accept:
       - application/json
@@ -129,54 +128,58 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: POST
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/random.fulltest/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/random.fulltest/TXT
   response:
     body:
-      string: !!python/unicode '{"message": "DNS Record Created"}'
+      string: '{"message":"DNS Record Created"}'
     headers:
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '33'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:35:00 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:35:00 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:35:00 GMT
-      location:
-      - https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379/records/random.fulltest/TXT
-      pragma:
+      Content-Length:
+      - '32'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:47 GMT
+      ETag:
+      - W/"20-8GzTjxqNVdrkc6ay0Gf8zJRLVdc"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:47 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:47 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
+      location:
+      - https://api.gandi.net/v5/livedns/domains/t18s.fr/records/random.fulltest/TXT
     status:
       code: 201
       message: Created
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -189,50 +192,52 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/random.fulltest/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/random.fulltest/TXT
   response:
     body:
-      string: !!python/unicode '{"rrset_type": "TXT", "rrset_ttl": 3600, "rrset_name":
-        "random.fulltest", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/random.fulltest/TXT",
-        "rrset_values": ["\"challengetoken\""]}'
+      string: '{"rrset_type":"TXT","rrset_ttl":3600,"rrset_name":"random.fulltest","rrset_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/records/random.fulltest/TXT","rrset_values":["\"challengetoken\""]}'
     headers:
-      accept-ranges:
+      Accept-Ranges:
       - bytes
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '207'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:35:01 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:35:01 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:35:01 GMT
-      pragma:
+      Content-Length:
+      - '200'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:48 GMT
+      ETag:
+      - W/"c8-PIW93N1coxYNOuFMEoiiDqLCuQ4"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:48 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:48 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
     status:
       code: 200

--- a/tests/fixtures/cassettes/gandi/REST-IntegrationTests/test_provider_when_calling_list_records_with_invalid_filter_should_be_empty_list.yaml
+++ b/tests/fixtures/cassettes/gandi/REST-IntegrationTests/test_provider_when_calling_list_records_with_invalid_filter_should_be_empty_list.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -13,59 +13,58 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr
   response:
     body:
-      string: !!python/unicode '{"zone_uuid": "4fd93cb0-5c6c-11e8-b297-00163ee24379",
-        "domain_keys_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/keys",
-        "fqdn": "t18s.fr", "zone_href": "https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379",
-        "zone_records_href": "https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379/records",
-        "domain_records_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records",
-        "domain_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr"}'
+      string: '{"domain_keys_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/keys","fqdn":"t18s.fr","automatic_snapshots":true,"domain_records_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/records","domain_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr"}'
     headers:
-      accept-ranges:
+      Accept-Ranges:
       - bytes
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '499'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:35:02 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:35:02 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:35:02 GMT
-      pragma:
+      Content-Length:
+      - '274'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:49 GMT
+      ETag:
+      - W/"112-tyQllSkZqMzGHTaisDLSgpwZtfY"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:49 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:49 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -78,40 +77,39 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/filter.thisdoesnotexist/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/filter.thisdoesnotexist/TXT
   response:
     body:
-      string: !!python/unicode '{"code": 404, "message": "Can''t find the DNS record
-        filter.thisdoesnotexist/TXT in the zone", "object": "dns-record", "cause":
-        "Not Found"}'
+      string: '{"code": 404, "message": "Can''t find the DNS record filter.thisdoesnotexist/TXT
+        in the zone", "object": "dns-record", "cause": "Not Found"}'
     headers:
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
+      Content-Length:
       - '139'
-      content-type:
+      Content-Type:
       - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:35:04 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:35:04 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:35:04 GMT
-      pragma:
+      Date:
+      - Thu, 22 Oct 2020 21:23:49 GMT
+      Expires:
+      - Thu, 22 Oct 2020 21:23:49 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:49 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      via:
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
     status:
       code: 404

--- a/tests/fixtures/cassettes/gandi/REST-IntegrationTests/test_provider_when_calling_list_records_with_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/gandi/REST-IntegrationTests/test_provider_when_calling_list_records_with_name_filter_should_return_record.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -13,59 +13,58 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr
   response:
     body:
-      string: !!python/unicode '{"zone_uuid": "4fd93cb0-5c6c-11e8-b297-00163ee24379",
-        "domain_keys_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/keys",
-        "fqdn": "t18s.fr", "zone_href": "https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379",
-        "zone_records_href": "https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379/records",
-        "domain_records_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records",
-        "domain_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr"}'
+      string: '{"domain_keys_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/keys","fqdn":"t18s.fr","automatic_snapshots":true,"domain_records_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/records","domain_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr"}'
     headers:
-      accept-ranges:
+      Accept-Ranges:
       - bytes
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '499'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:35:06 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:35:06 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:35:06 GMT
-      pragma:
+      Content-Length:
+      - '274'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:50 GMT
+      ETag:
+      - W/"112-tyQllSkZqMzGHTaisDLSgpwZtfY"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:50 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:50 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -78,45 +77,45 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/random.test/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/random.test/TXT
   response:
     body:
-      string: !!python/unicode '{"code": 404, "message": "Can''t find the DNS record
-        random.test/TXT in the zone", "object": "dns-record", "cause": "Not Found"}'
+      string: '{"code": 404, "message": "Can''t find the DNS record random.test/TXT
+        in the zone", "object": "dns-record", "cause": "Not Found"}'
     headers:
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
+      Content-Length:
       - '127'
-      content-type:
+      Content-Type:
       - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:35:06 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:35:06 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:35:06 GMT
-      pragma:
+      Date:
+      - Thu, 22 Oct 2020 21:23:51 GMT
+      Expires:
+      - Thu, 22 Oct 2020 21:23:51 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:51 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      via:
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
     status:
       code: 404
       message: Not Found
 - request:
-    body: !!python/unicode '{"rrset_values": ["challengetoken"], "rrset_ttl": 3600}'
+    body: '{"rrset_values": ["challengetoken"], "rrset_ttl": 3600}'
     headers:
       Accept:
       - application/json
@@ -129,54 +128,58 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: POST
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/random.test/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/random.test/TXT
   response:
     body:
-      string: !!python/unicode '{"message": "DNS Record Created"}'
+      string: '{"message":"DNS Record Created"}'
     headers:
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '33'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:35:07 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:35:07 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:35:07 GMT
-      location:
-      - https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379/records/random.test/TXT
-      pragma:
+      Content-Length:
+      - '32'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:51 GMT
+      ETag:
+      - W/"20-8GzTjxqNVdrkc6ay0Gf8zJRLVdc"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:51 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:51 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
+      location:
+      - https://api.gandi.net/v5/livedns/domains/t18s.fr/records/random.test/TXT
     status:
       code: 201
       message: Created
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -189,50 +192,52 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/random.test/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/random.test/TXT
   response:
     body:
-      string: !!python/unicode '{"rrset_type": "TXT", "rrset_ttl": 3600, "rrset_name":
-        "random.test", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/random.test/TXT",
-        "rrset_values": ["\"challengetoken\""]}'
+      string: '{"rrset_type":"TXT","rrset_ttl":3600,"rrset_name":"random.test","rrset_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/records/random.test/TXT","rrset_values":["\"challengetoken\""]}'
     headers:
-      accept-ranges:
+      Accept-Ranges:
       - bytes
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '199'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:35:07 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:35:07 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:35:07 GMT
-      pragma:
+      Content-Length:
+      - '192'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:51 GMT
+      ETag:
+      - W/"c0-xLS62tUAb/kgaQWkxSjrsdtjsjA"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:51 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:51 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
     status:
       code: 200

--- a/tests/fixtures/cassettes/gandi/REST-IntegrationTests/test_provider_when_calling_list_records_with_no_arguments_should_list_all.yaml
+++ b/tests/fixtures/cassettes/gandi/REST-IntegrationTests/test_provider_when_calling_list_records_with_no_arguments_should_list_all.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -13,59 +13,58 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr
   response:
     body:
-      string: !!python/unicode '{"zone_uuid": "4fd93cb0-5c6c-11e8-b297-00163ee24379",
-        "domain_keys_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/keys",
-        "fqdn": "t18s.fr", "zone_href": "https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379",
-        "zone_records_href": "https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379/records",
-        "domain_records_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records",
-        "domain_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr"}'
+      string: '{"domain_keys_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/keys","fqdn":"t18s.fr","automatic_snapshots":true,"domain_records_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/records","domain_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr"}'
     headers:
-      accept-ranges:
+      Accept-Ranges:
       - bytes
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '499'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:35:08 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:35:08 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:35:08 GMT
-      pragma:
+      Content-Length:
+      - '274'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:51 GMT
+      ETag:
+      - W/"112-tyQllSkZqMzGHTaisDLSgpwZtfY"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:51 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:51 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -78,163 +77,55 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records
   response:
     body:
-      string: !!python/unicode '[{"rrset_type": "A", "rrset_ttl": 10800, "rrset_name":
-        "*", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/%2A/A",
-        "rrset_values": ["62.210.124.142"]}, {"rrset_type": "AAAA", "rrset_ttl": 1800,
-        "rrset_name": "*", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/%2A/AAAA",
-        "rrset_values": ["2001:bc8:3dc1:100::142"]}, {"rrset_type": "MX", "rrset_ttl":
-        10800, "rrset_name": "*", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/%2A/MX",
-        "rrset_values": ["10 in1-smtp.messagingengine.com.", "20 in2-smtp.messagingengine.com."]},
-        {"rrset_type": "A", "rrset_ttl": 10800, "rrset_name": "@", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/%40/A",
-        "rrset_values": ["62.210.124.142"]}, {"rrset_type": "AAAA", "rrset_ttl": 1800,
-        "rrset_name": "@", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/%40/AAAA",
-        "rrset_values": ["2001:bc8:3dc1:100::142"]}, {"rrset_type": "CAA", "rrset_ttl":
-        300, "rrset_name": "@", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/%40/CAA",
-        "rrset_values": ["128 issue \"letsencrypt.org\""]}, {"rrset_type": "MX", "rrset_ttl":
-        10800, "rrset_name": "@", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/%40/MX",
-        "rrset_values": ["10 in1-smtp.messagingengine.com.", "20 in2-smtp.messagingengine.com."]},
-        {"rrset_type": "TXT", "rrset_ttl": 10800, "rrset_name": "@", "rrset_href":
-        "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/%40/TXT", "rrset_values":
-        ["\"v=spf1 include:spf.messagingengine.com ?all\""]}, {"rrset_type": "A",
-        "rrset_ttl": 10800, "rrset_name": "angband", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/angband/A",
-        "rrset_values": ["62.210.124.142"]}, {"rrset_type": "AAAA", "rrset_ttl": 10800,
-        "rrset_name": "angband", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/angband/AAAA",
-        "rrset_values": ["2001:bc8:3dc1:100::142"]}, {"rrset_type": "CAA", "rrset_ttl":
-        10800, "rrset_name": "angband", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/angband/CAA",
-        "rrset_values": ["128 issue \"letsencrypt.org\""]}, {"rrset_type": "SSHFP",
-        "rrset_ttl": 300, "rrset_name": "angband", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/angband/SSHFP",
-        "rrset_values": ["4 2 4ff8e0489c7b0f957dbf169dab2936ca82783e19c3a3799075a7a42236a194a7"]},
-        {"rrset_type": "A", "rrset_ttl": 10800, "rrset_name": "bitwarden", "rrset_href":
-        "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/bitwarden/A", "rrset_values":
-        ["62.210.124.142"]}, {"rrset_type": "AAAA", "rrset_ttl": 10800, "rrset_name":
-        "bitwarden", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/bitwarden/AAAA",
-        "rrset_values": ["2001:bc8:3dc1:100::142"]}, {"rrset_type": "CNAME", "rrset_ttl":
-        3600, "rrset_name": "docs", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/docs/CNAME",
-        "rrset_values": ["docs.example.com"]}, {"rrset_type": "A", "rrset_ttl": 10800,
-        "rrset_name": "finger", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/finger/A",
-        "rrset_values": ["62.210.124.142"]}, {"rrset_type": "AAAA", "rrset_ttl": 10800,
-        "rrset_name": "finger", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/finger/AAAA",
-        "rrset_values": ["2001:bc8:3dc1:100::142"]}, {"rrset_type": "CAA", "rrset_ttl":
-        10800, "rrset_name": "finger", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/finger/CAA",
-        "rrset_values": ["128 issue \"letsencrypt.org\""]}, {"rrset_type": "CNAME",
-        "rrset_ttl": 10800, "rrset_name": "fm1._domainkey", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/fm1._domainkey/CNAME",
-        "rrset_values": ["fm1.t18s.fr.dkim.fmhosted.com."]}, {"rrset_type": "CNAME",
-        "rrset_ttl": 10800, "rrset_name": "fm2._domainkey", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/fm2._domainkey/CNAME",
-        "rrset_values": ["fm2.t18s.fr.dkim.fmhosted.com."]}, {"rrset_type": "CNAME",
-        "rrset_ttl": 10800, "rrset_name": "fm3._domainkey", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/fm3._domainkey/CNAME",
-        "rrset_values": ["fm3.t18s.fr.dkim.fmhosted.com."]}, {"rrset_type": "A", "rrset_ttl":
-        10800, "rrset_name": "git", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/git/A",
-        "rrset_values": ["62.210.124.142"]}, {"rrset_type": "AAAA", "rrset_ttl": 10800,
-        "rrset_name": "git", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/git/AAAA",
-        "rrset_values": ["2001:bc8:3dc1:100::142"]}, {"rrset_type": "CAA", "rrset_ttl":
-        10800, "rrset_name": "git", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/git/CAA",
-        "rrset_values": ["128 issue \"letsencrypt.org\""]}, {"rrset_type": "A", "rrset_ttl":
-        10800, "rrset_name": "gopher", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/gopher/A",
-        "rrset_values": ["62.210.124.142"]}, {"rrset_type": "AAAA", "rrset_ttl": 10800,
-        "rrset_name": "gopher", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/gopher/AAAA",
-        "rrset_values": ["2001:bc8:3dc1:100::142"]}, {"rrset_type": "CAA", "rrset_ttl":
-        300, "rrset_name": "gopher", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/gopher/CAA",
-        "rrset_values": ["128 issue \"letsencrypt.org\""]}, {"rrset_type": "A", "rrset_ttl":
-        3600, "rrset_name": "localhost", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/localhost/A",
-        "rrset_values": ["127.0.0.1"]}, {"rrset_type": "A", "rrset_ttl": 10800, "rrset_name":
-        "mail", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/mail/A",
-        "rrset_values": ["66.111.4.147", "66.111.4.148"]}, {"rrset_type": "MX", "rrset_ttl":
-        10800, "rrset_name": "mail", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/mail/MX",
-        "rrset_values": ["10 in1-smtp.messagingengine.com.", "20 in2-smtp.messagingengine.com."]},
-        {"rrset_type": "CNAME", "rrset_ttl": 10800, "rrset_name": "mesmtp._domainkey",
-        "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/mesmtp._domainkey/CNAME",
-        "rrset_values": ["mesmtp.t18s.fr.dkim.fmhosted.com."]}, {"rrset_type": "A",
-        "rrset_ttl": 10800, "rrset_name": "monitoring", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/monitoring/A",
-        "rrset_values": ["62.210.124.142"]}, {"rrset_type": "AAAA", "rrset_ttl": 10800,
-        "rrset_name": "monitoring", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/monitoring/AAAA",
-        "rrset_values": ["2001:bc8:3dc1:100::142"]}, {"rrset_type": "TXT", "rrset_ttl":
-        3600, "rrset_name": "random.fqdntest", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/random.fqdntest/TXT",
-        "rrset_values": ["\"challengetoken\""]}, {"rrset_type": "TXT", "rrset_ttl":
-        3600, "rrset_name": "random.fulltest", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/random.fulltest/TXT",
-        "rrset_values": ["\"challengetoken\""]}, {"rrset_type": "TXT", "rrset_ttl":
-        3600, "rrset_name": "random.test", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/random.test/TXT",
-        "rrset_values": ["\"challengetoken\""]}, {"rrset_type": "LOC", "rrset_ttl":
-        10800, "rrset_name": "srv3", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/srv3/LOC",
-        "rrset_values": ["44 21 43.528 N 71 5 6.284 W 12.00m"]}, {"rrset_type": "TXT",
-        "rrset_ttl": 3600, "rrset_name": "ttl.fqdn", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/ttl.fqdn/TXT",
-        "rrset_values": ["\"ttlshouldbe3600\""]}, {"rrset_type": "A", "rrset_ttl":
-        10800, "rrset_name": "www", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/www/A",
-        "rrset_values": ["62.210.124.142"]}, {"rrset_type": "AAAA", "rrset_ttl": 10800,
-        "rrset_name": "www", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/www/AAAA",
-        "rrset_values": ["2001:bc8:3dc1:100::142"]}, {"rrset_type": "CAA", "rrset_ttl":
-        300, "rrset_name": "www", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/www/CAA",
-        "rrset_values": ["128 issue \"letsencrypt.org\""]}, {"rrset_type": "TXT",
-        "rrset_ttl": 10800, "rrset_name": "_acme-challenge.createrecordset", "rrset_href":
-        "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/_acme-challenge.createrecordset/TXT",
-        "rrset_values": ["\"challengetoken1\"", "\"challengetoken2\""]}, {"rrset_type":
-        "TXT", "rrset_ttl": 10800, "rrset_name": "_acme-challenge.deleterecordinset",
-        "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/_acme-challenge.deleterecordinset/TXT",
-        "rrset_values": ["\"challengetoken2\""]}, {"rrset_type": "TXT", "rrset_ttl":
-        3600, "rrset_name": "_acme-challenge.fqdn", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/_acme-challenge.fqdn/TXT",
-        "rrset_values": ["\"challengetoken\""]}, {"rrset_type": "TXT", "rrset_ttl":
-        3600, "rrset_name": "_acme-challenge.full", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/_acme-challenge.full/TXT",
-        "rrset_values": ["\"challengetoken\""]}, {"rrset_type": "TXT", "rrset_ttl":
-        10800, "rrset_name": "_acme-challenge.listrecordset", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/_acme-challenge.listrecordset/TXT",
-        "rrset_values": ["\"challengetoken1\"", "\"challengetoken2\""]}, {"rrset_type":
-        "TXT", "rrset_ttl": 3600, "rrset_name": "_acme-challenge.noop", "rrset_href":
-        "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/_acme-challenge.noop/TXT",
-        "rrset_values": ["\"challengetoken\""]}, {"rrset_type": "TXT", "rrset_ttl":
-        3600, "rrset_name": "_acme-challenge.test", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/_acme-challenge.test/TXT",
-        "rrset_values": ["\"challengetoken\""]}, {"rrset_type": "SRV", "rrset_ttl":
-        10800, "rrset_name": "_caldavs._tcp", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/_caldavs._tcp/SRV",
-        "rrset_values": ["0 1 443 caldav.fastmail.com."]}, {"rrset_type": "SRV", "rrset_ttl":
-        10800, "rrset_name": "_carddavs._tcp", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/_carddavs._tcp/SRV",
-        "rrset_values": ["0 1 443 carddav.fastmail.com."]}, {"rrset_type": "SRV",
-        "rrset_ttl": 10800, "rrset_name": "_imaps._tcp", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/_imaps._tcp/SRV",
-        "rrset_values": ["0 1 993 imap.fastmail.com."]}, {"rrset_type": "SRV", "rrset_ttl":
-        10800, "rrset_name": "_pop3s._tcp", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/_pop3s._tcp/SRV",
-        "rrset_values": ["10 1 995 pop.fastmail.com."]}, {"rrset_type": "SRV", "rrset_ttl":
-        10800, "rrset_name": "_submission._tcp", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/_submission._tcp/SRV",
-        "rrset_values": ["0 1 587 smtp.fastmail.com."]}]'
+      string: '[{"rrset_type":"A","rrset_ttl":600,"rrset_name":"@","rrset_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/records/%40/A","rrset_values":["82.64.93.53"]},{"rrset_type":"AAAA","rrset_ttl":600,"rrset_name":"@","rrset_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/records/%40/AAAA","rrset_values":["2a01:e0a:1f8:17e0:b62e:99ff:fef8:cdb9"]},{"rrset_type":"CNAME","rrset_ttl":3600,"rrset_name":"docs","rrset_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/records/docs/CNAME","rrset_values":["docs.example.com"]},{"rrset_type":"A","rrset_ttl":3600,"rrset_name":"localhost","rrset_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/records/localhost/A","rrset_values":["127.0.0.1"]},{"rrset_type":"TXT","rrset_ttl":3600,"rrset_name":"random.fqdntest","rrset_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/records/random.fqdntest/TXT","rrset_values":["\"challengetoken\""]},{"rrset_type":"TXT","rrset_ttl":3600,"rrset_name":"random.fulltest","rrset_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/records/random.fulltest/TXT","rrset_values":["\"challengetoken\""]},{"rrset_type":"TXT","rrset_ttl":3600,"rrset_name":"random.test","rrset_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/records/random.test/TXT","rrset_values":["\"challengetoken\""]},{"rrset_type":"TXT","rrset_ttl":3600,"rrset_name":"ttl.fqdn","rrset_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/records/ttl.fqdn/TXT","rrset_values":["\"ttlshouldbe3600\""]},{"rrset_type":"CNAME","rrset_ttl":86400,"rrset_name":"www","rrset_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/records/www/CNAME","rrset_values":["t18s.fr."]},{"rrset_type":"TXT","rrset_ttl":3600,"rrset_name":"_acme-challenge.createrecordset","rrset_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/records/_acme-challenge.createrecordset/TXT","rrset_values":["\"challengetoken1\"","\"challengetoken2\""]},{"rrset_type":"TXT","rrset_ttl":10800,"rrset_name":"_acme-challenge.deleterecordinset","rrset_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/records/_acme-challenge.deleterecordinset/TXT","rrset_values":["\"challengetoken2\""]},{"rrset_type":"TXT","rrset_ttl":3600,"rrset_name":"_acme-challenge.fqdn","rrset_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/records/_acme-challenge.fqdn/TXT","rrset_values":["\"challengetoken\""]},{"rrset_type":"TXT","rrset_ttl":3600,"rrset_name":"_acme-challenge.full","rrset_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/records/_acme-challenge.full/TXT","rrset_values":["\"challengetoken\""]},{"rrset_type":"TXT","rrset_ttl":3600,"rrset_name":"_acme-challenge.listrecordset","rrset_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/records/_acme-challenge.listrecordset/TXT","rrset_values":["\"challengetoken1\"","\"challengetoken2\""]},{"rrset_type":"TXT","rrset_ttl":3600,"rrset_name":"_acme-challenge.noop","rrset_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/records/_acme-challenge.noop/TXT","rrset_values":["\"challengetoken\""]},{"rrset_type":"TXT","rrset_ttl":3600,"rrset_name":"_acme-challenge.test","rrset_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/records/_acme-challenge.test/TXT","rrset_values":["\"challengetoken\""]}]'
     headers:
-      accept-ranges:
+      Accept-Ranges:
       - bytes
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '10982'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:35:08 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:35:08 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:35:08 GMT
-      pragma:
+      Content-Length:
+      - '3264'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:52 GMT
+      ETag:
+      - W/"cc0-8mSr6qo/O6iTi7RjgMHOxERwLAc"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:52 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:52 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-total-count:
-      - '53'
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
+      total-count:
+      - '16'
     status:
       code: 200
       message: OK

--- a/tests/fixtures/cassettes/gandi/REST-IntegrationTests/test_provider_when_calling_update_record_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/gandi/REST-IntegrationTests/test_provider_when_calling_update_record_should_modify_record.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -13,59 +13,58 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr
   response:
     body:
-      string: !!python/unicode '{"zone_uuid": "4fd93cb0-5c6c-11e8-b297-00163ee24379",
-        "domain_keys_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/keys",
-        "fqdn": "t18s.fr", "zone_href": "https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379",
-        "zone_records_href": "https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379/records",
-        "domain_records_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records",
-        "domain_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr"}'
+      string: '{"domain_keys_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/keys","fqdn":"t18s.fr","automatic_snapshots":true,"domain_records_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/records","domain_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr"}'
     headers:
-      accept-ranges:
+      Accept-Ranges:
       - bytes
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '499'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:35:09 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:35:09 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:35:09 GMT
-      pragma:
+      Content-Length:
+      - '274'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:53 GMT
+      ETag:
+      - W/"112-tyQllSkZqMzGHTaisDLSgpwZtfY"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:53 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:53 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -78,45 +77,45 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/orig.test/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/orig.test/TXT
   response:
     body:
-      string: !!python/unicode '{"code": 404, "message": "Can''t find the DNS record
-        orig.test/TXT in the zone", "object": "dns-record", "cause": "Not Found"}'
+      string: '{"code": 404, "message": "Can''t find the DNS record orig.test/TXT
+        in the zone", "object": "dns-record", "cause": "Not Found"}'
     headers:
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
+      Content-Length:
       - '125'
-      content-type:
+      Content-Type:
       - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:35:09 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:35:09 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:35:09 GMT
-      pragma:
+      Date:
+      - Thu, 22 Oct 2020 21:23:53 GMT
+      Expires:
+      - Thu, 22 Oct 2020 21:23:53 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:53 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      via:
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
     status:
       code: 404
       message: Not Found
 - request:
-    body: !!python/unicode '{"rrset_values": ["challengetoken"], "rrset_ttl": 3600}'
+    body: '{"rrset_values": ["challengetoken"], "rrset_ttl": 3600}'
     headers:
       Accept:
       - application/json
@@ -129,54 +128,58 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: POST
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/orig.test/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/orig.test/TXT
   response:
     body:
-      string: !!python/unicode '{"message": "DNS Record Created"}'
+      string: '{"message":"DNS Record Created"}'
     headers:
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '33'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:35:09 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:35:09 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:35:09 GMT
-      location:
-      - https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379/records/orig.test/TXT
-      pragma:
+      Content-Length:
+      - '32'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:53 GMT
+      ETag:
+      - W/"20-8GzTjxqNVdrkc6ay0Gf8zJRLVdc"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:53 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:53 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
+      location:
+      - https://api.gandi.net/v5/livedns/domains/t18s.fr/records/orig.test/TXT
     status:
       code: 201
       message: Created
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -189,57 +192,58 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/orig.test/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/orig.test/TXT
   response:
     body:
-      string: !!python/unicode '{"rrset_type": "TXT", "rrset_ttl": 3600, "rrset_name":
-        "orig.test", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/orig.test/TXT",
-        "rrset_values": ["\"challengetoken\""]}'
+      string: '{"rrset_type":"TXT","rrset_ttl":3600,"rrset_name":"orig.test","rrset_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/records/orig.test/TXT","rrset_values":["\"challengetoken\""]}'
     headers:
-      accept-ranges:
+      Accept-Ranges:
       - bytes
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '195'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:35:10 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:35:10 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:35:10 GMT
-      pragma:
+      Content-Length:
+      - '188'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:53 GMT
+      ETag:
+      - W/"bc-l0MpIpp+dXlqBD6KqdjzsGSabsE"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:53 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:53 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: !!python/unicode '{"rrset_type": "TXT", "rrset_name": "updated.test", "rrset_values":
-      ["challengetoken"]}'
+    body: '{"rrset_type": "TXT", "rrset_name": "updated.test", "rrset_values": ["challengetoken"]}'
     headers:
       Accept:
       - application/json
@@ -252,49 +256,53 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: PUT
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/orig.test/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/orig.test/TXT
   response:
     body:
-      string: !!python/unicode '{"message": "DNS Record Created"}'
+      string: '{"message":"DNS Record Created"}'
     headers:
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '33'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:35:10 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:35:10 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:35:10 GMT
-      location:
-      - https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379/records/orig.test/TXT
-      pragma:
+      Content-Length:
+      - '32'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:54 GMT
+      ETag:
+      - W/"20-8GzTjxqNVdrkc6ay0Gf8zJRLVdc"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:54 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:54 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
+      location:
+      - https://api.gandi.net/v5/livedns/domains/t18s.fr/records/orig.test/TXT
     status:
       code: 201
       message: Created

--- a/tests/fixtures/cassettes/gandi/REST-IntegrationTests/test_provider_when_calling_update_record_should_modify_record_name_specified.yaml
+++ b/tests/fixtures/cassettes/gandi/REST-IntegrationTests/test_provider_when_calling_update_record_should_modify_record_name_specified.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -13,59 +13,58 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr
   response:
     body:
-      string: !!python/unicode '{"zone_uuid": "4fd93cb0-5c6c-11e8-b297-00163ee24379",
-        "domain_keys_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/keys",
-        "fqdn": "t18s.fr", "zone_href": "https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379",
-        "zone_records_href": "https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379/records",
-        "domain_records_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records",
-        "domain_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr"}'
+      string: '{"domain_keys_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/keys","fqdn":"t18s.fr","automatic_snapshots":true,"domain_records_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/records","domain_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr"}'
     headers:
-      accept-ranges:
+      Accept-Ranges:
       - bytes
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '499'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:35:11 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:35:11 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:35:11 GMT
-      pragma:
+      Content-Length:
+      - '274'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:55 GMT
+      ETag:
+      - W/"112-tyQllSkZqMzGHTaisDLSgpwZtfY"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:55 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:55 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -78,46 +77,45 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/orig.nameonly.test/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/orig.nameonly.test/TXT
   response:
     body:
-      string: !!python/unicode '{"code": 404, "message": "Can''t find the DNS record
-        orig.nameonly.test/TXT in the zone", "object": "dns-record", "cause": "Not
-        Found"}'
+      string: '{"code": 404, "message": "Can''t find the DNS record orig.nameonly.test/TXT
+        in the zone", "object": "dns-record", "cause": "Not Found"}'
     headers:
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
+      Content-Length:
       - '134'
-      content-type:
+      Content-Type:
       - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:35:11 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:35:11 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:35:11 GMT
-      pragma:
+      Date:
+      - Thu, 22 Oct 2020 21:23:55 GMT
+      Expires:
+      - Thu, 22 Oct 2020 21:23:55 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:55 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      via:
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
     status:
       code: 404
       message: Not Found
 - request:
-    body: !!python/unicode '{"rrset_values": ["challengetoken"], "rrset_ttl": 3600}'
+    body: '{"rrset_values": ["challengetoken"], "rrset_ttl": 3600}'
     headers:
       Accept:
       - application/json
@@ -130,55 +128,59 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: POST
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/orig.nameonly.test/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/orig.nameonly.test/TXT
   response:
     body:
-      string: !!python/unicode '{"message": "DNS Record Created"}'
+      string: '{"message":"DNS Record Created"}'
     headers:
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '33'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:35:12 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:35:12 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:35:12 GMT
-      location:
-      - https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379/records/orig.nameonly.test/TXT
-      pragma:
+      Content-Length:
+      - '32'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:55 GMT
+      ETag:
+      - W/"20-8GzTjxqNVdrkc6ay0Gf8zJRLVdc"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:55 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:55 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
+      location:
+      - https://api.gandi.net/v5/livedns/domains/t18s.fr/records/orig.nameonly.test/TXT
     status:
       code: 201
       message: Created
 - request:
-    body: !!python/unicode '{"rrset_type": "TXT", "rrset_name": "orig.nameonly.test",
-      "rrset_values": ["updated"]}'
+    body: '{"rrset_type": "TXT", "rrset_name": "orig.nameonly.test", "rrset_values":
+      ["updated"]}'
     headers:
       Accept:
       - application/json
@@ -191,49 +193,53 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: PUT
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/orig.nameonly.test/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/orig.nameonly.test/TXT
   response:
     body:
-      string: !!python/unicode '{"message": "DNS Record Created"}'
+      string: '{"message":"DNS Record Created"}'
     headers:
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '33'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:35:12 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:35:12 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:35:12 GMT
-      location:
-      - https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379/records/orig.nameonly.test/TXT
-      pragma:
+      Content-Length:
+      - '32'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:56 GMT
+      ETag:
+      - W/"20-8GzTjxqNVdrkc6ay0Gf8zJRLVdc"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:56 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:56 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
+      location:
+      - https://api.gandi.net/v5/livedns/domains/t18s.fr/records/orig.nameonly.test/TXT
     status:
       code: 201
       message: Created

--- a/tests/fixtures/cassettes/gandi/REST-IntegrationTests/test_provider_when_calling_update_record_with_fqdn_name_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/gandi/REST-IntegrationTests/test_provider_when_calling_update_record_with_fqdn_name_should_modify_record.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -13,59 +13,58 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr
   response:
     body:
-      string: !!python/unicode '{"zone_uuid": "4fd93cb0-5c6c-11e8-b297-00163ee24379",
-        "domain_keys_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/keys",
-        "fqdn": "t18s.fr", "zone_href": "https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379",
-        "zone_records_href": "https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379/records",
-        "domain_records_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records",
-        "domain_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr"}'
+      string: '{"domain_keys_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/keys","fqdn":"t18s.fr","automatic_snapshots":true,"domain_records_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/records","domain_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr"}'
     headers:
-      accept-ranges:
+      Accept-Ranges:
       - bytes
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '499'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:35:13 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:35:13 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:35:13 GMT
-      pragma:
+      Content-Length:
+      - '274'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:56 GMT
+      ETag:
+      - W/"112-tyQllSkZqMzGHTaisDLSgpwZtfY"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:56 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:56 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -78,45 +77,45 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/orig.testfqdn/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/orig.testfqdn/TXT
   response:
     body:
-      string: !!python/unicode '{"code": 404, "message": "Can''t find the DNS record
-        orig.testfqdn/TXT in the zone", "object": "dns-record", "cause": "Not Found"}'
+      string: '{"code": 404, "message": "Can''t find the DNS record orig.testfqdn/TXT
+        in the zone", "object": "dns-record", "cause": "Not Found"}'
     headers:
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
+      Content-Length:
       - '129'
-      content-type:
+      Content-Type:
       - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:35:13 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:35:13 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:35:13 GMT
-      pragma:
+      Date:
+      - Thu, 22 Oct 2020 21:23:57 GMT
+      Expires:
+      - Thu, 22 Oct 2020 21:23:57 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:57 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      via:
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
     status:
       code: 404
       message: Not Found
 - request:
-    body: !!python/unicode '{"rrset_values": ["challengetoken"], "rrset_ttl": 3600}'
+    body: '{"rrset_values": ["challengetoken"], "rrset_ttl": 3600}'
     headers:
       Accept:
       - application/json
@@ -129,54 +128,58 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: POST
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/orig.testfqdn/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/orig.testfqdn/TXT
   response:
     body:
-      string: !!python/unicode '{"message": "DNS Record Created"}'
+      string: '{"message":"DNS Record Created"}'
     headers:
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '33'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:35:14 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:35:14 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:35:14 GMT
-      location:
-      - https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379/records/orig.testfqdn/TXT
-      pragma:
+      Content-Length:
+      - '32'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:57 GMT
+      ETag:
+      - W/"20-8GzTjxqNVdrkc6ay0Gf8zJRLVdc"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:57 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:57 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
+      location:
+      - https://api.gandi.net/v5/livedns/domains/t18s.fr/records/orig.testfqdn/TXT
     status:
       code: 201
       message: Created
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -189,57 +192,59 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/orig.testfqdn/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/orig.testfqdn/TXT
   response:
     body:
-      string: !!python/unicode '{"rrset_type": "TXT", "rrset_ttl": 3600, "rrset_name":
-        "orig.testfqdn", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/orig.testfqdn/TXT",
-        "rrset_values": ["\"challengetoken\""]}'
+      string: '{"rrset_type":"TXT","rrset_ttl":3600,"rrset_name":"orig.testfqdn","rrset_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/records/orig.testfqdn/TXT","rrset_values":["\"challengetoken\""]}'
     headers:
-      accept-ranges:
+      Accept-Ranges:
       - bytes
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '203'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:35:14 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:35:14 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:35:14 GMT
-      pragma:
+      Content-Length:
+      - '196'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:57 GMT
+      ETag:
+      - W/"c4-YP20RB+Iz812UN6B9G4GDUYRHbE"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:57 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:57 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: !!python/unicode '{"rrset_type": "TXT", "rrset_name": "updated.testfqdn",
-      "rrset_values": ["challengetoken"]}'
+    body: '{"rrset_type": "TXT", "rrset_name": "updated.testfqdn", "rrset_values":
+      ["challengetoken"]}'
     headers:
       Accept:
       - application/json
@@ -252,49 +257,53 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: PUT
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/orig.testfqdn/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/orig.testfqdn/TXT
   response:
     body:
-      string: !!python/unicode '{"message": "DNS Record Created"}'
+      string: '{"message":"DNS Record Created"}'
     headers:
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '33'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:35:15 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:35:15 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:35:15 GMT
-      location:
-      - https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379/records/orig.testfqdn/TXT
-      pragma:
+      Content-Length:
+      - '32'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:58 GMT
+      ETag:
+      - W/"20-8GzTjxqNVdrkc6ay0Gf8zJRLVdc"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:58 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:58 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
+      location:
+      - https://api.gandi.net/v5/livedns/domains/t18s.fr/records/orig.testfqdn/TXT
     status:
       code: 201
       message: Created

--- a/tests/fixtures/cassettes/gandi/REST-IntegrationTests/test_provider_when_calling_update_record_with_full_name_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/gandi/REST-IntegrationTests/test_provider_when_calling_update_record_with_full_name_should_modify_record.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -13,59 +13,58 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr
   response:
     body:
-      string: !!python/unicode '{"zone_uuid": "4fd93cb0-5c6c-11e8-b297-00163ee24379",
-        "domain_keys_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/keys",
-        "fqdn": "t18s.fr", "zone_href": "https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379",
-        "zone_records_href": "https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379/records",
-        "domain_records_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records",
-        "domain_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr"}'
+      string: '{"domain_keys_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/keys","fqdn":"t18s.fr","automatic_snapshots":true,"domain_records_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/records","domain_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr"}'
     headers:
-      accept-ranges:
+      Accept-Ranges:
       - bytes
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '499'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:35:15 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:35:15 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:35:15 GMT
-      pragma:
+      Content-Length:
+      - '274'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:59 GMT
+      ETag:
+      - W/"112-tyQllSkZqMzGHTaisDLSgpwZtfY"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:59 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:59 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -78,45 +77,45 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/orig.testfull/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/orig.testfull/TXT
   response:
     body:
-      string: !!python/unicode '{"code": 404, "message": "Can''t find the DNS record
-        orig.testfull/TXT in the zone", "object": "dns-record", "cause": "Not Found"}'
+      string: '{"code": 404, "message": "Can''t find the DNS record orig.testfull/TXT
+        in the zone", "object": "dns-record", "cause": "Not Found"}'
     headers:
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
+      Content-Length:
       - '129'
-      content-type:
+      Content-Type:
       - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:35:16 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:35:16 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:35:16 GMT
-      pragma:
+      Date:
+      - Thu, 22 Oct 2020 21:23:59 GMT
+      Expires:
+      - Thu, 22 Oct 2020 21:23:59 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:59 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      via:
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
     status:
       code: 404
       message: Not Found
 - request:
-    body: !!python/unicode '{"rrset_values": ["challengetoken"], "rrset_ttl": 3600}'
+    body: '{"rrset_values": ["challengetoken"], "rrset_ttl": 3600}'
     headers:
       Accept:
       - application/json
@@ -129,54 +128,58 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: POST
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/orig.testfull/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/orig.testfull/TXT
   response:
     body:
-      string: !!python/unicode '{"message": "DNS Record Created"}'
+      string: '{"message":"DNS Record Created"}'
     headers:
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '33'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:35:16 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:35:16 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:35:16 GMT
-      location:
-      - https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379/records/orig.testfull/TXT
-      pragma:
+      Content-Length:
+      - '32'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:23:59 GMT
+      ETag:
+      - W/"20-8GzTjxqNVdrkc6ay0Gf8zJRLVdc"
+      Expires:
+      - Thu, 22 Oct 2020 21:23:59 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:23:59 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
+      location:
+      - https://api.gandi.net/v5/livedns/domains/t18s.fr/records/orig.testfull/TXT
     status:
       code: 201
       message: Created
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept:
       - application/json
@@ -189,57 +192,59 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/orig.testfull/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/orig.testfull/TXT
   response:
     body:
-      string: !!python/unicode '{"rrset_type": "TXT", "rrset_ttl": 3600, "rrset_name":
-        "orig.testfull", "rrset_href": "https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/orig.testfull/TXT",
-        "rrset_values": ["\"challengetoken\""]}'
+      string: '{"rrset_type":"TXT","rrset_ttl":3600,"rrset_name":"orig.testfull","rrset_href":"https://api.gandi.net/v5/livedns/domains/t18s.fr/records/orig.testfull/TXT","rrset_values":["\"challengetoken\""]}'
     headers:
-      accept-ranges:
+      Accept-Ranges:
       - bytes
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '203'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:35:17 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:35:17 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:35:17 GMT
-      pragma:
+      Content-Length:
+      - '196'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:24:00 GMT
+      ETag:
+      - W/"c4-1OwSkgd1dz6RydlKsI5EgkwB7vM"
+      Expires:
+      - Thu, 22 Oct 2020 21:24:00 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:24:00 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: !!python/unicode '{"rrset_type": "TXT", "rrset_name": "updated.testfull",
-      "rrset_values": ["challengetoken"]}'
+    body: '{"rrset_type": "TXT", "rrset_name": "updated.testfull", "rrset_values":
+      ["challengetoken"]}'
     headers:
       Accept:
       - application/json
@@ -252,49 +257,53 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.21.0
+      - python-requests/2.22.0
     method: PUT
-    uri: https://dns.api.gandi.net/api/v5/domains/t18s.fr/records/orig.testfull/TXT
+    uri: https://api.gandi.net/v5/livedns/domains/t18s.fr/records/orig.testfull/TXT
   response:
     body:
-      string: !!python/unicode '{"message": "DNS Record Created"}'
+      string: '{"message":"DNS Record Created"}'
     headers:
-      age:
+      Age:
       - '0'
-      cache-control:
+      Cache-Control:
       - max-age=0, must-revalidate, no-cache, no-store
-      connection:
+      Connection:
       - keep-alive
-      content-length:
-      - '33'
-      content-type:
-      - application/json; charset=UTF-8
-      date:
-      - Fri, 29 Mar 2019 20:35:17 GMT
-      expires:
-      - Fri, 29 Mar 2019 20:35:17 GMT
-      last-modified:
-      - Fri, 29 Mar 2019 20:35:17 GMT
-      location:
-      - https://dns.api.gandi.net/api/v5/zones/4fd93cb0-5c6c-11e8-b297-00163ee24379/records/orig.testfull/TXT
-      pragma:
+      Content-Length:
+      - '32'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 22 Oct 2020 21:24:01 GMT
+      ETag:
+      - W/"20-8GzTjxqNVdrkc6ay0Gf8zJRLVdc"
+      Expires:
+      - Thu, 22 Oct 2020 21:24:01 GMT
+      Last-Modified:
+      - Thu, 22 Oct 2020 21:24:01 GMT
+      Pragma:
       - no-cache
-      server:
+      Server:
       - nginx
-      strict-transport-security:
+      Strict-Transport-Security:
       - max-age=15768000;
-      via:
+      Vary:
+      - Accept-Encoding, Accept-Language
+      Via:
       - 1.1 varnish-v4, 1.1 varnish-v4
-      x-cache:
+      X-Cache:
       - MISS
-      x-cache-hits:
+      X-Cache-Hits:
       - '0'
-      x-content-type-options:
+      X-Content-Type-Options:
       - nosniff
-      x-frame-options:
+      X-Frame-Options:
       - DENY
-      x-xss-protection:
+      X-XSS-Protection:
       - 1; mode=block
+      location:
+      - https://api.gandi.net/v5/livedns/domains/t18s.fr/records/orig.testfull/TXT
     status:
       code: 201
       message: Created


### PR DESCRIPTION
API endpoint dns.api.gandi.net is no more working. See https://doc.livedns.gandi.net/.

Changes are:
* Endpoint URL
* How apikey is used
* Minimum supported ttl value when creating record (300)