### PR TITLE
[INWX] authentication - change API call from domain to nameserver (Issue #827)

### DIFF
--- a/lexicon/providers/inwx.py
+++ b/lexicon/providers/inwx.py
@@ -76,7 +76,7 @@ class Provider(BaseProvider):
         """
         opts = {"domain": self._domain}
         opts.update(self._auth)
-        response = self._api.domain.info(opts)
+        response = self._api.nameserver.info(opts)
         try:
             self._validate_response(response=response, message="Failed to authenticate")
         except Exception as e:


### PR DESCRIPTION
Here the `nameserver.info` call should be used to check if a domain is registered in the INWX-Nameserver and not the domain call because it checks if the domain is bought from INWX.
According to issue #827