### PR TITLE
Silent a warning in new setuptools

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [flake8]
-max-line-length = 80
+max_line_length = 80
 select = C,E,F,W,B,B950
 ignore = E203,E501,W503


### PR DESCRIPTION
```
/usr/lib/python3.9/site-packages/setuptools/dist.py:634: UserWarning: Usage of dash-separated 'max-line-length' will not be supported in future versions. Please use the underscore name 'max_line_length' instead
```