### PR TITLE
Update pyproject.toml to workaround issue with setuptools 50

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [build-system]
 requires = [
+    "setuptools!=50",
     "poetry>=0.12",
 ]
 build-backend = "poetry.masonry.api"


### PR DESCRIPTION
Added setuptools to requirements in pyproject.toml and blacklisted version 50 to fix #628.

