### PR TITLE
Add support for Oracle Cloud Infrastructure (OCI) DNS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -60,6 +60,7 @@ lexicon/providers/netcup.py         @coldfix
 lexicon/providers/nfsn.py           @tersers
 lexicon/providers/njalla.py         @chapatt
 lexicon/providers/nsone.py          @init-js @trinopoty
+lexicon/providers/oci.py            @Djelibeybi
 lexicon/providers/onapp.py          @alexzorin
 lexicon/providers/online.py         @kapouer
 lexicon/providers/ovh.py            @adferrand

--- a/lexicon/providers/oci.py
+++ b/lexicon/providers/oci.py
@@ -1,0 +1,358 @@
+# coding: utf-8
+# Copyright (c) 2016, Jason Kulatunga
+# Copyright (c) 2021, Oracle and/or its affiliates.
+"""
+The Oracle Cloud Infrastructure (OCI) provider can create, list, update and
+delete records in any public DNS zone hosted in a tenancy located in any
+region within the OCI commercial (OC1) realm.
+
+No authentication details are required if the OCI CLI installed and the DEFAULT
+profile configured in the ~/.oci/config file has the appropriate permission for
+the target DNS zone or the equivalent OCI_CLI environment variables are set.
+
+Otherwise, you can either set the required LEXICON_OCI_AUTH_* environment
+variables or pass the required --auth-* command-line parameters. If you do not
+have a configuration file, you must provide user, tenancy, region, key and
+fingerprint details.
+
+Set the --auth-type parameter to 'instance_principal' to use instance principal
+authentication when running Lexicon on an Oracle Cloud Infrastructure compute
+instance. This method requires permission to be granted via IAM policy to a
+dynamic group that includes the compute instance.
+
+See https://docs.oracle.com/en-us/iaas/Content/DNS/Concepts/dnszonemanagement.htm
+for in-depth documentation on managing DNS via the OCI console, SDK or API.
+"""
+import os
+import logging
+import requests
+
+from pathlib import Path
+
+from lexicon.exceptions import LexiconError
+from lexicon.providers.base import Provider as BaseProvider
+
+# oci is an optional dependency of lexicon; do not throw an ImportError if
+# the dependency is unmet.
+try:
+    from oci.auth.signers import InstancePrincipalsSecurityTokenSigner  # type: ignore
+    from oci.config import from_file, validate_config  # type: ignore
+    from oci.exceptions import ConfigFileNotFound, ProfileNotFound, InvalidConfig  # type: ignore
+    from oci.signer import Signer  # type: ignore
+except ImportError:
+    pass
+
+LOGGER = logging.getLogger(__name__)
+
+NAMESERVER_DOMAINS = ["dns.oraclecloud.net"]
+
+CONFIG_VARS = {
+    "user",
+    "tenancy",
+    "fingerprint",
+    "key_file",
+    "key_content",
+    "pass_phrase",
+    "region",
+}
+
+
+def provider_parser(subparser):
+    """Generate a subparser for Oracle Cloud Infrastructure DNS"""
+    subparser.description = """
+    Oracle Cloud Infrastructure (OCI) DNS provider
+    """
+    subparser.add_argument(
+        "--auth-config-file",
+        help="The full path including filename to an OCI configuration file.",
+    )
+    subparser.add_argument(
+        "--auth-user",
+        help="The OCID of the user calling the API.",
+    )
+    subparser.add_argument(
+        "--auth-tenancy",
+        help="The OCID of your tenancy.",
+    )
+    subparser.add_argument(
+        "--auth-fingerprint",
+        help="The fingerprint for the public key that was added to the calling user.",
+    )
+    subparser.add_argument(
+        "--auth-key-content",
+        help="The full content of the calling user's private signing key in PEM format.",
+    )
+    subparser.add_argument(
+        "--auth-pass-phrase",
+        help="If the private key is encrypted, the pass phrase must be provided.",
+    )
+    subparser.add_argument(
+        "--auth-region",
+        help="The home region of your tenancy.",
+    )
+    subparser.add_argument(
+        "--auth-type",
+        help="Valid options are 'api_key' (default) or 'instance_principal'.",
+    )
+
+
+class Provider(BaseProvider):
+    """
+    Provider class for Oracle Cloud Infrastructure DNS
+    """
+
+    def __init__(self, config):
+        """Initialize OCI DNS client."""
+        super(Provider, self).__init__(config)
+        self.domain_id = None
+
+        file_location = (
+            self._get_provider_option("auth_config_file")
+            if self._get_provider_option("auth_config_file")
+            else str(Path(Path.home() / ".oci" / "config"))
+        )
+        profile_name = (
+            self._get_provider_option("auth_profile")
+            if self._get_provider_option("auth_profile")
+            else "DEFAULT"
+        )
+        auth_type = (
+            self._get_provider_option("auth_type")
+            if self._get_provider_option("auth_type")
+            else "api_key"
+        )
+
+        signer = (
+            InstancePrincipalsSecurityTokenSigner()
+            if auth_type == "instance_principal"
+            else None
+        )
+
+        oci_config = {}
+        try:
+            oci_config = from_file(file_location=file_location, profile_name=profile_name)
+        except (ConfigFileNotFound, ProfileNotFound):
+            pass
+
+        for var in CONFIG_VARS:
+            if os.environ.get(f"OCI_CLI_{var.upper()}"):
+                oci_config[var] = os.environ.get(f"OCI_CLI_{var.upper()}")
+
+            if self._get_provider_option(f"auth_{var}"):
+                oci_config[var] = self._get_provider_option(f"auth_{var}")
+
+            if var not in oci_config.keys():
+                oci_config[var] = None
+
+        try:
+            validate_config(oci_config)
+        except InvalidConfig:
+            raise
+
+        self.auth = (
+            signer
+            if signer
+            else Signer(
+                oci_config["tenancy"],
+                oci_config["user"],
+                oci_config["fingerprint"],
+                oci_config["key_file"],
+                oci_config["pass_phrase"],
+                oci_config["key_content"],
+            )
+        )
+
+        self.endpoint = f"https://dns.{oci_config['region']}.oraclecloud.com/20180115"
+        LOGGER.debug(f"Activated OCI provider with endpoint: {self.endpoint}")
+
+    def _authenticate(self):
+        try:
+            zone = self._get(f"/zones/{self.domain}")
+            self.domain_id = zone["id"]
+            self.zone_name = zone["name"]
+        except requests.exceptions.HTTPError:
+            LOGGER.error(f"Error: invalid zone or permission denied accessing {self.domain}")
+            raise
+
+    # Create record. If record already exists with the same content, do nothing
+    def _create_record(self, rtype, name, content):
+
+        name = self._full_name(name)
+        patchset = {
+            "items": [
+                {
+                    "operation": "ADD",
+                    "rtype": rtype,
+                    "rdata": content,
+                    "ttl": self._get_lexicon_option("ttl")
+                    if self._get_lexicon_option("ttl")
+                    else None,
+                }
+            ]
+        }
+
+        try:
+            self._patch(f"/zones/{self.zone_name}/records/{name}", patchset)
+            LOGGER.debug(f"OCI: created new {rtype} record for {name}.")
+        except requests.exceptions.HTTPError:
+            raise LexiconError("OCI Error: record not created.")
+
+        return True
+
+    # List all records. Return an empty list if no records found
+    # type, name and content are used to filter records.
+    # If possible filter during the query, otherwise filter after response is received.
+    def _list_records(self, rtype=None, name=None, content=None):
+
+        query_params = {"limit": 100, "rtype": rtype}
+        name = self._full_name(name) if name else None
+
+        if name:
+            payload = self._get(f"/zones/{self.zone_name}/records/{name}", query_params)
+        else:
+            payload = self._get(f"/zones/{self.zone_name}/records", query_params)
+
+        records = []
+        for item in payload["items"]:
+            rdata = item["rdata"].strip('"')
+            name = self._full_name(item["domain"])
+            if content and content != rdata:
+                continue
+
+            record = {
+                "type": item["rtype"],
+                "name": name,
+                "ttl": item["ttl"],
+                "content": rdata,
+                "id": item["recordHash"],
+            }
+            records.append(record)
+
+        LOGGER.debug(
+            f"OCI: listing {len(records)} {rtype} records from {self.zone_name}."
+        )
+        return records
+
+    # Update a record. Identifier must be specified.
+    def _update_record(self, identifier, rtype=None, name=None, content=None):
+
+        name = self._full_name(name) if name else None
+        if identifier:
+            records = [
+                record
+                for record in self._list_records(rtype=rtype)
+                if identifier == record["id"]
+            ]
+        else:
+            records = self._list_records(rtype=rtype, name=name)
+
+        if not records:
+            raise LexiconError(
+                f"OCI Error: unable to find {rtype} record for {name} to update."
+            )
+        elif len(records) > 1:
+            LOGGER.warning(
+                f"Warning: multiple {rtype} records found for {name} containing {content}. Updating the first record returned.",
+            )
+
+        identifier = records[0]["id"]
+        domain = self._full_name(records[0]["name"])
+        ttl = (
+            self._get_lexicon_option("ttl") if self._get_lexicon_option("ttl") else None
+        )
+
+        patchset = {
+            "items": [
+                {"operation": "REMOVE", "recordHash": identifier},
+                {"operation": "ADD", "rtype": rtype, "rdata": content, "ttl": ttl},
+            ]
+        }
+
+        try:
+            self._patch(f"/zones/{self.zone_name}/records/{domain}", patchset)
+            LOGGER.debug(f"OCI: updated {rtype} record [{identifier}].")
+        except requests.exceptions.HTTPError:
+            raise LexiconError(f"OCI Error updating {rtype} record for {domain}")
+
+        return True
+
+    # Delete an existing record.
+    # If record does not exist, do nothing.
+    # If an identifier is specified, use it, otherwise do a lookup using type, name and content.
+    def _delete_record(self, identifier=None, rtype=None, name=None, content=None):
+
+        name = self._full_name(name) if name else None
+        if not identifier and not content:
+            try:
+                records = self._list_records(rtype, name)
+                if len(records) > 0:
+                    self._delete(f"/zones/{self.zone_name}/records/{name}/{rtype}")
+                    LOGGER.debug(f"OCI: deleted {rtype} recordset for {name}.")
+                else:
+                    return True
+            except requests.exceptions.HTTPError:
+                raise LexiconError(f"OCI Error deleting {rtype} recordset for {name}")
+
+        else:
+            records = self._list_records(rtype=rtype, name=name, content=content)
+
+            if identifier:
+                records = [record for record in records if record["id"] == identifier]
+
+            if len(records) == 0:
+                return True
+
+            patchset = {
+                "items": [
+                    {"operation": "REMOVE", "recordHash": record["id"]}
+                    for record in records
+                ]
+            }
+
+            try:
+                self._patch(f"/zones/{self.zone_name}/records", patchset)
+                LOGGER.debug(f"OCI: deleted {rtype} record(s) from {self.zone_name}.")
+            except requests.exceptions.HTTPError:
+                raise LexiconError("Error deleting record(s)")
+
+        return True
+
+    def _request(self, action="GET", url="/", data=None, query_params=None):
+
+        if not data and action != "DELETE":
+            data = {}
+
+        if not query_params:
+            query_params = {}
+
+        if not url.startswith(self.endpoint):
+            url = self.endpoint + url
+
+        response = requests.request(
+            action,
+            url,
+            params=query_params,
+            auth=self.auth,
+            json=data if data else None,
+        )
+        response.raise_for_status()
+
+        if response.content:
+            results = response.json()
+        else:
+            return None
+
+        # The opc-next-page header indicates there is another page of results
+        if "opc-next-page" in response.headers:
+            query_params["page"] = response.headers["opc-next-page"]
+            response = requests.request(
+                action,
+                url,
+                params=query_params,
+                auth=self.auth,
+                json=data if data else None,
+            )
+            response.raise_for_status()
+            results += response.json()
+
+        return results

--- a/lexicon/tests/providers/test_oci.py
+++ b/lexicon/tests/providers/test_oci.py
@@ -1,0 +1,71 @@
+# coding: utf-8
+# Copyright (c) 2016, Jason Kulatunga
+# Copyright (c) 2021, Oracle and/or its affiliates.
+import re
+
+from lexicon.tests.providers.integration_tests import IntegrationTestsV2
+from unittest import TestCase
+
+
+# Hook into testing framework by inheriting unittest.TestCase and reuse
+# the tests which *each and every* implementation of the interface must
+# pass, by inheritance from integration_tests.IntegrationTests
+class OciProviderTests(TestCase, IntegrationTestsV2):
+    """Integration tests for OCI provider"""
+
+    provider_name = "oci"
+    domain = "lexicon-test.com"
+
+    # Provide a fake credentials but the same region as the recorded tests
+    def _test_parameters_overrides(self):
+        return {
+            "auth_user": "ocid1.user.oc1..aaaaaaa",
+            "auth_tenancy": "ocid1.tenancy.oc1..aaaaaaaa",
+            "auth_fingerprint": "aa:11:bb:22:cc:33:dd:44:ee:55:ff:66:a1:77:a2:88",
+            "auth_region": "us-ashburn-1",
+            "auth_key_content": """-----BEGIN RSA PRIVATE KEY-----
+MIIEpAIBAAKCAQEA17lz4CMII+rpvu9Pi/AkOosjQR+kvDxdpbbxYY2JMkRnTuuN
+nb7kefWQ9fEqsmTJcaUl0rrDORrYU+W+WYmuPYh839BeKPFbg/WbfPFMhLwF2X6G
+w2Ozj7a9JceEYsuOptxtYawYabsN3wbPLAuTvY4B08kGLgVIzs7A3L/6JPbHJhjV
+YuiRwWe2zzD64ERe3UuGEOXcTyU/guS3bX91W46E4vw6CFL2GiNgI5Q46xF3D31/
+P/GKdFewm8rr7kAEouGW4mhOw0KI/mqgNrctQt+YQAzw/QKI4+umMu01ZtuYXRbF
+40JsTuQOxnmClf7P59YrsI3ltBA94XthyVxh0QIDAQABAoIBADqnXt0zSTRS2+kh
+MjSvP3p3eEdtriHMG/5BppHKpOH4/UnU+/VHAOI0JYzpXJ2Sj78JkyYfx5LQPL9a
++Q1pROnQIXvNMLzbGvHfJr6q8Q4p/UEsiMG5awoJOpZ6EAG4rPmrd0YWP7EHvfbE
+6DFmmG3ynYaS4s5Ce5BXYNLkk8PWoWpEBGDOrdOU6bvMFqEgzqjnlbVNwGDP09HQ
+fGtnycAqOsyC2CnrpNoOq6TWr/Y7s0EViajYxxTgoSgXnscntz8M2tqCW3Hd1T94
+w2DOe1W5EGIkVrNpTePwFCkqPI47kTUT1eHDowf5NmRADJVDHr5H6yNCk7d/u2mr
+6JsggE0CgYEA8YUBc/fagXLVAsEi3sOcyJrq04C+oy3Zz7zHz7ZH72cfJvaPlBPI
+FPLVhEptn7bPMR7JuzUL6BckEnoPdXG52ncnZZbKMKXfBS6IkC/SSYjX6TWBXH9I
+523QUi45N68UGb+opX/0iTvSrimK4wDWdz+Umx3rbt6uqmwuCHj9dn8CgYEA5KiG
+7bnMRQAMadOOeFQePpViisEuHAAtL4f8qbXrwEjEjCjFBb3Hifdl6bRsvU8LEcN2
+6YUM+KQXTOu+10N+4ANptjXzHJMIliO6FQ+7S8Rs/wDSrtuKHaEQR19HgyJzPfSi
+ptZNWBFphrFE3nYO2GoYqCGwFYqNkW084XPBH68CgYEAyZcJBXEF0zK0FV576pA/
+1zlndC5r8Owed8TMytUM6gia+fynDyQLx2CBU7CEG+GMwyU9oKLAU3KtSzbSnGbW
+iEEYgzT/gueQZVTX6/Hehj5QaXmdhkU/5tvEHDQ00gOytWNCMxHAXKOwUGqgYKWc
+XWCWe3rXvmzkQZ+WNMA4X6UCgYEAgJcmClsKvWMhmAIZhSIJQDjSiiXJwIV449oe
+BXMBeclyf0AOTQRFSxmOfrewz2W8W+kI3pqsiMf/MosBcB3NJD3HHWmJpvApTAYb
+h+yo8BsvENltolhke/UwKnMyzFR7asRBFIJATN698bmPeWv7PUmtRCBt3i9lHfvI
+2SE34pECgYABPlBhx/irQMLXOacZxpXdVUj6/ivy4asiHe4OZN4uSXS1WqmrRHBe
+Spzc4VkUFCDazQqxbG2/4ElGUzw+z0C0KMsSfSXTIk/YpNkyrCTwsllyvZrH7gVP
+qpq9aJr7G9qW+9Yovwm2qLR1joa4XoOqn13bkEU7lc96fyRBr0ucDg==
+-----END RSA PRIVATE KEY-----
+"""
+        }
+
+    def _filter_headers(self):
+        return ["authorization", "x-content-sha256"]
+
+    def _filter_response(self, response):
+
+        response["body"]["string"] = re.sub(
+            br'"compartmentId":"[\w.-]+"',
+            b'"compartmentId":"OCI-COMPARTMENT-ID"',
+            response["body"]["string"],
+        )
+        response["body"]["string"] = re.sub(
+            br'"id":"[\w.-]+"',
+            b'"id":"DNS-ZONE-ID"',
+            response["body"]["string"],
+        )
+        return response

--- a/poetry.lock
+++ b/poetry.lock
@@ -68,20 +68,20 @@ d = ["aiohttp (>=3.3.2)", "aiohttp-cors"]
 
 [[package]]
 name = "boto3"
-version = "1.17.101"
+version = "1.17.102"
 description = "The AWS SDK for Python"
 category = "main"
 optional = true
 python-versions = ">= 2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 
 [package.dependencies]
-botocore = ">=1.20.101,<1.21.0"
+botocore = ">=1.20.102,<1.21.0"
 jmespath = ">=0.7.1,<1.0.0"
 s3transfer = ">=0.4.0,<0.5.0"
 
 [[package]]
 name = "botocore"
-version = "1.20.101"
+version = "1.20.102"
 description = "Low-level, data-driven core of boto 3."
 category = "main"
 optional = true
@@ -149,6 +149,18 @@ description = "Cross-platform colored terminal text."
 category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "configparser"
+version = "4.0.2"
+description = "Updated configparser from Python 3.7 for Python 2.6+."
+category = "main"
+optional = true
+python-versions = ">=2.6"
+
+[package.extras]
+docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
+testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2)", "pytest-flake8", "pytest-black-multipy"]
 
 [[package]]
 name = "coverage"
@@ -279,7 +291,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 
 [[package]]
 name = "importlib-resources"
-version = "5.1.4"
+version = "5.2.0"
 description = "Read resources from Python packages"
 category = "dev"
 optional = false
@@ -400,6 +412,22 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "oci"
+version = "2.40.1"
+description = "Oracle Cloud Infrastructure Python SDK"
+category = "main"
+optional = true
+python-versions = "*"
+
+[package.dependencies]
+certifi = "*"
+configparser = "4.0.2"
+cryptography = ">=3.2.1,<=3.4.7"
+pyOpenSSL = ">=17.5.0,<=19.1.0"
+python-dateutil = ">=2.5.3,<3.0.0"
+pytz = ">=2016.10"
+
+[[package]]
 name = "packaging"
 version = "20.9"
 description = "Core utilities for Python packages"
@@ -490,6 +518,22 @@ description = "Pygments is a syntax highlighting package written in Python."
 category = "main"
 optional = true
 python-versions = ">=3.5"
+
+[[package]]
+name = "pyopenssl"
+version = "19.1.0"
+description = "Python wrapper module around the OpenSSL library"
+category = "main"
+optional = true
+python-versions = "*"
+
+[package.dependencies]
+cryptography = ">=2.8"
+six = ">=1.5.2"
+
+[package.extras]
+docs = ["sphinx", "sphinx-rtd-theme"]
+test = ["flaky", "pretend", "pytest (>=3.0.1)"]
 
 [[package]]
 name = "pyparsing"
@@ -934,9 +978,10 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 
 [extras]
 ddns = ["dnspython"]
-full = ["boto3", "transip", "localzone", "softlayer", "zeep"]
+full = ["boto3", "transip", "localzone", "softlayer", "zeep", "oci"]
 gransy = ["zeep"]
 localzone = ["localzone"]
+oci = ["oci"]
 route53 = ["boto3"]
 softlayer = ["softlayer"]
 transip = ["transip"]
@@ -944,7 +989,7 @@ transip = ["transip"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "0ce9a908cb1398339ce75816741da5d3f12869555717193f44b15ce5faf2b660"
+content-hash = "15cb93cbc983bfbeb0fe01b69283148c0c80f0bc5dc4b3d6ef9918173f318071"
 
 [metadata.files]
 appdirs = [
@@ -968,12 +1013,12 @@ black = [
     {file = "black-20.8b1.tar.gz", hash = "sha256:1c02557aa099101b9d21496f8a914e9ed2222ef70336404eeeac8edba836fbea"},
 ]
 boto3 = [
-    {file = "boto3-1.17.101-py2.py3-none-any.whl", hash = "sha256:a9beeb6f1be835ced95e90e93e5ac35b972a0fc35b71e6a1edc01abdc87932d4"},
-    {file = "boto3-1.17.101.tar.gz", hash = "sha256:77ebaa3645ae153978a0f2c492502fef3804fe0e693abc7dc74620e4884afe67"},
+    {file = "boto3-1.17.102-py2.py3-none-any.whl", hash = "sha256:6300e9ee9a404038113250bd218e2c4827f5e676efb14e77de2ad2dcb67679bc"},
+    {file = "boto3-1.17.102.tar.gz", hash = "sha256:be4714f0475c1f5183eea09ddbf568ced6fa41b0fc9976f2698b8442e1b17303"},
 ]
 botocore = [
-    {file = "botocore-1.20.101-py2.py3-none-any.whl", hash = "sha256:2c56644dc1fdfc3f7cc5c690371d0770d8e6b9edb3f4e15f206e5bc27422dcd6"},
-    {file = "botocore-1.20.101.tar.gz", hash = "sha256:f7a44fab1a3739ca54e7f72e8625b71574f8218f05349e59d3b871c887444edd"},
+    {file = "botocore-1.20.102-py2.py3-none-any.whl", hash = "sha256:bdf08a4f7f01ead00d386848f089c08270499711447569c18d0db60023619c06"},
+    {file = "botocore-1.20.102.tar.gz", hash = "sha256:2f57f7ceed1598d96cc497aeb45317db5d3b21a5aafea4732d0e561d0fc2a8fa"},
 ]
 cached-property = [
     {file = "cached-property-1.5.2.tar.gz", hash = "sha256:9fa5755838eecbb2d234c3aa390bd80fbd3ac6b6869109bfc1b499f7bd89a130"},
@@ -1045,6 +1090,10 @@ click = [
 colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
     {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
+]
+configparser = [
+    {file = "configparser-4.0.2-py2.py3-none-any.whl", hash = "sha256:254c1d9c79f60c45dfde850850883d5aaa7f19a23f13561243a050d5a7c3fe4c"},
+    {file = "configparser-4.0.2.tar.gz", hash = "sha256:c7d282687a5308319bf3d2e7706e575c635b0a470342641c93bea0ea3b5331df"},
 ]
 coverage = [
     {file = "coverage-5.5-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:b6d534e4b2ab35c9f93f46229363e17f63c53ad01330df9f2d6bd1187e5eaacf"},
@@ -1151,8 +1200,8 @@ importlib-metadata = [
     {file = "importlib_metadata-4.6.0.tar.gz", hash = "sha256:4a5611fea3768d3d967c447ab4e93f567d95db92225b43b7b238dbfb855d70bb"},
 ]
 importlib-resources = [
-    {file = "importlib_resources-5.1.4-py3-none-any.whl", hash = "sha256:e962bff7440364183203d179d7ae9ad90cb1f2b74dcb84300e88ecc42dca3351"},
-    {file = "importlib_resources-5.1.4.tar.gz", hash = "sha256:54161657e8ffc76596c4ede7080ca68cb02962a2e074a2586b695a93a925d36e"},
+    {file = "importlib_resources-5.2.0-py3-none-any.whl", hash = "sha256:a0143290bef3cbc99de9e40176e4987780939a955b8632f02ce6c935f42e9bfc"},
+    {file = "importlib_resources-5.2.0.tar.gz", hash = "sha256:22a2c42d8c6a1d30aa8a0e1f57293725bfd5c013d562585e46aff469e0ff78b3"},
 ]
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
@@ -1294,6 +1343,10 @@ mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
     {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
 ]
+oci = [
+    {file = "oci-2.40.1-py2.py3-none-any.whl", hash = "sha256:5c8e29366b4c2b8ba23f634b3ef63866cc8028bfdb112bfd3bc0d2b833e4789e"},
+    {file = "oci-2.40.1.tar.gz", hash = "sha256:217509a26e036209f4652acb23973fc42039a5113bbbaf3db9edda9a878fe729"},
+]
 packaging = [
     {file = "packaging-20.9-py2.py3-none-any.whl", hash = "sha256:67714da7f7bc052e064859c05c595155bd1ee9f69f76557e21f051443c20947a"},
     {file = "packaging-20.9.tar.gz", hash = "sha256:5b327ac1320dc863dca72f4514ecc086f31186744b84a230374cc1fd776feae5"},
@@ -1332,6 +1385,10 @@ pyflakes = [
 pygments = [
     {file = "Pygments-2.9.0-py3-none-any.whl", hash = "sha256:d66e804411278594d764fc69ec36ec13d9ae9147193a1740cd34d272ca383b8e"},
     {file = "Pygments-2.9.0.tar.gz", hash = "sha256:a18f47b506a429f6f4b9df81bb02beab9ca21d0a5fee38ed15aef65f0545519f"},
+]
+pyopenssl = [
+    {file = "pyOpenSSL-19.1.0-py2.py3-none-any.whl", hash = "sha256:621880965a720b8ece2f1b2f54ea2071966ab00e2970ad2ce11d596102063504"},
+    {file = "pyOpenSSL-19.1.0.tar.gz", hash = "sha256:9a24494b2602aaf402be5c9e30a0b82d4a5c67528fe8fb475e3f3bc00dd69507"},
 ]
 pyparsing = [
     {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ localzone = { version = ">=0.9.8,<1", optional = true }
 transip = { version = "^2", optional = true }
 softlayer = {version = "^5", optional = true}
 zeep = { version = ">=3,<5", optional = true }
+oci = {version = "^2.40.1", optional = true}
 
 [tool.poetry.extras]
 route53 = ["boto3"]
@@ -56,8 +57,9 @@ localzone = ["localzone"]
 softlayer = ["softlayer"]
 gransy = ["zeep"]
 ddns = ["dnspython"]
+oci = ["oci"]
 # Extra "full" list must contain all other extras
-full = ["boto3", "transip", "localzone", "softlayer", "zeep", "ddns"]
+full = ["boto3", "transip", "localzone", "softlayer", "zeep", "ddns", "oci"]
 
 [tool.poetry.dev-dependencies]
 pytest = "*"

--- a/tests/fixtures/cassettes/oci/IntegrationTests/test_provider_authenticate.yaml
+++ b/tests/fixtures/cassettes/oci/IntegrationTests/test_provider_authenticate.yaml
@@ -1,0 +1,44 @@
+interactions:
+- request:
+    body: null
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:18:27 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com
+  response:
+    body:
+      string: '{"zoneType":"PRIMARY","name":"lexicon-test.com","externalMasters":[],"self":"https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com","timeCreated":"2021-06-23T10:07:46Z","version":"435","serial":435,"nameservers":[{"hostname":"ns1.p68.dns.oraclecloud.net"},{"hostname":"ns2.p68.dns.oraclecloud.net"},{"hostname":"ns3.p68.dns.oraclecloud.net"},{"hostname":"ns4.p68.dns.oraclecloud.net"}],"compartmentId":"OCI-COMPARTMENT-ID","id":"DNS-ZONE-ID","lifecycleState":"ACTIVE","scope":"GLOBAL","viewId":null,"isProtected":false}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:18:28 GMT
+      ETag:
+      - '"435ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168docid1.compartment.oc1..aaaaaaaakklh3onuoqfzgpe4tlflbmabkytrmmukcllef5vfc65quvqhtfsq164374825086dc65cd5dc548c248f61328b5d668#application/json--gzip"'
+      Vary:
+      - Accept-Encoding
+      content-length:
+      - '645'
+      opc-request-id:
+      - /38832CBA85B6072E633266341AE22BD6/93785EDEF33D5EEB20527B5A88BCC58C
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/oci/IntegrationTests/test_provider_authenticate_with_unmanaged_domain_should_fail.yaml
+++ b/tests/fixtures/cassettes/oci/IntegrationTests/test_provider_authenticate_with_unmanaged_domain_should_fail.yaml
@@ -1,0 +1,41 @@
+interactions:
+- request:
+    body: null
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:18:28 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/thisisadomainidonotown.com
+  response:
+    body:
+      string: '{"code":"NotAuthorizedOrNotFound","message":"Authorization failed or
+        requested resource not found."}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '101'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:18:30 GMT
+      opc-request-id:
+      - /FA6FF86C0661513126F5FD7EB7A14AE8/830F7AFFF82E011C9A026688E1004579
+    status:
+      code: 404
+      message: Not Found
+version: 1

--- a/tests/fixtures/cassettes/oci/IntegrationTests/test_provider_when_calling_create_record_for_A_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/oci/IntegrationTests/test_provider_when_calling_create_record_for_A_with_valid_name_and_content.yaml
@@ -1,0 +1,89 @@
+interactions:
+- request:
+    body: null
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:18:30 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com
+  response:
+    body:
+      string: '{"zoneType":"PRIMARY","name":"lexicon-test.com","externalMasters":[],"self":"https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com","timeCreated":"2021-06-23T10:07:46Z","version":"435","serial":435,"nameservers":[{"hostname":"ns1.p68.dns.oraclecloud.net"},{"hostname":"ns2.p68.dns.oraclecloud.net"},{"hostname":"ns3.p68.dns.oraclecloud.net"},{"hostname":"ns4.p68.dns.oraclecloud.net"}],"compartmentId":"OCI-COMPARTMENT-ID","id":"DNS-ZONE-ID","lifecycleState":"ACTIVE","scope":"GLOBAL","viewId":null,"isProtected":false}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:18:32 GMT
+      ETag:
+      - '"435ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168docid1.compartment.oc1..aaaaaaaakklh3onuoqfzgpe4tlflbmabkytrmmukcllef5vfc65quvqhtfsq164374825086dc65cd5dc548c248f61328b5d668#application/json--gzip"'
+      Vary:
+      - Accept-Encoding
+      content-length:
+      - '645'
+      opc-request-id:
+      - /DB675F191B92CD03F25804AF2F99B5BD/20B4D88032345BA683B9CB4A4972F864
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"items": [{"operation": "ADD", "rtype": "A", "rdata": "127.0.0.1", "ttl":
+      3600}]}'
+    headers:
+      Content-Length:
+      - '82'
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:18:32 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: PATCH
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com/records/localhost.lexicon-test.com
+  response:
+    body:
+      string: '{"items":[{"domain":"localhost.lexicon-test.com","recordHash":"20068f94cf294942b1811fd409231dbe","isProtected":false,"rdata":"127.0.0.1","rrsetVersion":"277","rtype":"A","ttl":3600}]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '184'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:18:34 GMT
+      ETag:
+      - '"277ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168d#application/json"'
+      opc-request-id:
+      - /6F627AC2C24941E784E2F0160E426D40/F980AE88A2063E8A42D00D9C7CD9A644
+      opc-total-items:
+      - '1'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/oci/IntegrationTests/test_provider_when_calling_create_record_for_CNAME_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/oci/IntegrationTests/test_provider_when_calling_create_record_for_CNAME_with_valid_name_and_content.yaml
@@ -1,0 +1,89 @@
+interactions:
+- request:
+    body: null
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:18:34 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com
+  response:
+    body:
+      string: '{"zoneType":"PRIMARY","name":"lexicon-test.com","externalMasters":[],"self":"https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com","timeCreated":"2021-06-23T10:07:46Z","version":"435","serial":435,"nameservers":[{"hostname":"ns1.p68.dns.oraclecloud.net"},{"hostname":"ns2.p68.dns.oraclecloud.net"},{"hostname":"ns3.p68.dns.oraclecloud.net"},{"hostname":"ns4.p68.dns.oraclecloud.net"}],"compartmentId":"OCI-COMPARTMENT-ID","id":"DNS-ZONE-ID","lifecycleState":"ACTIVE","scope":"GLOBAL","viewId":null,"isProtected":false}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:18:36 GMT
+      ETag:
+      - '"435ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168docid1.compartment.oc1..aaaaaaaakklh3onuoqfzgpe4tlflbmabkytrmmukcllef5vfc65quvqhtfsq164374825086dc65cd5dc548c248f61328b5d668#application/json--gzip"'
+      Vary:
+      - Accept-Encoding
+      content-length:
+      - '645'
+      opc-request-id:
+      - /CE86F09FF545C3FA72C08C3BAFF94EEC/3B9BCEA134331ED27E082540D4DEF763
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"items": [{"operation": "ADD", "rtype": "CNAME", "rdata": "docs.example.com",
+      "ttl": 3600}]}'
+    headers:
+      Content-Length:
+      - '93'
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:18:36 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: PATCH
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com/records/docs.lexicon-test.com
+  response:
+    body:
+      string: '{"items":[{"domain":"docs.lexicon-test.com","recordHash":"d6fe36b079d4ac2985b25a5b96882cd7","isProtected":false,"rdata":"docs.example.com.","rrsetVersion":"278","rtype":"CNAME","ttl":3600}]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '191'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:18:39 GMT
+      ETag:
+      - '"278ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168d#application/json"'
+      opc-request-id:
+      - /2C677C7D2C903ACF8B40E95026B1470E/0EE9C6673B38DAC4A3C9F4C3C18E4E8C
+      opc-total-items:
+      - '1'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/oci/IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_fqdn_name_and_content.yaml
+++ b/tests/fixtures/cassettes/oci/IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_fqdn_name_and_content.yaml
@@ -1,0 +1,89 @@
+interactions:
+- request:
+    body: null
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:18:39 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com
+  response:
+    body:
+      string: '{"zoneType":"PRIMARY","name":"lexicon-test.com","externalMasters":[],"self":"https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com","timeCreated":"2021-06-23T10:07:46Z","version":"435","serial":435,"nameservers":[{"hostname":"ns1.p68.dns.oraclecloud.net"},{"hostname":"ns2.p68.dns.oraclecloud.net"},{"hostname":"ns3.p68.dns.oraclecloud.net"},{"hostname":"ns4.p68.dns.oraclecloud.net"}],"compartmentId":"OCI-COMPARTMENT-ID","id":"DNS-ZONE-ID","lifecycleState":"ACTIVE","scope":"GLOBAL","viewId":null,"isProtected":false}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:18:40 GMT
+      ETag:
+      - '"435ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168docid1.compartment.oc1..aaaaaaaakklh3onuoqfzgpe4tlflbmabkytrmmukcllef5vfc65quvqhtfsq164374825086dc65cd5dc548c248f61328b5d668#application/json--gzip"'
+      Vary:
+      - Accept-Encoding
+      content-length:
+      - '645'
+      opc-request-id:
+      - /19C0A46FAACA034C78C6ADFEB9C5DC00/6452E76A513B2B84E64A1B3318345B74
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"items": [{"operation": "ADD", "rtype": "TXT", "rdata": "challengetoken",
+      "ttl": 3600}]}'
+    headers:
+      Content-Length:
+      - '89'
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:18:40 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: PATCH
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com/records/_acme-challenge.fqdn.lexicon-test.com
+  response:
+    body:
+      string: '{"items":[{"domain":"_acme-challenge.fqdn.lexicon-test.com","recordHash":"2e1d5026438c46441999c0ed61cb6450","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"279","rtype":"TXT","ttl":3600}]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '206'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:18:43 GMT
+      ETag:
+      - '"279ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168d#application/json"'
+      opc-request-id:
+      - /3E6D89C41DC46DC16DAA83FD2A2E6268/CBF88161708FF7B547F22576B2A6029E
+      opc-total-items:
+      - '1'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/oci/IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_full_name_and_content.yaml
+++ b/tests/fixtures/cassettes/oci/IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_full_name_and_content.yaml
@@ -1,0 +1,89 @@
+interactions:
+- request:
+    body: null
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:18:43 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com
+  response:
+    body:
+      string: '{"zoneType":"PRIMARY","name":"lexicon-test.com","externalMasters":[],"self":"https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com","timeCreated":"2021-06-23T10:07:46Z","version":"435","serial":435,"nameservers":[{"hostname":"ns1.p68.dns.oraclecloud.net"},{"hostname":"ns2.p68.dns.oraclecloud.net"},{"hostname":"ns3.p68.dns.oraclecloud.net"},{"hostname":"ns4.p68.dns.oraclecloud.net"}],"compartmentId":"OCI-COMPARTMENT-ID","id":"DNS-ZONE-ID","lifecycleState":"ACTIVE","scope":"GLOBAL","viewId":null,"isProtected":false}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:18:44 GMT
+      ETag:
+      - '"435ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168docid1.compartment.oc1..aaaaaaaakklh3onuoqfzgpe4tlflbmabkytrmmukcllef5vfc65quvqhtfsq164374825086dc65cd5dc548c248f61328b5d668#application/json--gzip"'
+      Vary:
+      - Accept-Encoding
+      content-length:
+      - '645'
+      opc-request-id:
+      - /DF0FE4D6E837CF26A21769A4905C7AEB/735E7FCD0E375CFD5EA6018251BAF627
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"items": [{"operation": "ADD", "rtype": "TXT", "rdata": "challengetoken",
+      "ttl": 3600}]}'
+    headers:
+      Content-Length:
+      - '89'
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:18:45 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: PATCH
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com/records/_acme-challenge.full.lexicon-test.com
+  response:
+    body:
+      string: '{"items":[{"domain":"_acme-challenge.full.lexicon-test.com","recordHash":"92f11feb1c17981adef50d1c93ec3c5e","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"280","rtype":"TXT","ttl":3600}]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '206'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:18:47 GMT
+      ETag:
+      - '"280ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168d#application/json"'
+      opc-request-id:
+      - /EBCA2C5017DFF21D3E44B414A76FA197/CEE962DCE27DE4CAF5B4B11880267F17
+      opc-total-items:
+      - '1'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/oci/IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/oci/IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_valid_name_and_content.yaml
@@ -1,0 +1,89 @@
+interactions:
+- request:
+    body: null
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:18:47 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com
+  response:
+    body:
+      string: '{"zoneType":"PRIMARY","name":"lexicon-test.com","externalMasters":[],"self":"https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com","timeCreated":"2021-06-23T10:07:46Z","version":"435","serial":435,"nameservers":[{"hostname":"ns1.p68.dns.oraclecloud.net"},{"hostname":"ns2.p68.dns.oraclecloud.net"},{"hostname":"ns3.p68.dns.oraclecloud.net"},{"hostname":"ns4.p68.dns.oraclecloud.net"}],"compartmentId":"OCI-COMPARTMENT-ID","id":"DNS-ZONE-ID","lifecycleState":"ACTIVE","scope":"GLOBAL","viewId":null,"isProtected":false}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:18:48 GMT
+      ETag:
+      - '"435ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168docid1.compartment.oc1..aaaaaaaakklh3onuoqfzgpe4tlflbmabkytrmmukcllef5vfc65quvqhtfsq164374825086dc65cd5dc548c248f61328b5d668#application/json--gzip"'
+      Vary:
+      - Accept-Encoding
+      content-length:
+      - '645'
+      opc-request-id:
+      - /C72DACE73ECCFA67409CAAD9E84E4EA2/BEAEB147B11D9E0B12AA2544421414A2
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"items": [{"operation": "ADD", "rtype": "TXT", "rdata": "challengetoken",
+      "ttl": 3600}]}'
+    headers:
+      Content-Length:
+      - '89'
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:18:48 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: PATCH
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com/records/_acme-challenge.test.lexicon-test.com
+  response:
+    body:
+      string: '{"items":[{"domain":"_acme-challenge.test.lexicon-test.com","recordHash":"768ea81c2972b69ac41fd65fe5bb53be","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"281","rtype":"TXT","ttl":3600}]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '206'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:18:50 GMT
+      ETag:
+      - '"281ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168d#application/json"'
+      opc-request-id:
+      - /3C6CEA02252CC33FAACCCC13898FAE4B/24FECDFAF417AD73D307F14D1B16BAFD
+      opc-total-items:
+      - '1'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/oci/IntegrationTests/test_provider_when_calling_create_record_multiple_times_should_create_record_set.yaml
+++ b/tests/fixtures/cassettes/oci/IntegrationTests/test_provider_when_calling_create_record_multiple_times_should_create_record_set.yaml
@@ -1,0 +1,134 @@
+interactions:
+- request:
+    body: null
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:18:51 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com
+  response:
+    body:
+      string: '{"zoneType":"PRIMARY","name":"lexicon-test.com","externalMasters":[],"self":"https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com","timeCreated":"2021-06-23T10:07:46Z","version":"435","serial":435,"nameservers":[{"hostname":"ns1.p68.dns.oraclecloud.net"},{"hostname":"ns2.p68.dns.oraclecloud.net"},{"hostname":"ns3.p68.dns.oraclecloud.net"},{"hostname":"ns4.p68.dns.oraclecloud.net"}],"compartmentId":"OCI-COMPARTMENT-ID","id":"DNS-ZONE-ID","lifecycleState":"ACTIVE","scope":"GLOBAL","viewId":null,"isProtected":false}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:18:52 GMT
+      ETag:
+      - '"435ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168docid1.compartment.oc1..aaaaaaaakklh3onuoqfzgpe4tlflbmabkytrmmukcllef5vfc65quvqhtfsq164374825086dc65cd5dc548c248f61328b5d668#application/json--gzip"'
+      Vary:
+      - Accept-Encoding
+      content-length:
+      - '645'
+      opc-request-id:
+      - /006AD0A12487F2DB928F8A557718DAFF/E59AD15A754B74A3DE3DF79D5374B826
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"items": [{"operation": "ADD", "rtype": "TXT", "rdata": "challengetoken1",
+      "ttl": 3600}]}'
+    headers:
+      Content-Length:
+      - '90'
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:18:52 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: PATCH
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com/records/_acme-challenge.createrecordset.lexicon-test.com
+  response:
+    body:
+      string: '{"items":[{"domain":"_acme-challenge.createrecordset.lexicon-test.com","recordHash":"b6ebc41fde88500b72e3c74ed37f555e","isProtected":false,"rdata":"\"challengetoken2\"","rrsetVersion":"283","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.createrecordset.lexicon-test.com","recordHash":"eaca746d30c89bd96cf39ad069a282ce","isProtected":false,"rdata":"\"challengetoken1\"","rrsetVersion":"283","rtype":"TXT","ttl":3600}]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '424'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:18:55 GMT
+      ETag:
+      - '"283ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168d#application/json"'
+      opc-request-id:
+      - /5605A5AB2006A1D0682EF180CE141A22/E1489CE9EAC454F5EBDEB7BA2A5471D1
+      opc-total-items:
+      - '2'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"items": [{"operation": "ADD", "rtype": "TXT", "rdata": "challengetoken2",
+      "ttl": 3600}]}'
+    headers:
+      Content-Length:
+      - '90'
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:18:55 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: PATCH
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com/records/_acme-challenge.createrecordset.lexicon-test.com
+  response:
+    body:
+      string: '{"items":[{"domain":"_acme-challenge.createrecordset.lexicon-test.com","recordHash":"b6ebc41fde88500b72e3c74ed37f555e","isProtected":false,"rdata":"\"challengetoken2\"","rrsetVersion":"283","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.createrecordset.lexicon-test.com","recordHash":"eaca746d30c89bd96cf39ad069a282ce","isProtected":false,"rdata":"\"challengetoken1\"","rrsetVersion":"283","rtype":"TXT","ttl":3600}]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '424'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:18:57 GMT
+      ETag:
+      - '"283ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168d#application/json"'
+      opc-request-id:
+      - /5EF25E6DD4221781CAC3C93D1946E06D/B7FA48A4F7F59DB04EDC74E50F98E7FE
+      opc-total-items:
+      - '2'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/oci/IntegrationTests/test_provider_when_calling_create_record_with_duplicate_records_should_be_noop.yaml
+++ b/tests/fixtures/cassettes/oci/IntegrationTests/test_provider_when_calling_create_record_with_duplicate_records_should_be_noop.yaml
@@ -1,0 +1,178 @@
+interactions:
+- request:
+    body: null
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:18:57 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com
+  response:
+    body:
+      string: '{"zoneType":"PRIMARY","name":"lexicon-test.com","externalMasters":[],"self":"https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com","timeCreated":"2021-06-23T10:07:46Z","version":"435","serial":435,"nameservers":[{"hostname":"ns1.p68.dns.oraclecloud.net"},{"hostname":"ns2.p68.dns.oraclecloud.net"},{"hostname":"ns3.p68.dns.oraclecloud.net"},{"hostname":"ns4.p68.dns.oraclecloud.net"}],"compartmentId":"OCI-COMPARTMENT-ID","id":"DNS-ZONE-ID","lifecycleState":"ACTIVE","scope":"GLOBAL","viewId":null,"isProtected":false}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:19:00 GMT
+      ETag:
+      - '"435ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168docid1.compartment.oc1..aaaaaaaakklh3onuoqfzgpe4tlflbmabkytrmmukcllef5vfc65quvqhtfsq164374825086dc65cd5dc548c248f61328b5d668#application/json--gzip"'
+      Vary:
+      - Accept-Encoding
+      content-length:
+      - '645'
+      opc-request-id:
+      - /A516C990E3FD586EB025B75BA3CFF21B/13E55746D1BCF1C695B3221AB42D2861
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"items": [{"operation": "ADD", "rtype": "TXT", "rdata": "challengetoken",
+      "ttl": 3600}]}'
+    headers:
+      Content-Length:
+      - '89'
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:19:00 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: PATCH
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com/records/_acme-challenge.noop.lexicon-test.com
+  response:
+    body:
+      string: '{"items":[{"domain":"_acme-challenge.noop.lexicon-test.com","recordHash":"575c16c67d0a8ec908f50cca7bc8c0cb","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"284","rtype":"TXT","ttl":3600}]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '206'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:19:04 GMT
+      ETag:
+      - '"284ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168d#application/json"'
+      opc-request-id:
+      - /84C330C00D0CB417AC22356EFFAD38DE/92BC230DBFEE1290C152FC97062A7497
+      opc-total-items:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"items": [{"operation": "ADD", "rtype": "TXT", "rdata": "challengetoken",
+      "ttl": 3600}]}'
+    headers:
+      Content-Length:
+      - '89'
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:19:04 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: PATCH
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com/records/_acme-challenge.noop.lexicon-test.com
+  response:
+    body:
+      string: '{"items":[{"domain":"_acme-challenge.noop.lexicon-test.com","recordHash":"575c16c67d0a8ec908f50cca7bc8c0cb","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"284","rtype":"TXT","ttl":3600}]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '206'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:19:06 GMT
+      ETag:
+      - '"284ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168d#application/json"'
+      opc-request-id:
+      - /C01A4C78789E66309B63644FC6893222/5D43BEBA5E8933FE8FABC6BC8BE195C2
+      opc-total-items:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:19:07 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com/records/_acme-challenge.noop.lexicon-test.com?limit=100&rtype=TXT
+  response:
+    body:
+      string: '{"items":[{"domain":"_acme-challenge.noop.lexicon-test.com","recordHash":"575c16c67d0a8ec908f50cca7bc8c0cb","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"284","rtype":"TXT","ttl":3600}]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '206'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:19:08 GMT
+      ETag:
+      - '"284ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168d#application/json"'
+      Vary:
+      - Accept-Encoding
+      opc-request-id:
+      - /F68F7683FD8C0F8F09D99EB040146C52/A33F9D61EF819705A1C4D941C68B3DA7
+      opc-total-items:
+      - '1'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/oci/IntegrationTests/test_provider_when_calling_delete_record_by_filter_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/oci/IntegrationTests/test_provider_when_calling_delete_record_by_filter_should_remove_record.yaml
@@ -1,0 +1,222 @@
+interactions:
+- request:
+    body: null
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:19:09 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com
+  response:
+    body:
+      string: '{"zoneType":"PRIMARY","name":"lexicon-test.com","externalMasters":[],"self":"https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com","timeCreated":"2021-06-23T10:07:46Z","version":"435","serial":435,"nameservers":[{"hostname":"ns1.p68.dns.oraclecloud.net"},{"hostname":"ns2.p68.dns.oraclecloud.net"},{"hostname":"ns3.p68.dns.oraclecloud.net"},{"hostname":"ns4.p68.dns.oraclecloud.net"}],"compartmentId":"OCI-COMPARTMENT-ID","id":"DNS-ZONE-ID","lifecycleState":"ACTIVE","scope":"GLOBAL","viewId":null,"isProtected":false}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:19:10 GMT
+      ETag:
+      - '"435ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168docid1.compartment.oc1..aaaaaaaakklh3onuoqfzgpe4tlflbmabkytrmmukcllef5vfc65quvqhtfsq164374825086dc65cd5dc548c248f61328b5d668#application/json--gzip"'
+      Vary:
+      - Accept-Encoding
+      content-length:
+      - '645'
+      opc-request-id:
+      - /422CF717D2A808A32F405D19BABBA905/E9E8CAAE92ED54711FD6B29FCA3C226B
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"items": [{"operation": "ADD", "rtype": "TXT", "rdata": "challengetoken",
+      "ttl": 3600}]}'
+    headers:
+      Content-Length:
+      - '89'
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:19:10 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: PATCH
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com/records/delete.testfilt.lexicon-test.com
+  response:
+    body:
+      string: '{"items":[{"domain":"delete.testfilt.lexicon-test.com","recordHash":"15937d8e0be61249296bf77e76a7a675","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"436","rtype":"TXT","ttl":3600}]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '201'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:19:13 GMT
+      ETag:
+      - '"436ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168d#application/json"'
+      opc-request-id:
+      - /1A8D1442B84B397F7B88AB1FD07624ED/8E2709A13F9BDC803BD1500CFB1BF3CD
+      opc-total-items:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:19:13 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com/records/delete.testfilt.lexicon-test.com?limit=100&rtype=TXT
+  response:
+    body:
+      string: '{"items":[{"domain":"delete.testfilt.lexicon-test.com","recordHash":"15937d8e0be61249296bf77e76a7a675","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"436","rtype":"TXT","ttl":3600}]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '201'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:19:15 GMT
+      ETag:
+      - '"436ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168d#application/json"'
+      Vary:
+      - Accept-Encoding
+      opc-request-id:
+      - /337D6E506C87B96454769F95B230822C/98033782C36AFCCA07DAF831F097958B
+      opc-total-items:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"items": [{"operation": "REMOVE", "recordHash": "15937d8e0be61249296bf77e76a7a675"}]}'
+    headers:
+      Content-Length:
+      - '86'
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:19:15 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: PATCH
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com/records
+  response:
+    body:
+      string: '{"items":[{"domain":"docs.lexicon-test.com","recordHash":"d6fe36b079d4ac2985b25a5b96882cd7","isProtected":false,"rdata":"docs.example.com.","rrsetVersion":"278","rtype":"CNAME","ttl":3600},{"domain":"lexicon-test.com","recordHash":"5ce9d2cc56bc9db57ba9d998a98d911a","isProtected":true,"rdata":"ns1.p68.dns.oraclecloud.net.
+        hostmaster.lexicon-test.com. 437 3600 600 604800 1800","rrsetVersion":"437","rtype":"SOA","ttl":300},{"domain":"lexicon-test.com","recordHash":"8afe5805e230374e4703870ce5e1b362","isProtected":true,"rdata":"ns4.p68.dns.oraclecloud.net.","rrsetVersion":"1","rtype":"NS","ttl":86400},{"domain":"lexicon-test.com","recordHash":"cab28e6a040cdfae00893dad01209480","isProtected":true,"rdata":"ns2.p68.dns.oraclecloud.net.","rrsetVersion":"1","rtype":"NS","ttl":86400},{"domain":"lexicon-test.com","recordHash":"e276958b1b2c5ec312c120f9448f0295","isProtected":true,"rdata":"ns1.p68.dns.oraclecloud.net.","rrsetVersion":"1","rtype":"NS","ttl":86400},{"domain":"lexicon-test.com","recordHash":"fc5e04ede640257ab27fe19e8554c727","isProtected":true,"rdata":"ns3.p68.dns.oraclecloud.net.","rrsetVersion":"1","rtype":"NS","ttl":86400},{"domain":"localhost.lexicon-test.com","recordHash":"20068f94cf294942b1811fd409231dbe","isProtected":false,"rdata":"127.0.0.1","rrsetVersion":"277","rtype":"A","ttl":3600},{"domain":"orig.nameonly.test.lexicon-test.com","recordHash":"896d848b26f834d9c8fe08f83aaa580b","isProtected":false,"rdata":"\"updated\"","rrsetVersion":"321","rtype":"TXT","ttl":3600},{"domain":"orig.nameonly.test.lexicon-test.com","recordHash":"d96871ac7da8df9d246600731475f74a","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"321","rtype":"TXT","ttl":3600},{"domain":"orig.test.lexicon-test.com","recordHash":"c7825b2895d6a22416fe1e807f86d27d","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"304","rtype":"TXT","ttl":3600},{"domain":"orig.testfqdn.lexicon-test.com","recordHash":"b157b0f18514bf637d2da9a60c2d5db7","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"306","rtype":"TXT","ttl":3600},{"domain":"orig.testfull.lexicon-test.com","recordHash":"5812b10f4c43f8ac590a8bd07f5dce3c","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"307","rtype":"TXT","ttl":3600},{"domain":"random.fqdntest.lexicon-test.com","recordHash":"5d5b4b9a09be257562199ec4184d0a93","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"301","rtype":"TXT","ttl":3600},{"domain":"random.fulltest.lexicon-test.com","recordHash":"da642cca98776d00b0f61fad4051e489","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"302","rtype":"TXT","ttl":3600},{"domain":"random.test.lexicon-test.com","recordHash":"5939d233a3249cb1034c6267ee7d1013","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"303","rtype":"TXT","ttl":3600},{"domain":"ttl.fqdn.lexicon-test.com","recordHash":"b1a860728a050a1e193737002a8c392e","isProtected":false,"rdata":"\"ttlshouldbe3600\"","rrsetVersion":"298","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.createrecordset.lexicon-test.com","recordHash":"b6ebc41fde88500b72e3c74ed37f555e","isProtected":false,"rdata":"\"challengetoken2\"","rrsetVersion":"283","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.createrecordset.lexicon-test.com","recordHash":"eaca746d30c89bd96cf39ad069a282ce","isProtected":false,"rdata":"\"challengetoken1\"","rrsetVersion":"283","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.deleterecordinset.lexicon-test.com","recordHash":"05a878f361773a0bcaa7ac0b74900b7f","isProtected":false,"rdata":"\"challengetoken2\"","rrsetVersion":"432","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.fqdn.lexicon-test.com","recordHash":"2e1d5026438c46441999c0ed61cb6450","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"279","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.full.lexicon-test.com","recordHash":"92f11feb1c17981adef50d1c93ec3c5e","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"280","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.listrecordset.lexicon-test.com","recordHash":"06c966e4438fe15715878d4105682b58","isProtected":false,"rdata":"\"challengetoken1\"","rrsetVersion":"300","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.listrecordset.lexicon-test.com","recordHash":"cc91cf484d8cd148c3e9ddd3fd4018c0","isProtected":false,"rdata":"\"challengetoken2\"","rrsetVersion":"300","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.noop.lexicon-test.com","recordHash":"575c16c67d0a8ec908f50cca7bc8c0cb","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"284","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.test.lexicon-test.com","recordHash":"768ea81c2972b69ac41fd65fe5bb53be","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"281","rtype":"TXT","ttl":3600}]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '4802'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:19:18 GMT
+      ETag:
+      - '"437ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168d#application/json"'
+      opc-request-id:
+      - /2E4A62E71978BE090388BD855D5C95EE/37AF05163EBF3B87767A709C4387C149
+      opc-total-items:
+      - '25'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:19:18 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com/records/delete.testfilt.lexicon-test.com?limit=100&rtype=TXT
+  response:
+    body:
+      string: '{"items":[]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '13'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:19:21 GMT
+      ETag:
+      - '"437ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168d#application/json"'
+      Vary:
+      - Accept-Encoding
+      opc-request-id:
+      - /A1D8263C9E428D5727F914C2EC44E7AB/0F10CCD3A74EE9A938FC7EBF4231B139
+      opc-total-items:
+      - '0'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/oci/IntegrationTests/test_provider_when_calling_delete_record_by_filter_with_fqdn_name_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/oci/IntegrationTests/test_provider_when_calling_delete_record_by_filter_with_fqdn_name_should_remove_record.yaml
@@ -1,0 +1,222 @@
+interactions:
+- request:
+    body: null
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:19:21 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com
+  response:
+    body:
+      string: '{"zoneType":"PRIMARY","name":"lexicon-test.com","externalMasters":[],"self":"https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com","timeCreated":"2021-06-23T10:07:46Z","version":"437","serial":437,"nameservers":[{"hostname":"ns1.p68.dns.oraclecloud.net"},{"hostname":"ns2.p68.dns.oraclecloud.net"},{"hostname":"ns3.p68.dns.oraclecloud.net"},{"hostname":"ns4.p68.dns.oraclecloud.net"}],"compartmentId":"OCI-COMPARTMENT-ID","id":"DNS-ZONE-ID","lifecycleState":"ACTIVE","scope":"GLOBAL","viewId":null,"isProtected":false}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:19:23 GMT
+      ETag:
+      - '"437ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168docid1.compartment.oc1..aaaaaaaakklh3onuoqfzgpe4tlflbmabkytrmmukcllef5vfc65quvqhtfsq164374825086dc65cd5dc548c248f61328b5d668#application/json--gzip"'
+      Vary:
+      - Accept-Encoding
+      content-length:
+      - '645'
+      opc-request-id:
+      - /24D5F52F671CA16599FF9B321823F75E/5AC0FE7EB527F4307CF1D7CB5CE035A1
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"items": [{"operation": "ADD", "rtype": "TXT", "rdata": "challengetoken",
+      "ttl": 3600}]}'
+    headers:
+      Content-Length:
+      - '89'
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:19:23 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: PATCH
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com/records/delete.testfqdn.lexicon-test.com
+  response:
+    body:
+      string: '{"items":[{"domain":"delete.testfqdn.lexicon-test.com","recordHash":"9474b14f5a802399805027dd51c5d72e","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"438","rtype":"TXT","ttl":3600}]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '201'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:19:26 GMT
+      ETag:
+      - '"438ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168d#application/json"'
+      opc-request-id:
+      - /1A49377F2BB20DAD2C4F665DB43E5262/B7D600DACB04B29B186068F5FD65DC70
+      opc-total-items:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:19:26 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com/records/delete.testfqdn.lexicon-test.com?limit=100&rtype=TXT
+  response:
+    body:
+      string: '{"items":[{"domain":"delete.testfqdn.lexicon-test.com","recordHash":"9474b14f5a802399805027dd51c5d72e","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"438","rtype":"TXT","ttl":3600}]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '201'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:19:29 GMT
+      ETag:
+      - '"438ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168d#application/json"'
+      Vary:
+      - Accept-Encoding
+      opc-request-id:
+      - /9613808E081D3CC6A0EC7597ADEED716/6C69F87C949D2CCAF7EDC48BF2A02C88
+      opc-total-items:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"items": [{"operation": "REMOVE", "recordHash": "9474b14f5a802399805027dd51c5d72e"}]}'
+    headers:
+      Content-Length:
+      - '86'
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:19:29 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: PATCH
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com/records
+  response:
+    body:
+      string: '{"items":[{"domain":"docs.lexicon-test.com","recordHash":"d6fe36b079d4ac2985b25a5b96882cd7","isProtected":false,"rdata":"docs.example.com.","rrsetVersion":"278","rtype":"CNAME","ttl":3600},{"domain":"lexicon-test.com","recordHash":"5ce9d2cc56bc9db57ba9d998a98d911a","isProtected":true,"rdata":"ns1.p68.dns.oraclecloud.net.
+        hostmaster.lexicon-test.com. 439 3600 600 604800 1800","rrsetVersion":"439","rtype":"SOA","ttl":300},{"domain":"lexicon-test.com","recordHash":"8afe5805e230374e4703870ce5e1b362","isProtected":true,"rdata":"ns4.p68.dns.oraclecloud.net.","rrsetVersion":"1","rtype":"NS","ttl":86400},{"domain":"lexicon-test.com","recordHash":"cab28e6a040cdfae00893dad01209480","isProtected":true,"rdata":"ns2.p68.dns.oraclecloud.net.","rrsetVersion":"1","rtype":"NS","ttl":86400},{"domain":"lexicon-test.com","recordHash":"e276958b1b2c5ec312c120f9448f0295","isProtected":true,"rdata":"ns1.p68.dns.oraclecloud.net.","rrsetVersion":"1","rtype":"NS","ttl":86400},{"domain":"lexicon-test.com","recordHash":"fc5e04ede640257ab27fe19e8554c727","isProtected":true,"rdata":"ns3.p68.dns.oraclecloud.net.","rrsetVersion":"1","rtype":"NS","ttl":86400},{"domain":"localhost.lexicon-test.com","recordHash":"20068f94cf294942b1811fd409231dbe","isProtected":false,"rdata":"127.0.0.1","rrsetVersion":"277","rtype":"A","ttl":3600},{"domain":"orig.nameonly.test.lexicon-test.com","recordHash":"896d848b26f834d9c8fe08f83aaa580b","isProtected":false,"rdata":"\"updated\"","rrsetVersion":"321","rtype":"TXT","ttl":3600},{"domain":"orig.nameonly.test.lexicon-test.com","recordHash":"d96871ac7da8df9d246600731475f74a","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"321","rtype":"TXT","ttl":3600},{"domain":"orig.test.lexicon-test.com","recordHash":"c7825b2895d6a22416fe1e807f86d27d","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"304","rtype":"TXT","ttl":3600},{"domain":"orig.testfqdn.lexicon-test.com","recordHash":"b157b0f18514bf637d2da9a60c2d5db7","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"306","rtype":"TXT","ttl":3600},{"domain":"orig.testfull.lexicon-test.com","recordHash":"5812b10f4c43f8ac590a8bd07f5dce3c","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"307","rtype":"TXT","ttl":3600},{"domain":"random.fqdntest.lexicon-test.com","recordHash":"5d5b4b9a09be257562199ec4184d0a93","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"301","rtype":"TXT","ttl":3600},{"domain":"random.fulltest.lexicon-test.com","recordHash":"da642cca98776d00b0f61fad4051e489","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"302","rtype":"TXT","ttl":3600},{"domain":"random.test.lexicon-test.com","recordHash":"5939d233a3249cb1034c6267ee7d1013","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"303","rtype":"TXT","ttl":3600},{"domain":"ttl.fqdn.lexicon-test.com","recordHash":"b1a860728a050a1e193737002a8c392e","isProtected":false,"rdata":"\"ttlshouldbe3600\"","rrsetVersion":"298","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.createrecordset.lexicon-test.com","recordHash":"b6ebc41fde88500b72e3c74ed37f555e","isProtected":false,"rdata":"\"challengetoken2\"","rrsetVersion":"283","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.createrecordset.lexicon-test.com","recordHash":"eaca746d30c89bd96cf39ad069a282ce","isProtected":false,"rdata":"\"challengetoken1\"","rrsetVersion":"283","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.deleterecordinset.lexicon-test.com","recordHash":"05a878f361773a0bcaa7ac0b74900b7f","isProtected":false,"rdata":"\"challengetoken2\"","rrsetVersion":"432","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.fqdn.lexicon-test.com","recordHash":"2e1d5026438c46441999c0ed61cb6450","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"279","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.full.lexicon-test.com","recordHash":"92f11feb1c17981adef50d1c93ec3c5e","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"280","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.listrecordset.lexicon-test.com","recordHash":"06c966e4438fe15715878d4105682b58","isProtected":false,"rdata":"\"challengetoken1\"","rrsetVersion":"300","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.listrecordset.lexicon-test.com","recordHash":"cc91cf484d8cd148c3e9ddd3fd4018c0","isProtected":false,"rdata":"\"challengetoken2\"","rrsetVersion":"300","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.noop.lexicon-test.com","recordHash":"575c16c67d0a8ec908f50cca7bc8c0cb","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"284","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.test.lexicon-test.com","recordHash":"768ea81c2972b69ac41fd65fe5bb53be","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"281","rtype":"TXT","ttl":3600}]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '4802'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:19:32 GMT
+      ETag:
+      - '"439ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168d#application/json"'
+      opc-request-id:
+      - /F997DB9719C9A437F1E7B24FC16CB2CF/628DF7E987B56892F0A08C22280BC6CB
+      opc-total-items:
+      - '25'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:19:32 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com/records/delete.testfqdn.lexicon-test.com?limit=100&rtype=TXT
+  response:
+    body:
+      string: '{"items":[]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '13'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:19:34 GMT
+      ETag:
+      - '"439ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168d#application/json"'
+      Vary:
+      - Accept-Encoding
+      opc-request-id:
+      - /96050E93AB1A783FED9D701E137D6D7A/53F06811B3C7E2628DA7F4994676A888
+      opc-total-items:
+      - '0'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/oci/IntegrationTests/test_provider_when_calling_delete_record_by_filter_with_full_name_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/oci/IntegrationTests/test_provider_when_calling_delete_record_by_filter_with_full_name_should_remove_record.yaml
@@ -1,0 +1,222 @@
+interactions:
+- request:
+    body: null
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:19:34 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com
+  response:
+    body:
+      string: '{"zoneType":"PRIMARY","name":"lexicon-test.com","externalMasters":[],"self":"https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com","timeCreated":"2021-06-23T10:07:46Z","version":"439","serial":439,"nameservers":[{"hostname":"ns1.p68.dns.oraclecloud.net"},{"hostname":"ns2.p68.dns.oraclecloud.net"},{"hostname":"ns3.p68.dns.oraclecloud.net"},{"hostname":"ns4.p68.dns.oraclecloud.net"}],"compartmentId":"OCI-COMPARTMENT-ID","id":"DNS-ZONE-ID","lifecycleState":"ACTIVE","scope":"GLOBAL","viewId":null,"isProtected":false}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:19:36 GMT
+      ETag:
+      - '"439ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168docid1.compartment.oc1..aaaaaaaakklh3onuoqfzgpe4tlflbmabkytrmmukcllef5vfc65quvqhtfsq164374825086dc65cd5dc548c248f61328b5d668#application/json--gzip"'
+      Vary:
+      - Accept-Encoding
+      content-length:
+      - '645'
+      opc-request-id:
+      - /F30917F8341A4C24F130EDB5833BB6D0/E932B6EC20F7975395F1179A2DAF249F
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"items": [{"operation": "ADD", "rtype": "TXT", "rdata": "challengetoken",
+      "ttl": 3600}]}'
+    headers:
+      Content-Length:
+      - '89'
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:19:36 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: PATCH
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com/records/delete.testfull.lexicon-test.com
+  response:
+    body:
+      string: '{"items":[{"domain":"delete.testfull.lexicon-test.com","recordHash":"f2da6c9d9803f60f6bf2ec467db5f587","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"440","rtype":"TXT","ttl":3600}]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '201'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:19:39 GMT
+      ETag:
+      - '"440ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168d#application/json"'
+      opc-request-id:
+      - /03020BFE943094E9246D74F35115656C/29891C4014A7AFDAF333D82A7BC67814
+      opc-total-items:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:19:40 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com/records/delete.testfull.lexicon-test.com?limit=100&rtype=TXT
+  response:
+    body:
+      string: '{"items":[{"domain":"delete.testfull.lexicon-test.com","recordHash":"f2da6c9d9803f60f6bf2ec467db5f587","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"440","rtype":"TXT","ttl":3600}]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '201'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:19:41 GMT
+      ETag:
+      - '"440ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168d#application/json"'
+      Vary:
+      - Accept-Encoding
+      opc-request-id:
+      - /B6B93DAB9EE5CA425E7061157FA0C90F/EEABA82C40A9F5BFD96F2BCD6A78539C
+      opc-total-items:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"items": [{"operation": "REMOVE", "recordHash": "f2da6c9d9803f60f6bf2ec467db5f587"}]}'
+    headers:
+      Content-Length:
+      - '86'
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:19:42 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: PATCH
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com/records
+  response:
+    body:
+      string: '{"items":[{"domain":"docs.lexicon-test.com","recordHash":"d6fe36b079d4ac2985b25a5b96882cd7","isProtected":false,"rdata":"docs.example.com.","rrsetVersion":"278","rtype":"CNAME","ttl":3600},{"domain":"lexicon-test.com","recordHash":"5ce9d2cc56bc9db57ba9d998a98d911a","isProtected":true,"rdata":"ns1.p68.dns.oraclecloud.net.
+        hostmaster.lexicon-test.com. 441 3600 600 604800 1800","rrsetVersion":"441","rtype":"SOA","ttl":300},{"domain":"lexicon-test.com","recordHash":"8afe5805e230374e4703870ce5e1b362","isProtected":true,"rdata":"ns4.p68.dns.oraclecloud.net.","rrsetVersion":"1","rtype":"NS","ttl":86400},{"domain":"lexicon-test.com","recordHash":"cab28e6a040cdfae00893dad01209480","isProtected":true,"rdata":"ns2.p68.dns.oraclecloud.net.","rrsetVersion":"1","rtype":"NS","ttl":86400},{"domain":"lexicon-test.com","recordHash":"e276958b1b2c5ec312c120f9448f0295","isProtected":true,"rdata":"ns1.p68.dns.oraclecloud.net.","rrsetVersion":"1","rtype":"NS","ttl":86400},{"domain":"lexicon-test.com","recordHash":"fc5e04ede640257ab27fe19e8554c727","isProtected":true,"rdata":"ns3.p68.dns.oraclecloud.net.","rrsetVersion":"1","rtype":"NS","ttl":86400},{"domain":"localhost.lexicon-test.com","recordHash":"20068f94cf294942b1811fd409231dbe","isProtected":false,"rdata":"127.0.0.1","rrsetVersion":"277","rtype":"A","ttl":3600},{"domain":"orig.nameonly.test.lexicon-test.com","recordHash":"896d848b26f834d9c8fe08f83aaa580b","isProtected":false,"rdata":"\"updated\"","rrsetVersion":"321","rtype":"TXT","ttl":3600},{"domain":"orig.nameonly.test.lexicon-test.com","recordHash":"d96871ac7da8df9d246600731475f74a","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"321","rtype":"TXT","ttl":3600},{"domain":"orig.test.lexicon-test.com","recordHash":"c7825b2895d6a22416fe1e807f86d27d","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"304","rtype":"TXT","ttl":3600},{"domain":"orig.testfqdn.lexicon-test.com","recordHash":"b157b0f18514bf637d2da9a60c2d5db7","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"306","rtype":"TXT","ttl":3600},{"domain":"orig.testfull.lexicon-test.com","recordHash":"5812b10f4c43f8ac590a8bd07f5dce3c","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"307","rtype":"TXT","ttl":3600},{"domain":"random.fqdntest.lexicon-test.com","recordHash":"5d5b4b9a09be257562199ec4184d0a93","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"301","rtype":"TXT","ttl":3600},{"domain":"random.fulltest.lexicon-test.com","recordHash":"da642cca98776d00b0f61fad4051e489","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"302","rtype":"TXT","ttl":3600},{"domain":"random.test.lexicon-test.com","recordHash":"5939d233a3249cb1034c6267ee7d1013","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"303","rtype":"TXT","ttl":3600},{"domain":"ttl.fqdn.lexicon-test.com","recordHash":"b1a860728a050a1e193737002a8c392e","isProtected":false,"rdata":"\"ttlshouldbe3600\"","rrsetVersion":"298","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.createrecordset.lexicon-test.com","recordHash":"b6ebc41fde88500b72e3c74ed37f555e","isProtected":false,"rdata":"\"challengetoken2\"","rrsetVersion":"283","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.createrecordset.lexicon-test.com","recordHash":"eaca746d30c89bd96cf39ad069a282ce","isProtected":false,"rdata":"\"challengetoken1\"","rrsetVersion":"283","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.deleterecordinset.lexicon-test.com","recordHash":"05a878f361773a0bcaa7ac0b74900b7f","isProtected":false,"rdata":"\"challengetoken2\"","rrsetVersion":"432","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.fqdn.lexicon-test.com","recordHash":"2e1d5026438c46441999c0ed61cb6450","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"279","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.full.lexicon-test.com","recordHash":"92f11feb1c17981adef50d1c93ec3c5e","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"280","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.listrecordset.lexicon-test.com","recordHash":"06c966e4438fe15715878d4105682b58","isProtected":false,"rdata":"\"challengetoken1\"","rrsetVersion":"300","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.listrecordset.lexicon-test.com","recordHash":"cc91cf484d8cd148c3e9ddd3fd4018c0","isProtected":false,"rdata":"\"challengetoken2\"","rrsetVersion":"300","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.noop.lexicon-test.com","recordHash":"575c16c67d0a8ec908f50cca7bc8c0cb","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"284","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.test.lexicon-test.com","recordHash":"768ea81c2972b69ac41fd65fe5bb53be","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"281","rtype":"TXT","ttl":3600}]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '4802'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:19:50 GMT
+      ETag:
+      - '"441ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168d#application/json"'
+      opc-request-id:
+      - /0653EA4E4BF8398DCA9CD6BC3636C9DE/D16D5282E7E08E71A311D7D5E4B76E87
+      opc-total-items:
+      - '25'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:19:50 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com/records/delete.testfull.lexicon-test.com?limit=100&rtype=TXT
+  response:
+    body:
+      string: '{"items":[]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '13'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:19:52 GMT
+      ETag:
+      - '"441ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168d#application/json"'
+      Vary:
+      - Accept-Encoding
+      opc-request-id:
+      - /186084F7797DE0BB6F3FB74AC6461667/EBE07D8C369E21F1A000971D5D275D72
+      opc-total-items:
+      - '0'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/oci/IntegrationTests/test_provider_when_calling_delete_record_by_identifier_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/oci/IntegrationTests/test_provider_when_calling_delete_record_by_identifier_should_remove_record.yaml
@@ -1,0 +1,267 @@
+interactions:
+- request:
+    body: null
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:19:52 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com
+  response:
+    body:
+      string: '{"zoneType":"PRIMARY","name":"lexicon-test.com","externalMasters":[],"self":"https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com","timeCreated":"2021-06-23T10:07:46Z","version":"441","serial":441,"nameservers":[{"hostname":"ns1.p68.dns.oraclecloud.net"},{"hostname":"ns2.p68.dns.oraclecloud.net"},{"hostname":"ns3.p68.dns.oraclecloud.net"},{"hostname":"ns4.p68.dns.oraclecloud.net"}],"compartmentId":"OCI-COMPARTMENT-ID","id":"DNS-ZONE-ID","lifecycleState":"ACTIVE","scope":"GLOBAL","viewId":null,"isProtected":false}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:19:54 GMT
+      ETag:
+      - '"441ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168docid1.compartment.oc1..aaaaaaaakklh3onuoqfzgpe4tlflbmabkytrmmukcllef5vfc65quvqhtfsq164374825086dc65cd5dc548c248f61328b5d668#application/json--gzip"'
+      Vary:
+      - Accept-Encoding
+      content-length:
+      - '645'
+      opc-request-id:
+      - /DF68A1276FF4C8A2883C29A2F77A4072/39E46E624E837D62EEE126183798F17E
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"items": [{"operation": "ADD", "rtype": "TXT", "rdata": "challengetoken",
+      "ttl": 3600}]}'
+    headers:
+      Content-Length:
+      - '89'
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:19:54 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: PATCH
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com/records/delete.testid.lexicon-test.com
+  response:
+    body:
+      string: '{"items":[{"domain":"delete.testid.lexicon-test.com","recordHash":"d645a76aa912f735b9a955dd4a9d9887","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"442","rtype":"TXT","ttl":3600}]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '199'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:20:00 GMT
+      ETag:
+      - '"442ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168d#application/json"'
+      opc-request-id:
+      - /69E44A63EC92FA0EF64EB2051C89EA69/3DD146FBD70A4190437704C3167E451D
+      opc-total-items:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:20:00 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com/records/delete.testid.lexicon-test.com?limit=100&rtype=TXT
+  response:
+    body:
+      string: '{"items":[{"domain":"delete.testid.lexicon-test.com","recordHash":"d645a76aa912f735b9a955dd4a9d9887","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"442","rtype":"TXT","ttl":3600}]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '199'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:20:02 GMT
+      ETag:
+      - '"442ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168d#application/json"'
+      Vary:
+      - Accept-Encoding
+      opc-request-id:
+      - /947B89EFDDDF6B0B172A4A1F8DC13534/AE22B7F5D1212777603B63108B7F3F6D
+      opc-total-items:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:20:03 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com/records?limit=100
+  response:
+    body:
+      string: '{"items":[{"domain":"delete.testid.lexicon-test.com","recordHash":"d645a76aa912f735b9a955dd4a9d9887","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"442","rtype":"TXT","ttl":3600},{"domain":"docs.lexicon-test.com","recordHash":"d6fe36b079d4ac2985b25a5b96882cd7","isProtected":false,"rdata":"docs.example.com.","rrsetVersion":"278","rtype":"CNAME","ttl":3600},{"domain":"lexicon-test.com","recordHash":"5ce9d2cc56bc9db57ba9d998a98d911a","isProtected":true,"rdata":"ns1.p68.dns.oraclecloud.net.
+        hostmaster.lexicon-test.com. 442 3600 600 604800 1800","rrsetVersion":"442","rtype":"SOA","ttl":300},{"domain":"lexicon-test.com","recordHash":"8afe5805e230374e4703870ce5e1b362","isProtected":true,"rdata":"ns4.p68.dns.oraclecloud.net.","rrsetVersion":"1","rtype":"NS","ttl":86400},{"domain":"lexicon-test.com","recordHash":"cab28e6a040cdfae00893dad01209480","isProtected":true,"rdata":"ns2.p68.dns.oraclecloud.net.","rrsetVersion":"1","rtype":"NS","ttl":86400},{"domain":"lexicon-test.com","recordHash":"e276958b1b2c5ec312c120f9448f0295","isProtected":true,"rdata":"ns1.p68.dns.oraclecloud.net.","rrsetVersion":"1","rtype":"NS","ttl":86400},{"domain":"lexicon-test.com","recordHash":"fc5e04ede640257ab27fe19e8554c727","isProtected":true,"rdata":"ns3.p68.dns.oraclecloud.net.","rrsetVersion":"1","rtype":"NS","ttl":86400},{"domain":"localhost.lexicon-test.com","recordHash":"20068f94cf294942b1811fd409231dbe","isProtected":false,"rdata":"127.0.0.1","rrsetVersion":"277","rtype":"A","ttl":3600},{"domain":"orig.nameonly.test.lexicon-test.com","recordHash":"896d848b26f834d9c8fe08f83aaa580b","isProtected":false,"rdata":"\"updated\"","rrsetVersion":"321","rtype":"TXT","ttl":3600},{"domain":"orig.nameonly.test.lexicon-test.com","recordHash":"d96871ac7da8df9d246600731475f74a","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"321","rtype":"TXT","ttl":3600},{"domain":"orig.test.lexicon-test.com","recordHash":"c7825b2895d6a22416fe1e807f86d27d","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"304","rtype":"TXT","ttl":3600},{"domain":"orig.testfqdn.lexicon-test.com","recordHash":"b157b0f18514bf637d2da9a60c2d5db7","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"306","rtype":"TXT","ttl":3600},{"domain":"orig.testfull.lexicon-test.com","recordHash":"5812b10f4c43f8ac590a8bd07f5dce3c","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"307","rtype":"TXT","ttl":3600},{"domain":"random.fqdntest.lexicon-test.com","recordHash":"5d5b4b9a09be257562199ec4184d0a93","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"301","rtype":"TXT","ttl":3600},{"domain":"random.fulltest.lexicon-test.com","recordHash":"da642cca98776d00b0f61fad4051e489","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"302","rtype":"TXT","ttl":3600},{"domain":"random.test.lexicon-test.com","recordHash":"5939d233a3249cb1034c6267ee7d1013","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"303","rtype":"TXT","ttl":3600},{"domain":"ttl.fqdn.lexicon-test.com","recordHash":"b1a860728a050a1e193737002a8c392e","isProtected":false,"rdata":"\"ttlshouldbe3600\"","rrsetVersion":"298","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.createrecordset.lexicon-test.com","recordHash":"b6ebc41fde88500b72e3c74ed37f555e","isProtected":false,"rdata":"\"challengetoken2\"","rrsetVersion":"283","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.createrecordset.lexicon-test.com","recordHash":"eaca746d30c89bd96cf39ad069a282ce","isProtected":false,"rdata":"\"challengetoken1\"","rrsetVersion":"283","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.deleterecordinset.lexicon-test.com","recordHash":"05a878f361773a0bcaa7ac0b74900b7f","isProtected":false,"rdata":"\"challengetoken2\"","rrsetVersion":"432","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.fqdn.lexicon-test.com","recordHash":"2e1d5026438c46441999c0ed61cb6450","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"279","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.full.lexicon-test.com","recordHash":"92f11feb1c17981adef50d1c93ec3c5e","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"280","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.listrecordset.lexicon-test.com","recordHash":"06c966e4438fe15715878d4105682b58","isProtected":false,"rdata":"\"challengetoken1\"","rrsetVersion":"300","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.listrecordset.lexicon-test.com","recordHash":"cc91cf484d8cd148c3e9ddd3fd4018c0","isProtected":false,"rdata":"\"challengetoken2\"","rrsetVersion":"300","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.noop.lexicon-test.com","recordHash":"575c16c67d0a8ec908f50cca7bc8c0cb","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"284","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.test.lexicon-test.com","recordHash":"768ea81c2972b69ac41fd65fe5bb53be","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"281","rtype":"TXT","ttl":3600}]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:20:04 GMT
+      ETag:
+      - '"442ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168d#application/json--gzip"'
+      Vary:
+      - Accept-Encoding
+      content-length:
+      - '4989'
+      opc-request-id:
+      - /4B930E31E22B943932285479C5035946/B09FFA80C6498D5D73B6CDAA76E09740
+      opc-total-items:
+      - '26'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"items": [{"operation": "REMOVE", "recordHash": "d645a76aa912f735b9a955dd4a9d9887"}]}'
+    headers:
+      Content-Length:
+      - '86'
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:20:04 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: PATCH
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com/records
+  response:
+    body:
+      string: '{"items":[{"domain":"docs.lexicon-test.com","recordHash":"d6fe36b079d4ac2985b25a5b96882cd7","isProtected":false,"rdata":"docs.example.com.","rrsetVersion":"278","rtype":"CNAME","ttl":3600},{"domain":"lexicon-test.com","recordHash":"5ce9d2cc56bc9db57ba9d998a98d911a","isProtected":true,"rdata":"ns1.p68.dns.oraclecloud.net.
+        hostmaster.lexicon-test.com. 443 3600 600 604800 1800","rrsetVersion":"443","rtype":"SOA","ttl":300},{"domain":"lexicon-test.com","recordHash":"8afe5805e230374e4703870ce5e1b362","isProtected":true,"rdata":"ns4.p68.dns.oraclecloud.net.","rrsetVersion":"1","rtype":"NS","ttl":86400},{"domain":"lexicon-test.com","recordHash":"cab28e6a040cdfae00893dad01209480","isProtected":true,"rdata":"ns2.p68.dns.oraclecloud.net.","rrsetVersion":"1","rtype":"NS","ttl":86400},{"domain":"lexicon-test.com","recordHash":"e276958b1b2c5ec312c120f9448f0295","isProtected":true,"rdata":"ns1.p68.dns.oraclecloud.net.","rrsetVersion":"1","rtype":"NS","ttl":86400},{"domain":"lexicon-test.com","recordHash":"fc5e04ede640257ab27fe19e8554c727","isProtected":true,"rdata":"ns3.p68.dns.oraclecloud.net.","rrsetVersion":"1","rtype":"NS","ttl":86400},{"domain":"localhost.lexicon-test.com","recordHash":"20068f94cf294942b1811fd409231dbe","isProtected":false,"rdata":"127.0.0.1","rrsetVersion":"277","rtype":"A","ttl":3600},{"domain":"orig.nameonly.test.lexicon-test.com","recordHash":"896d848b26f834d9c8fe08f83aaa580b","isProtected":false,"rdata":"\"updated\"","rrsetVersion":"321","rtype":"TXT","ttl":3600},{"domain":"orig.nameonly.test.lexicon-test.com","recordHash":"d96871ac7da8df9d246600731475f74a","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"321","rtype":"TXT","ttl":3600},{"domain":"orig.test.lexicon-test.com","recordHash":"c7825b2895d6a22416fe1e807f86d27d","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"304","rtype":"TXT","ttl":3600},{"domain":"orig.testfqdn.lexicon-test.com","recordHash":"b157b0f18514bf637d2da9a60c2d5db7","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"306","rtype":"TXT","ttl":3600},{"domain":"orig.testfull.lexicon-test.com","recordHash":"5812b10f4c43f8ac590a8bd07f5dce3c","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"307","rtype":"TXT","ttl":3600},{"domain":"random.fqdntest.lexicon-test.com","recordHash":"5d5b4b9a09be257562199ec4184d0a93","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"301","rtype":"TXT","ttl":3600},{"domain":"random.fulltest.lexicon-test.com","recordHash":"da642cca98776d00b0f61fad4051e489","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"302","rtype":"TXT","ttl":3600},{"domain":"random.test.lexicon-test.com","recordHash":"5939d233a3249cb1034c6267ee7d1013","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"303","rtype":"TXT","ttl":3600},{"domain":"ttl.fqdn.lexicon-test.com","recordHash":"b1a860728a050a1e193737002a8c392e","isProtected":false,"rdata":"\"ttlshouldbe3600\"","rrsetVersion":"298","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.createrecordset.lexicon-test.com","recordHash":"b6ebc41fde88500b72e3c74ed37f555e","isProtected":false,"rdata":"\"challengetoken2\"","rrsetVersion":"283","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.createrecordset.lexicon-test.com","recordHash":"eaca746d30c89bd96cf39ad069a282ce","isProtected":false,"rdata":"\"challengetoken1\"","rrsetVersion":"283","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.deleterecordinset.lexicon-test.com","recordHash":"05a878f361773a0bcaa7ac0b74900b7f","isProtected":false,"rdata":"\"challengetoken2\"","rrsetVersion":"432","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.fqdn.lexicon-test.com","recordHash":"2e1d5026438c46441999c0ed61cb6450","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"279","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.full.lexicon-test.com","recordHash":"92f11feb1c17981adef50d1c93ec3c5e","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"280","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.listrecordset.lexicon-test.com","recordHash":"06c966e4438fe15715878d4105682b58","isProtected":false,"rdata":"\"challengetoken1\"","rrsetVersion":"300","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.listrecordset.lexicon-test.com","recordHash":"cc91cf484d8cd148c3e9ddd3fd4018c0","isProtected":false,"rdata":"\"challengetoken2\"","rrsetVersion":"300","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.noop.lexicon-test.com","recordHash":"575c16c67d0a8ec908f50cca7bc8c0cb","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"284","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.test.lexicon-test.com","recordHash":"768ea81c2972b69ac41fd65fe5bb53be","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"281","rtype":"TXT","ttl":3600}]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '4802'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:20:07 GMT
+      ETag:
+      - '"443ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168d#application/json"'
+      opc-request-id:
+      - /874252D47D6C0AA45E7F416EDA983A8A/55C568265BD428C4D416BDE44AE0920F
+      opc-total-items:
+      - '25'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:20:07 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com/records/delete.testid.lexicon-test.com?limit=100&rtype=TXT
+  response:
+    body:
+      string: '{"items":[]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '13'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:20:09 GMT
+      ETag:
+      - '"443ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168d#application/json"'
+      Vary:
+      - Accept-Encoding
+      opc-request-id:
+      - /33CB5990919362A670CC9A619D2B19FB/5A867F5879F22411D660B1FD9766638D
+      opc-total-items:
+      - '0'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/oci/IntegrationTests/test_provider_when_calling_delete_record_with_record_set_by_content_should_leave_others_untouched.yaml
+++ b/tests/fixtures/cassettes/oci/IntegrationTests/test_provider_when_calling_delete_record_with_record_set_by_content_should_leave_others_untouched.yaml
@@ -1,0 +1,267 @@
+interactions:
+- request:
+    body: null
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:20:09 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com
+  response:
+    body:
+      string: '{"zoneType":"PRIMARY","name":"lexicon-test.com","externalMasters":[],"self":"https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com","timeCreated":"2021-06-23T10:07:46Z","version":"443","serial":443,"nameservers":[{"hostname":"ns1.p68.dns.oraclecloud.net"},{"hostname":"ns2.p68.dns.oraclecloud.net"},{"hostname":"ns3.p68.dns.oraclecloud.net"},{"hostname":"ns4.p68.dns.oraclecloud.net"}],"compartmentId":"OCI-COMPARTMENT-ID","id":"DNS-ZONE-ID","lifecycleState":"ACTIVE","scope":"GLOBAL","viewId":null,"isProtected":false}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:20:11 GMT
+      ETag:
+      - '"443ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168docid1.compartment.oc1..aaaaaaaakklh3onuoqfzgpe4tlflbmabkytrmmukcllef5vfc65quvqhtfsq164374825086dc65cd5dc548c248f61328b5d668#application/json--gzip"'
+      Vary:
+      - Accept-Encoding
+      content-length:
+      - '645'
+      opc-request-id:
+      - /65DA190726890A4C138264B590C0B702/50892FB62F0AC570CF5F660296015EA1
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"items": [{"operation": "ADD", "rtype": "TXT", "rdata": "challengetoken1",
+      "ttl": 3600}]}'
+    headers:
+      Content-Length:
+      - '90'
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:20:11 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: PATCH
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com/records/_acme-challenge.deleterecordinset.lexicon-test.com
+  response:
+    body:
+      string: '{"items":[{"domain":"_acme-challenge.deleterecordinset.lexicon-test.com","recordHash":"05a878f361773a0bcaa7ac0b74900b7f","isProtected":false,"rdata":"\"challengetoken2\"","rrsetVersion":"444","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.deleterecordinset.lexicon-test.com","recordHash":"b2d70b65b5a4ad3bcf9a62dec59860b0","isProtected":false,"rdata":"\"challengetoken1\"","rrsetVersion":"444","rtype":"TXT","ttl":3600}]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '428'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:20:16 GMT
+      ETag:
+      - '"444ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168d#application/json"'
+      opc-request-id:
+      - /93520F40E5E22F173F4A2919DBE7BCAF/2498271707BDCCA691EECEFB19FA1520
+      opc-total-items:
+      - '2'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"items": [{"operation": "ADD", "rtype": "TXT", "rdata": "challengetoken2",
+      "ttl": 3600}]}'
+    headers:
+      Content-Length:
+      - '90'
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:20:17 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: PATCH
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com/records/_acme-challenge.deleterecordinset.lexicon-test.com
+  response:
+    body:
+      string: '{"items":[{"domain":"_acme-challenge.deleterecordinset.lexicon-test.com","recordHash":"05a878f361773a0bcaa7ac0b74900b7f","isProtected":false,"rdata":"\"challengetoken2\"","rrsetVersion":"444","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.deleterecordinset.lexicon-test.com","recordHash":"b2d70b65b5a4ad3bcf9a62dec59860b0","isProtected":false,"rdata":"\"challengetoken1\"","rrsetVersion":"444","rtype":"TXT","ttl":3600}]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '428'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:20:19 GMT
+      ETag:
+      - '"444ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168d#application/json"'
+      opc-request-id:
+      - /EDAF4E6C4C8730F354F380C7B67AF8EB/4ED71E5CAE149C21F3BA380847D59266
+      opc-total-items:
+      - '2'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:20:19 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com/records/_acme-challenge.deleterecordinset.lexicon-test.com?limit=100&rtype=TXT
+  response:
+    body:
+      string: '{"items":[{"domain":"_acme-challenge.deleterecordinset.lexicon-test.com","recordHash":"05a878f361773a0bcaa7ac0b74900b7f","isProtected":false,"rdata":"\"challengetoken2\"","rrsetVersion":"444","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.deleterecordinset.lexicon-test.com","recordHash":"b2d70b65b5a4ad3bcf9a62dec59860b0","isProtected":false,"rdata":"\"challengetoken1\"","rrsetVersion":"444","rtype":"TXT","ttl":3600}]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:20:21 GMT
+      ETag:
+      - '"444ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168d#application/json--gzip"'
+      Vary:
+      - Accept-Encoding
+      content-length:
+      - '428'
+      opc-request-id:
+      - /F70692F130E7686DD25152D7E8472189/E90EE0C7E92AE5D694EB6B1DA180C7C8
+      opc-total-items:
+      - '2'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"items": [{"operation": "REMOVE", "recordHash": "b2d70b65b5a4ad3bcf9a62dec59860b0"}]}'
+    headers:
+      Content-Length:
+      - '86'
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:20:21 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: PATCH
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com/records
+  response:
+    body:
+      string: '{"items":[{"domain":"docs.lexicon-test.com","recordHash":"d6fe36b079d4ac2985b25a5b96882cd7","isProtected":false,"rdata":"docs.example.com.","rrsetVersion":"278","rtype":"CNAME","ttl":3600},{"domain":"lexicon-test.com","recordHash":"5ce9d2cc56bc9db57ba9d998a98d911a","isProtected":true,"rdata":"ns1.p68.dns.oraclecloud.net.
+        hostmaster.lexicon-test.com. 445 3600 600 604800 1800","rrsetVersion":"445","rtype":"SOA","ttl":300},{"domain":"lexicon-test.com","recordHash":"8afe5805e230374e4703870ce5e1b362","isProtected":true,"rdata":"ns4.p68.dns.oraclecloud.net.","rrsetVersion":"1","rtype":"NS","ttl":86400},{"domain":"lexicon-test.com","recordHash":"cab28e6a040cdfae00893dad01209480","isProtected":true,"rdata":"ns2.p68.dns.oraclecloud.net.","rrsetVersion":"1","rtype":"NS","ttl":86400},{"domain":"lexicon-test.com","recordHash":"e276958b1b2c5ec312c120f9448f0295","isProtected":true,"rdata":"ns1.p68.dns.oraclecloud.net.","rrsetVersion":"1","rtype":"NS","ttl":86400},{"domain":"lexicon-test.com","recordHash":"fc5e04ede640257ab27fe19e8554c727","isProtected":true,"rdata":"ns3.p68.dns.oraclecloud.net.","rrsetVersion":"1","rtype":"NS","ttl":86400},{"domain":"localhost.lexicon-test.com","recordHash":"20068f94cf294942b1811fd409231dbe","isProtected":false,"rdata":"127.0.0.1","rrsetVersion":"277","rtype":"A","ttl":3600},{"domain":"orig.nameonly.test.lexicon-test.com","recordHash":"896d848b26f834d9c8fe08f83aaa580b","isProtected":false,"rdata":"\"updated\"","rrsetVersion":"321","rtype":"TXT","ttl":3600},{"domain":"orig.nameonly.test.lexicon-test.com","recordHash":"d96871ac7da8df9d246600731475f74a","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"321","rtype":"TXT","ttl":3600},{"domain":"orig.test.lexicon-test.com","recordHash":"c7825b2895d6a22416fe1e807f86d27d","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"304","rtype":"TXT","ttl":3600},{"domain":"orig.testfqdn.lexicon-test.com","recordHash":"b157b0f18514bf637d2da9a60c2d5db7","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"306","rtype":"TXT","ttl":3600},{"domain":"orig.testfull.lexicon-test.com","recordHash":"5812b10f4c43f8ac590a8bd07f5dce3c","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"307","rtype":"TXT","ttl":3600},{"domain":"random.fqdntest.lexicon-test.com","recordHash":"5d5b4b9a09be257562199ec4184d0a93","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"301","rtype":"TXT","ttl":3600},{"domain":"random.fulltest.lexicon-test.com","recordHash":"da642cca98776d00b0f61fad4051e489","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"302","rtype":"TXT","ttl":3600},{"domain":"random.test.lexicon-test.com","recordHash":"5939d233a3249cb1034c6267ee7d1013","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"303","rtype":"TXT","ttl":3600},{"domain":"ttl.fqdn.lexicon-test.com","recordHash":"b1a860728a050a1e193737002a8c392e","isProtected":false,"rdata":"\"ttlshouldbe3600\"","rrsetVersion":"298","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.createrecordset.lexicon-test.com","recordHash":"b6ebc41fde88500b72e3c74ed37f555e","isProtected":false,"rdata":"\"challengetoken2\"","rrsetVersion":"283","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.createrecordset.lexicon-test.com","recordHash":"eaca746d30c89bd96cf39ad069a282ce","isProtected":false,"rdata":"\"challengetoken1\"","rrsetVersion":"283","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.deleterecordinset.lexicon-test.com","recordHash":"05a878f361773a0bcaa7ac0b74900b7f","isProtected":false,"rdata":"\"challengetoken2\"","rrsetVersion":"445","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.fqdn.lexicon-test.com","recordHash":"2e1d5026438c46441999c0ed61cb6450","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"279","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.full.lexicon-test.com","recordHash":"92f11feb1c17981adef50d1c93ec3c5e","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"280","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.listrecordset.lexicon-test.com","recordHash":"06c966e4438fe15715878d4105682b58","isProtected":false,"rdata":"\"challengetoken1\"","rrsetVersion":"300","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.listrecordset.lexicon-test.com","recordHash":"cc91cf484d8cd148c3e9ddd3fd4018c0","isProtected":false,"rdata":"\"challengetoken2\"","rrsetVersion":"300","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.noop.lexicon-test.com","recordHash":"575c16c67d0a8ec908f50cca7bc8c0cb","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"284","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.test.lexicon-test.com","recordHash":"768ea81c2972b69ac41fd65fe5bb53be","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"281","rtype":"TXT","ttl":3600}]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '4802'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:20:24 GMT
+      ETag:
+      - '"445ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168d#application/json"'
+      opc-request-id:
+      - /94272C80F135003B6096B108AB9DD75B/9E74A69FD4671EE2FDAEA5BD9CE22466
+      opc-total-items:
+      - '25'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:20:24 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com/records/_acme-challenge.deleterecordinset.lexicon-test.com?limit=100&rtype=TXT
+  response:
+    body:
+      string: '{"items":[{"domain":"_acme-challenge.deleterecordinset.lexicon-test.com","recordHash":"05a878f361773a0bcaa7ac0b74900b7f","isProtected":false,"rdata":"\"challengetoken2\"","rrsetVersion":"445","rtype":"TXT","ttl":3600}]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '220'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:20:25 GMT
+      ETag:
+      - '"445ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168d#application/json"'
+      Vary:
+      - Accept-Encoding
+      opc-request-id:
+      - /85049157EB246F5815BE878D5E7B1B6F/B5E1A82F3B569D6B1C092FBFB32C09FA
+      opc-total-items:
+      - '1'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/oci/IntegrationTests/test_provider_when_calling_delete_record_with_record_set_name_remove_all.yaml
+++ b/tests/fixtures/cassettes/oci/IntegrationTests/test_provider_when_calling_delete_record_with_record_set_name_remove_all.yaml
@@ -1,0 +1,258 @@
+interactions:
+- request:
+    body: null
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:20:26 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com
+  response:
+    body:
+      string: '{"zoneType":"PRIMARY","name":"lexicon-test.com","externalMasters":[],"self":"https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com","timeCreated":"2021-06-23T10:07:46Z","version":"445","serial":445,"nameservers":[{"hostname":"ns1.p68.dns.oraclecloud.net"},{"hostname":"ns2.p68.dns.oraclecloud.net"},{"hostname":"ns3.p68.dns.oraclecloud.net"},{"hostname":"ns4.p68.dns.oraclecloud.net"}],"compartmentId":"OCI-COMPARTMENT-ID","id":"DNS-ZONE-ID","lifecycleState":"ACTIVE","scope":"GLOBAL","viewId":null,"isProtected":false}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:20:28 GMT
+      ETag:
+      - '"445ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168docid1.compartment.oc1..aaaaaaaakklh3onuoqfzgpe4tlflbmabkytrmmukcllef5vfc65quvqhtfsq164374825086dc65cd5dc548c248f61328b5d668#application/json--gzip"'
+      Vary:
+      - Accept-Encoding
+      content-length:
+      - '645'
+      opc-request-id:
+      - /B98E56D1BC501A72DA2425E2DFA45C0B/112097AD760F7FCE59ED3A6DC8602F11
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"items": [{"operation": "ADD", "rtype": "TXT", "rdata": "challengetoken1",
+      "ttl": 3600}]}'
+    headers:
+      Content-Length:
+      - '90'
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:20:28 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: PATCH
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com/records/_acme-challenge.deleterecordset.lexicon-test.com
+  response:
+    body:
+      string: '{"items":[{"domain":"_acme-challenge.deleterecordset.lexicon-test.com","recordHash":"2f064ab900906b5b2c4a7e74c4e8c676","isProtected":false,"rdata":"\"challengetoken1\"","rrsetVersion":"446","rtype":"TXT","ttl":3600}]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '218'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:20:31 GMT
+      ETag:
+      - '"446ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168d#application/json"'
+      opc-request-id:
+      - /F8F8B2D63FF7D776459657B8A64FE1F4/51016F7F8C1B495A390AEFA8F6D920BA
+      opc-total-items:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"items": [{"operation": "ADD", "rtype": "TXT", "rdata": "challengetoken2",
+      "ttl": 3600}]}'
+    headers:
+      Content-Length:
+      - '90'
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:20:31 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: PATCH
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com/records/_acme-challenge.deleterecordset.lexicon-test.com
+  response:
+    body:
+      string: '{"items":[{"domain":"_acme-challenge.deleterecordset.lexicon-test.com","recordHash":"2f064ab900906b5b2c4a7e74c4e8c676","isProtected":false,"rdata":"\"challengetoken1\"","rrsetVersion":"447","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.deleterecordset.lexicon-test.com","recordHash":"ded7b12876d5ce61f018792d0c523742","isProtected":false,"rdata":"\"challengetoken2\"","rrsetVersion":"447","rtype":"TXT","ttl":3600}]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '424'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:20:34 GMT
+      ETag:
+      - '"447ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168d#application/json"'
+      opc-request-id:
+      - /40F291CE27CE4B237184AD3F9675BA0D/1C20672943ACC133368E900D011DF8D8
+      opc-total-items:
+      - '2'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:20:34 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com/records/_acme-challenge.deleterecordset.lexicon-test.com?limit=100&rtype=TXT
+  response:
+    body:
+      string: '{"items":[{"domain":"_acme-challenge.deleterecordset.lexicon-test.com","recordHash":"2f064ab900906b5b2c4a7e74c4e8c676","isProtected":false,"rdata":"\"challengetoken1\"","rrsetVersion":"447","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.deleterecordset.lexicon-test.com","recordHash":"ded7b12876d5ce61f018792d0c523742","isProtected":false,"rdata":"\"challengetoken2\"","rrsetVersion":"447","rtype":"TXT","ttl":3600}]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:20:36 GMT
+      ETag:
+      - '"447ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168d#application/json--gzip"'
+      Vary:
+      - Accept-Encoding
+      content-length:
+      - '424'
+      opc-request-id:
+      - /2C1B4A14F83DBC5A3D59DCD52B6C227E/A6005BA3D4C24A64F4C8E145C0B32236
+      opc-total-items:
+      - '2'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '0'
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:20:36 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: DELETE
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com/records/_acme-challenge.deleterecordset.lexicon-test.com/TXT
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/plain
+      Date:
+      - Mon, 28 Jun 2021 22:20:39 GMT
+      opc-request-id:
+      - /BEED751195CE5284C8A08F771A9DF57C/39A4D0D6B164555D1C408085970C3FBC
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: null
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:20:39 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com/records/_acme-challenge.deleterecordset.lexicon-test.com?limit=100&rtype=TXT
+  response:
+    body:
+      string: '{"items":[]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '13'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:20:41 GMT
+      ETag:
+      - '"448ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168d#application/json"'
+      Vary:
+      - Accept-Encoding
+      opc-request-id:
+      - /C20B552C09094E31365FAAFE8D1CE32B/205CB36F8B08E04F9E9C4594D9CCE2A4
+      opc-total-items:
+      - '0'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/oci/IntegrationTests/test_provider_when_calling_list_records_after_setting_ttl.yaml
+++ b/tests/fixtures/cassettes/oci/IntegrationTests/test_provider_when_calling_list_records_after_setting_ttl.yaml
@@ -1,0 +1,133 @@
+interactions:
+- request:
+    body: null
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:20:41 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com
+  response:
+    body:
+      string: '{"zoneType":"PRIMARY","name":"lexicon-test.com","externalMasters":[],"self":"https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com","timeCreated":"2021-06-23T10:07:46Z","version":"448","serial":448,"nameservers":[{"hostname":"ns1.p68.dns.oraclecloud.net"},{"hostname":"ns2.p68.dns.oraclecloud.net"},{"hostname":"ns3.p68.dns.oraclecloud.net"},{"hostname":"ns4.p68.dns.oraclecloud.net"}],"compartmentId":"OCI-COMPARTMENT-ID","id":"DNS-ZONE-ID","lifecycleState":"ACTIVE","scope":"GLOBAL","viewId":null,"isProtected":false}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:20:43 GMT
+      ETag:
+      - '"448ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168docid1.compartment.oc1..aaaaaaaakklh3onuoqfzgpe4tlflbmabkytrmmukcllef5vfc65quvqhtfsq164374825086dc65cd5dc548c248f61328b5d668#application/json--gzip"'
+      Vary:
+      - Accept-Encoding
+      content-length:
+      - '645'
+      opc-request-id:
+      - /B269221EA13D24BC452952EEC26C3192/9B68BF2941832DAA06240CE44D1F0310
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"items": [{"operation": "ADD", "rtype": "TXT", "rdata": "ttlshouldbe3600",
+      "ttl": 3600}]}'
+    headers:
+      Content-Length:
+      - '90'
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:20:43 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: PATCH
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com/records/ttl.fqdn.lexicon-test.com
+  response:
+    body:
+      string: '{"items":[{"domain":"ttl.fqdn.lexicon-test.com","recordHash":"b1a860728a050a1e193737002a8c392e","isProtected":false,"rdata":"\"ttlshouldbe3600\"","rrsetVersion":"298","rtype":"TXT","ttl":3600}]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '195'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:20:47 GMT
+      ETag:
+      - '"298ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168d#application/json"'
+      opc-request-id:
+      - /3F9F54DFA9E1D9D251C6BE4B1CC055CA/75C30151C23D41F079BF84A836A6CC81
+      opc-total-items:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:20:47 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com/records/ttl.fqdn.lexicon-test.com?limit=100&rtype=TXT
+  response:
+    body:
+      string: '{"items":[{"domain":"ttl.fqdn.lexicon-test.com","recordHash":"b1a860728a050a1e193737002a8c392e","isProtected":false,"rdata":"\"ttlshouldbe3600\"","rrsetVersion":"298","rtype":"TXT","ttl":3600}]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '195'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:20:49 GMT
+      ETag:
+      - '"298ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168d#application/json"'
+      Vary:
+      - Accept-Encoding
+      opc-request-id:
+      - /8BBB0E3A01CC54974DA7836544909B7B/28CA1D6F53D3DDA12C6434630403FC06
+      opc-total-items:
+      - '1'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/oci/IntegrationTests/test_provider_when_calling_list_records_should_handle_record_sets.yaml
+++ b/tests/fixtures/cassettes/oci/IntegrationTests/test_provider_when_calling_list_records_should_handle_record_sets.yaml
@@ -1,0 +1,178 @@
+interactions:
+- request:
+    body: null
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:20:49 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com
+  response:
+    body:
+      string: '{"zoneType":"PRIMARY","name":"lexicon-test.com","externalMasters":[],"self":"https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com","timeCreated":"2021-06-23T10:07:46Z","version":"448","serial":448,"nameservers":[{"hostname":"ns1.p68.dns.oraclecloud.net"},{"hostname":"ns2.p68.dns.oraclecloud.net"},{"hostname":"ns3.p68.dns.oraclecloud.net"},{"hostname":"ns4.p68.dns.oraclecloud.net"}],"compartmentId":"OCI-COMPARTMENT-ID","id":"DNS-ZONE-ID","lifecycleState":"ACTIVE","scope":"GLOBAL","viewId":null,"isProtected":false}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:20:51 GMT
+      ETag:
+      - '"448ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168docid1.compartment.oc1..aaaaaaaakklh3onuoqfzgpe4tlflbmabkytrmmukcllef5vfc65quvqhtfsq164374825086dc65cd5dc548c248f61328b5d668#application/json--gzip"'
+      Vary:
+      - Accept-Encoding
+      content-length:
+      - '645'
+      opc-request-id:
+      - /67E3A40D5727BB5BB5569C8F5419FF8D/61F76C39571B527093C033545A062150
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"items": [{"operation": "ADD", "rtype": "TXT", "rdata": "challengetoken1",
+      "ttl": 3600}]}'
+    headers:
+      Content-Length:
+      - '90'
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:20:51 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: PATCH
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com/records/_acme-challenge.listrecordset.lexicon-test.com
+  response:
+    body:
+      string: '{"items":[{"domain":"_acme-challenge.listrecordset.lexicon-test.com","recordHash":"06c966e4438fe15715878d4105682b58","isProtected":false,"rdata":"\"challengetoken1\"","rrsetVersion":"300","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.listrecordset.lexicon-test.com","recordHash":"cc91cf484d8cd148c3e9ddd3fd4018c0","isProtected":false,"rdata":"\"challengetoken2\"","rrsetVersion":"300","rtype":"TXT","ttl":3600}]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '420'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:20:53 GMT
+      ETag:
+      - '"300ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168d#application/json"'
+      opc-request-id:
+      - /7F317E8D5D1F14674096A3EA88B644A4/3F93B0569286C23FA6195F39096B0D17
+      opc-total-items:
+      - '2'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"items": [{"operation": "ADD", "rtype": "TXT", "rdata": "challengetoken2",
+      "ttl": 3600}]}'
+    headers:
+      Content-Length:
+      - '90'
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:20:53 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: PATCH
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com/records/_acme-challenge.listrecordset.lexicon-test.com
+  response:
+    body:
+      string: '{"items":[{"domain":"_acme-challenge.listrecordset.lexicon-test.com","recordHash":"06c966e4438fe15715878d4105682b58","isProtected":false,"rdata":"\"challengetoken1\"","rrsetVersion":"300","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.listrecordset.lexicon-test.com","recordHash":"cc91cf484d8cd148c3e9ddd3fd4018c0","isProtected":false,"rdata":"\"challengetoken2\"","rrsetVersion":"300","rtype":"TXT","ttl":3600}]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '420'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:20:57 GMT
+      ETag:
+      - '"300ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168d#application/json"'
+      opc-request-id:
+      - /E5395E68C9CB2D53F6B88BA99E3A7250/673B4A6992F1589969521EE4503A0FA6
+      opc-total-items:
+      - '2'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:20:58 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com/records/_acme-challenge.listrecordset.lexicon-test.com?limit=100&rtype=TXT
+  response:
+    body:
+      string: '{"items":[{"domain":"_acme-challenge.listrecordset.lexicon-test.com","recordHash":"06c966e4438fe15715878d4105682b58","isProtected":false,"rdata":"\"challengetoken1\"","rrsetVersion":"300","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.listrecordset.lexicon-test.com","recordHash":"cc91cf484d8cd148c3e9ddd3fd4018c0","isProtected":false,"rdata":"\"challengetoken2\"","rrsetVersion":"300","rtype":"TXT","ttl":3600}]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:20:59 GMT
+      ETag:
+      - '"300ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168d#application/json--gzip"'
+      Vary:
+      - Accept-Encoding
+      content-length:
+      - '420'
+      opc-request-id:
+      - /139207125C9B344188CC7CCAC6DE8BA9/B5E865261502D115C78ECA4C0A2DD88C
+      opc-total-items:
+      - '2'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/oci/IntegrationTests/test_provider_when_calling_list_records_with_fqdn_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/oci/IntegrationTests/test_provider_when_calling_list_records_with_fqdn_name_filter_should_return_record.yaml
@@ -1,0 +1,133 @@
+interactions:
+- request:
+    body: null
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:20:59 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com
+  response:
+    body:
+      string: '{"zoneType":"PRIMARY","name":"lexicon-test.com","externalMasters":[],"self":"https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com","timeCreated":"2021-06-23T10:07:46Z","version":"448","serial":448,"nameservers":[{"hostname":"ns1.p68.dns.oraclecloud.net"},{"hostname":"ns2.p68.dns.oraclecloud.net"},{"hostname":"ns3.p68.dns.oraclecloud.net"},{"hostname":"ns4.p68.dns.oraclecloud.net"}],"compartmentId":"OCI-COMPARTMENT-ID","id":"DNS-ZONE-ID","lifecycleState":"ACTIVE","scope":"GLOBAL","viewId":null,"isProtected":false}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:21:01 GMT
+      ETag:
+      - '"448ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168docid1.compartment.oc1..aaaaaaaakklh3onuoqfzgpe4tlflbmabkytrmmukcllef5vfc65quvqhtfsq164374825086dc65cd5dc548c248f61328b5d668#application/json--gzip"'
+      Vary:
+      - Accept-Encoding
+      content-length:
+      - '645'
+      opc-request-id:
+      - /C8DCD4E5ECA6532F749559DF07241DED/DC62FFD38A0A1B6C02ABB8EB156BA498
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"items": [{"operation": "ADD", "rtype": "TXT", "rdata": "challengetoken",
+      "ttl": 3600}]}'
+    headers:
+      Content-Length:
+      - '89'
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:21:01 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: PATCH
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com/records/random.fqdntest.lexicon-test.com
+  response:
+    body:
+      string: '{"items":[{"domain":"random.fqdntest.lexicon-test.com","recordHash":"5d5b4b9a09be257562199ec4184d0a93","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"301","rtype":"TXT","ttl":3600}]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '201'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:21:05 GMT
+      ETag:
+      - '"301ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168d#application/json"'
+      opc-request-id:
+      - /AA61E64BE42FF913D4F7BB77078E8C3A/54BA43E02245226BDA97B1C32E8A7C6E
+      opc-total-items:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:21:05 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com/records/random.fqdntest.lexicon-test.com?limit=100&rtype=TXT
+  response:
+    body:
+      string: '{"items":[{"domain":"random.fqdntest.lexicon-test.com","recordHash":"5d5b4b9a09be257562199ec4184d0a93","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"301","rtype":"TXT","ttl":3600}]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '201'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:21:08 GMT
+      ETag:
+      - '"301ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168d#application/json"'
+      Vary:
+      - Accept-Encoding
+      opc-request-id:
+      - /09DFF9B16C0D907986A73C612FDD614A/445B82F26EA12DD50A2EEF52B0CDA1EB
+      opc-total-items:
+      - '1'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/oci/IntegrationTests/test_provider_when_calling_list_records_with_full_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/oci/IntegrationTests/test_provider_when_calling_list_records_with_full_name_filter_should_return_record.yaml
@@ -1,0 +1,133 @@
+interactions:
+- request:
+    body: null
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:21:08 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com
+  response:
+    body:
+      string: '{"zoneType":"PRIMARY","name":"lexicon-test.com","externalMasters":[],"self":"https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com","timeCreated":"2021-06-23T10:07:46Z","version":"448","serial":448,"nameservers":[{"hostname":"ns1.p68.dns.oraclecloud.net"},{"hostname":"ns2.p68.dns.oraclecloud.net"},{"hostname":"ns3.p68.dns.oraclecloud.net"},{"hostname":"ns4.p68.dns.oraclecloud.net"}],"compartmentId":"OCI-COMPARTMENT-ID","id":"DNS-ZONE-ID","lifecycleState":"ACTIVE","scope":"GLOBAL","viewId":null,"isProtected":false}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:21:09 GMT
+      ETag:
+      - '"448ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168docid1.compartment.oc1..aaaaaaaakklh3onuoqfzgpe4tlflbmabkytrmmukcllef5vfc65quvqhtfsq164374825086dc65cd5dc548c248f61328b5d668#application/json--gzip"'
+      Vary:
+      - Accept-Encoding
+      content-length:
+      - '645'
+      opc-request-id:
+      - /4DCAB10223038F91EEFEC70BAAD2AD5F/0BE7C2B44B13778F119FD9975B0EF4AD
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"items": [{"operation": "ADD", "rtype": "TXT", "rdata": "challengetoken",
+      "ttl": 3600}]}'
+    headers:
+      Content-Length:
+      - '89'
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:21:10 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: PATCH
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com/records/random.fulltest.lexicon-test.com
+  response:
+    body:
+      string: '{"items":[{"domain":"random.fulltest.lexicon-test.com","recordHash":"da642cca98776d00b0f61fad4051e489","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"302","rtype":"TXT","ttl":3600}]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '201'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:21:12 GMT
+      ETag:
+      - '"302ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168d#application/json"'
+      opc-request-id:
+      - /95F1BD8485854FA1484EF173A1240400/165326BF87742AF8291EDF78D9C81F78
+      opc-total-items:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:21:12 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com/records/random.fulltest.lexicon-test.com?limit=100&rtype=TXT
+  response:
+    body:
+      string: '{"items":[{"domain":"random.fulltest.lexicon-test.com","recordHash":"da642cca98776d00b0f61fad4051e489","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"302","rtype":"TXT","ttl":3600}]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '201'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:21:15 GMT
+      ETag:
+      - '"302ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168d#application/json"'
+      Vary:
+      - Accept-Encoding
+      opc-request-id:
+      - /BEDD39159931378CB2D8F368F3BAAB64/CF43C085DD737BDC9F3738925DE9A896
+      opc-total-items:
+      - '1'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/oci/IntegrationTests/test_provider_when_calling_list_records_with_invalid_filter_should_be_empty_list.yaml
+++ b/tests/fixtures/cassettes/oci/IntegrationTests/test_provider_when_calling_list_records_with_invalid_filter_should_be_empty_list.yaml
@@ -1,0 +1,88 @@
+interactions:
+- request:
+    body: null
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:21:15 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com
+  response:
+    body:
+      string: '{"zoneType":"PRIMARY","name":"lexicon-test.com","externalMasters":[],"self":"https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com","timeCreated":"2021-06-23T10:07:46Z","version":"448","serial":448,"nameservers":[{"hostname":"ns1.p68.dns.oraclecloud.net"},{"hostname":"ns2.p68.dns.oraclecloud.net"},{"hostname":"ns3.p68.dns.oraclecloud.net"},{"hostname":"ns4.p68.dns.oraclecloud.net"}],"compartmentId":"OCI-COMPARTMENT-ID","id":"DNS-ZONE-ID","lifecycleState":"ACTIVE","scope":"GLOBAL","viewId":null,"isProtected":false}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:21:17 GMT
+      ETag:
+      - '"448ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168docid1.compartment.oc1..aaaaaaaakklh3onuoqfzgpe4tlflbmabkytrmmukcllef5vfc65quvqhtfsq164374825086dc65cd5dc548c248f61328b5d668#application/json--gzip"'
+      Vary:
+      - Accept-Encoding
+      content-length:
+      - '645'
+      opc-request-id:
+      - /BCFC0E6C43C159299A6375E7826993A0/A580C753EC913460E7BA8453ED50EC0D
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:21:17 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com/records/filter.thisdoesnotexist.lexicon-test.com?limit=100&rtype=TXT
+  response:
+    body:
+      string: '{"items":[]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '13'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:21:19 GMT
+      ETag:
+      - '"0ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168d#application/json"'
+      Vary:
+      - Accept-Encoding
+      opc-request-id:
+      - /6ED6DC1398A96C9DA9CF1B000D15A9AC/EACBDAF6CEB7C924403104DB07A20744
+      opc-total-items:
+      - '0'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/oci/IntegrationTests/test_provider_when_calling_list_records_with_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/oci/IntegrationTests/test_provider_when_calling_list_records_with_name_filter_should_return_record.yaml
@@ -1,0 +1,133 @@
+interactions:
+- request:
+    body: null
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:21:19 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com
+  response:
+    body:
+      string: '{"zoneType":"PRIMARY","name":"lexicon-test.com","externalMasters":[],"self":"https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com","timeCreated":"2021-06-23T10:07:46Z","version":"448","serial":448,"nameservers":[{"hostname":"ns1.p68.dns.oraclecloud.net"},{"hostname":"ns2.p68.dns.oraclecloud.net"},{"hostname":"ns3.p68.dns.oraclecloud.net"},{"hostname":"ns4.p68.dns.oraclecloud.net"}],"compartmentId":"OCI-COMPARTMENT-ID","id":"DNS-ZONE-ID","lifecycleState":"ACTIVE","scope":"GLOBAL","viewId":null,"isProtected":false}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:21:20 GMT
+      ETag:
+      - '"448ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168docid1.compartment.oc1..aaaaaaaakklh3onuoqfzgpe4tlflbmabkytrmmukcllef5vfc65quvqhtfsq164374825086dc65cd5dc548c248f61328b5d668#application/json--gzip"'
+      Vary:
+      - Accept-Encoding
+      content-length:
+      - '645'
+      opc-request-id:
+      - /4BDD90D1F55A6DE9BD0F4656BC6D4E23/D81C34DFEB9005F6C4F51A1217FF51B8
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"items": [{"operation": "ADD", "rtype": "TXT", "rdata": "challengetoken",
+      "ttl": 3600}]}'
+    headers:
+      Content-Length:
+      - '89'
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:21:20 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: PATCH
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com/records/random.test.lexicon-test.com
+  response:
+    body:
+      string: '{"items":[{"domain":"random.test.lexicon-test.com","recordHash":"5939d233a3249cb1034c6267ee7d1013","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"303","rtype":"TXT","ttl":3600}]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '197'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:21:24 GMT
+      ETag:
+      - '"303ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168d#application/json"'
+      opc-request-id:
+      - /9A03C4E7ABFBAB296619C29824351B8D/CE8B7D3E1D2D226C131F99B7BCB96724
+      opc-total-items:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:21:24 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com/records/random.test.lexicon-test.com?limit=100&rtype=TXT
+  response:
+    body:
+      string: '{"items":[{"domain":"random.test.lexicon-test.com","recordHash":"5939d233a3249cb1034c6267ee7d1013","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"303","rtype":"TXT","ttl":3600}]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '197'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:21:26 GMT
+      ETag:
+      - '"303ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168d#application/json"'
+      Vary:
+      - Accept-Encoding
+      opc-request-id:
+      - /A67A3C91F492BA737A6908B9FCC21B88/D06D0D1BEEFB20809B16416F745CFD31
+      opc-total-items:
+      - '1'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/oci/IntegrationTests/test_provider_when_calling_list_records_with_no_arguments_should_list_all.yaml
+++ b/tests/fixtures/cassettes/oci/IntegrationTests/test_provider_when_calling_list_records_with_no_arguments_should_list_all.yaml
@@ -1,0 +1,89 @@
+interactions:
+- request:
+    body: null
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:21:26 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com
+  response:
+    body:
+      string: '{"zoneType":"PRIMARY","name":"lexicon-test.com","externalMasters":[],"self":"https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com","timeCreated":"2021-06-23T10:07:46Z","version":"448","serial":448,"nameservers":[{"hostname":"ns1.p68.dns.oraclecloud.net"},{"hostname":"ns2.p68.dns.oraclecloud.net"},{"hostname":"ns3.p68.dns.oraclecloud.net"},{"hostname":"ns4.p68.dns.oraclecloud.net"}],"compartmentId":"OCI-COMPARTMENT-ID","id":"DNS-ZONE-ID","lifecycleState":"ACTIVE","scope":"GLOBAL","viewId":null,"isProtected":false}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:21:28 GMT
+      ETag:
+      - '"448ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168docid1.compartment.oc1..aaaaaaaakklh3onuoqfzgpe4tlflbmabkytrmmukcllef5vfc65quvqhtfsq164374825086dc65cd5dc548c248f61328b5d668#application/json--gzip"'
+      Vary:
+      - Accept-Encoding
+      content-length:
+      - '645'
+      opc-request-id:
+      - /F635DBF6251918A6BE24300C542D8FCC/03E18C785C53EE75002890FAC2CD1ED6
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:21:28 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com/records?limit=100
+  response:
+    body:
+      string: '{"items":[{"domain":"docs.lexicon-test.com","recordHash":"d6fe36b079d4ac2985b25a5b96882cd7","isProtected":false,"rdata":"docs.example.com.","rrsetVersion":"278","rtype":"CNAME","ttl":3600},{"domain":"lexicon-test.com","recordHash":"5ce9d2cc56bc9db57ba9d998a98d911a","isProtected":true,"rdata":"ns1.p68.dns.oraclecloud.net.
+        hostmaster.lexicon-test.com. 448 3600 600 604800 1800","rrsetVersion":"448","rtype":"SOA","ttl":300},{"domain":"lexicon-test.com","recordHash":"8afe5805e230374e4703870ce5e1b362","isProtected":true,"rdata":"ns4.p68.dns.oraclecloud.net.","rrsetVersion":"1","rtype":"NS","ttl":86400},{"domain":"lexicon-test.com","recordHash":"cab28e6a040cdfae00893dad01209480","isProtected":true,"rdata":"ns2.p68.dns.oraclecloud.net.","rrsetVersion":"1","rtype":"NS","ttl":86400},{"domain":"lexicon-test.com","recordHash":"e276958b1b2c5ec312c120f9448f0295","isProtected":true,"rdata":"ns1.p68.dns.oraclecloud.net.","rrsetVersion":"1","rtype":"NS","ttl":86400},{"domain":"lexicon-test.com","recordHash":"fc5e04ede640257ab27fe19e8554c727","isProtected":true,"rdata":"ns3.p68.dns.oraclecloud.net.","rrsetVersion":"1","rtype":"NS","ttl":86400},{"domain":"localhost.lexicon-test.com","recordHash":"20068f94cf294942b1811fd409231dbe","isProtected":false,"rdata":"127.0.0.1","rrsetVersion":"277","rtype":"A","ttl":3600},{"domain":"orig.nameonly.test.lexicon-test.com","recordHash":"896d848b26f834d9c8fe08f83aaa580b","isProtected":false,"rdata":"\"updated\"","rrsetVersion":"321","rtype":"TXT","ttl":3600},{"domain":"orig.nameonly.test.lexicon-test.com","recordHash":"d96871ac7da8df9d246600731475f74a","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"321","rtype":"TXT","ttl":3600},{"domain":"orig.test.lexicon-test.com","recordHash":"c7825b2895d6a22416fe1e807f86d27d","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"304","rtype":"TXT","ttl":3600},{"domain":"orig.testfqdn.lexicon-test.com","recordHash":"b157b0f18514bf637d2da9a60c2d5db7","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"306","rtype":"TXT","ttl":3600},{"domain":"orig.testfull.lexicon-test.com","recordHash":"5812b10f4c43f8ac590a8bd07f5dce3c","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"307","rtype":"TXT","ttl":3600},{"domain":"random.fqdntest.lexicon-test.com","recordHash":"5d5b4b9a09be257562199ec4184d0a93","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"301","rtype":"TXT","ttl":3600},{"domain":"random.fulltest.lexicon-test.com","recordHash":"da642cca98776d00b0f61fad4051e489","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"302","rtype":"TXT","ttl":3600},{"domain":"random.test.lexicon-test.com","recordHash":"5939d233a3249cb1034c6267ee7d1013","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"303","rtype":"TXT","ttl":3600},{"domain":"ttl.fqdn.lexicon-test.com","recordHash":"b1a860728a050a1e193737002a8c392e","isProtected":false,"rdata":"\"ttlshouldbe3600\"","rrsetVersion":"298","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.createrecordset.lexicon-test.com","recordHash":"b6ebc41fde88500b72e3c74ed37f555e","isProtected":false,"rdata":"\"challengetoken2\"","rrsetVersion":"283","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.createrecordset.lexicon-test.com","recordHash":"eaca746d30c89bd96cf39ad069a282ce","isProtected":false,"rdata":"\"challengetoken1\"","rrsetVersion":"283","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.deleterecordinset.lexicon-test.com","recordHash":"05a878f361773a0bcaa7ac0b74900b7f","isProtected":false,"rdata":"\"challengetoken2\"","rrsetVersion":"445","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.fqdn.lexicon-test.com","recordHash":"2e1d5026438c46441999c0ed61cb6450","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"279","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.full.lexicon-test.com","recordHash":"92f11feb1c17981adef50d1c93ec3c5e","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"280","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.listrecordset.lexicon-test.com","recordHash":"06c966e4438fe15715878d4105682b58","isProtected":false,"rdata":"\"challengetoken1\"","rrsetVersion":"300","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.listrecordset.lexicon-test.com","recordHash":"cc91cf484d8cd148c3e9ddd3fd4018c0","isProtected":false,"rdata":"\"challengetoken2\"","rrsetVersion":"300","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.noop.lexicon-test.com","recordHash":"575c16c67d0a8ec908f50cca7bc8c0cb","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"284","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.test.lexicon-test.com","recordHash":"768ea81c2972b69ac41fd65fe5bb53be","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"281","rtype":"TXT","ttl":3600}]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:21:30 GMT
+      ETag:
+      - '"448ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168d#application/json--gzip"'
+      Vary:
+      - Accept-Encoding
+      content-length:
+      - '4802'
+      opc-request-id:
+      - /D7E23F6EA321E689EE556B161664ABF4/519D5F6430654BAF76B8399B9C707E61
+      opc-total-items:
+      - '25'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/oci/IntegrationTests/test_provider_when_calling_update_record_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/oci/IntegrationTests/test_provider_when_calling_update_record_should_modify_record.yaml
@@ -1,0 +1,222 @@
+interactions:
+- request:
+    body: null
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:21:30 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com
+  response:
+    body:
+      string: '{"zoneType":"PRIMARY","name":"lexicon-test.com","externalMasters":[],"self":"https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com","timeCreated":"2021-06-23T10:07:46Z","version":"448","serial":448,"nameservers":[{"hostname":"ns1.p68.dns.oraclecloud.net"},{"hostname":"ns2.p68.dns.oraclecloud.net"},{"hostname":"ns3.p68.dns.oraclecloud.net"},{"hostname":"ns4.p68.dns.oraclecloud.net"}],"compartmentId":"OCI-COMPARTMENT-ID","id":"DNS-ZONE-ID","lifecycleState":"ACTIVE","scope":"GLOBAL","viewId":null,"isProtected":false}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:21:32 GMT
+      ETag:
+      - '"448ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168docid1.compartment.oc1..aaaaaaaakklh3onuoqfzgpe4tlflbmabkytrmmukcllef5vfc65quvqhtfsq164374825086dc65cd5dc548c248f61328b5d668#application/json--gzip"'
+      Vary:
+      - Accept-Encoding
+      content-length:
+      - '645'
+      opc-request-id:
+      - /5D84C44A5C454FB3B4453E0D3610375B/4576B034FD51B2664C748C1757CCE01F
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"items": [{"operation": "ADD", "rtype": "TXT", "rdata": "challengetoken",
+      "ttl": 3600}]}'
+    headers:
+      Content-Length:
+      - '89'
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:21:33 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: PATCH
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com/records/orig.test.lexicon-test.com
+  response:
+    body:
+      string: '{"items":[{"domain":"orig.test.lexicon-test.com","recordHash":"c7825b2895d6a22416fe1e807f86d27d","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"304","rtype":"TXT","ttl":3600}]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '195'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:21:35 GMT
+      ETag:
+      - '"304ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168d#application/json"'
+      opc-request-id:
+      - /2D5A706F2595AA39480CD3528EEBF73E/09D0020A996C4C53643A809A63B77B34
+      opc-total-items:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:21:35 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com/records/orig.test.lexicon-test.com?limit=100&rtype=TXT
+  response:
+    body:
+      string: '{"items":[{"domain":"orig.test.lexicon-test.com","recordHash":"c7825b2895d6a22416fe1e807f86d27d","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"304","rtype":"TXT","ttl":3600}]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '195'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:21:36 GMT
+      ETag:
+      - '"304ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168d#application/json"'
+      Vary:
+      - Accept-Encoding
+      opc-request-id:
+      - /CECCC92A8C918836B0F2582DCF6604AB/D32FC25CB8B7DD35B7C9C039349CDBAA
+      opc-total-items:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:21:37 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com/records?limit=100&rtype=TXT
+  response:
+    body:
+      string: '{"items":[{"domain":"orig.nameonly.test.lexicon-test.com","recordHash":"896d848b26f834d9c8fe08f83aaa580b","isProtected":false,"rdata":"\"updated\"","rrsetVersion":"321","rtype":"TXT","ttl":3600},{"domain":"orig.nameonly.test.lexicon-test.com","recordHash":"d96871ac7da8df9d246600731475f74a","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"321","rtype":"TXT","ttl":3600},{"domain":"orig.test.lexicon-test.com","recordHash":"c7825b2895d6a22416fe1e807f86d27d","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"304","rtype":"TXT","ttl":3600},{"domain":"orig.testfqdn.lexicon-test.com","recordHash":"b157b0f18514bf637d2da9a60c2d5db7","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"306","rtype":"TXT","ttl":3600},{"domain":"orig.testfull.lexicon-test.com","recordHash":"5812b10f4c43f8ac590a8bd07f5dce3c","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"307","rtype":"TXT","ttl":3600},{"domain":"random.fqdntest.lexicon-test.com","recordHash":"5d5b4b9a09be257562199ec4184d0a93","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"301","rtype":"TXT","ttl":3600},{"domain":"random.fulltest.lexicon-test.com","recordHash":"da642cca98776d00b0f61fad4051e489","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"302","rtype":"TXT","ttl":3600},{"domain":"random.test.lexicon-test.com","recordHash":"5939d233a3249cb1034c6267ee7d1013","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"303","rtype":"TXT","ttl":3600},{"domain":"ttl.fqdn.lexicon-test.com","recordHash":"b1a860728a050a1e193737002a8c392e","isProtected":false,"rdata":"\"ttlshouldbe3600\"","rrsetVersion":"298","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.createrecordset.lexicon-test.com","recordHash":"b6ebc41fde88500b72e3c74ed37f555e","isProtected":false,"rdata":"\"challengetoken2\"","rrsetVersion":"283","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.createrecordset.lexicon-test.com","recordHash":"eaca746d30c89bd96cf39ad069a282ce","isProtected":false,"rdata":"\"challengetoken1\"","rrsetVersion":"283","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.deleterecordinset.lexicon-test.com","recordHash":"05a878f361773a0bcaa7ac0b74900b7f","isProtected":false,"rdata":"\"challengetoken2\"","rrsetVersion":"445","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.fqdn.lexicon-test.com","recordHash":"2e1d5026438c46441999c0ed61cb6450","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"279","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.full.lexicon-test.com","recordHash":"92f11feb1c17981adef50d1c93ec3c5e","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"280","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.listrecordset.lexicon-test.com","recordHash":"06c966e4438fe15715878d4105682b58","isProtected":false,"rdata":"\"challengetoken1\"","rrsetVersion":"300","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.listrecordset.lexicon-test.com","recordHash":"cc91cf484d8cd148c3e9ddd3fd4018c0","isProtected":false,"rdata":"\"challengetoken2\"","rrsetVersion":"300","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.noop.lexicon-test.com","recordHash":"575c16c67d0a8ec908f50cca7bc8c0cb","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"284","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.test.lexicon-test.com","recordHash":"768ea81c2972b69ac41fd65fe5bb53be","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"281","rtype":"TXT","ttl":3600}]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:21:38 GMT
+      ETag:
+      - '"448ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168d#application/json--gzip"'
+      Vary:
+      - Accept-Encoding
+      content-length:
+      - '3496'
+      opc-request-id:
+      - /DD0FBDC655931FCAB54301A887ABC99D/A302B8EDF2611D1D72C2820E4FD03E48
+      opc-total-items:
+      - '18'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"items": [{"operation": "REMOVE", "recordHash": "c7825b2895d6a22416fe1e807f86d27d"},
+      {"operation": "ADD", "rtype": "TXT", "rdata": "challengetoken", "ttl": 3600}]}'
+    headers:
+      Content-Length:
+      - '164'
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:21:39 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: PATCH
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com/records/orig.test.lexicon-test.com
+  response:
+    body:
+      string: '{"items":[{"domain":"orig.test.lexicon-test.com","recordHash":"c7825b2895d6a22416fe1e807f86d27d","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"304","rtype":"TXT","ttl":3600}]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '195'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:21:43 GMT
+      ETag:
+      - '"304ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168d#application/json"'
+      opc-request-id:
+      - /1671FDC36577DE414AF15275DB29B93F/0BD66BBD2435C7E5C5B5B24CA93AF3C1
+      opc-total-items:
+      - '1'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/oci/IntegrationTests/test_provider_when_calling_update_record_should_modify_record_name_specified.yaml
+++ b/tests/fixtures/cassettes/oci/IntegrationTests/test_provider_when_calling_update_record_should_modify_record_name_specified.yaml
@@ -1,0 +1,178 @@
+interactions:
+- request:
+    body: null
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:21:43 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com
+  response:
+    body:
+      string: '{"zoneType":"PRIMARY","name":"lexicon-test.com","externalMasters":[],"self":"https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com","timeCreated":"2021-06-23T10:07:46Z","version":"448","serial":448,"nameservers":[{"hostname":"ns1.p68.dns.oraclecloud.net"},{"hostname":"ns2.p68.dns.oraclecloud.net"},{"hostname":"ns3.p68.dns.oraclecloud.net"},{"hostname":"ns4.p68.dns.oraclecloud.net"}],"compartmentId":"OCI-COMPARTMENT-ID","id":"DNS-ZONE-ID","lifecycleState":"ACTIVE","scope":"GLOBAL","viewId":null,"isProtected":false}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:21:45 GMT
+      ETag:
+      - '"448ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168docid1.compartment.oc1..aaaaaaaakklh3onuoqfzgpe4tlflbmabkytrmmukcllef5vfc65quvqhtfsq164374825086dc65cd5dc548c248f61328b5d668#application/json--gzip"'
+      Vary:
+      - Accept-Encoding
+      content-length:
+      - '645'
+      opc-request-id:
+      - /F575570A1A652403461B4FE2A31CB21C/840BBFFCC11DC422AB758F01E851BEB9
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"items": [{"operation": "ADD", "rtype": "TXT", "rdata": "challengetoken",
+      "ttl": 3600}]}'
+    headers:
+      Content-Length:
+      - '89'
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:21:45 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: PATCH
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com/records/orig.nameonly.test.lexicon-test.com
+  response:
+    body:
+      string: '{"items":[{"domain":"orig.nameonly.test.lexicon-test.com","recordHash":"896d848b26f834d9c8fe08f83aaa580b","isProtected":false,"rdata":"\"updated\"","rrsetVersion":"321","rtype":"TXT","ttl":3600},{"domain":"orig.nameonly.test.lexicon-test.com","recordHash":"d96871ac7da8df9d246600731475f74a","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"321","rtype":"TXT","ttl":3600}]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '389'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:21:47 GMT
+      ETag:
+      - '"321ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168d#application/json"'
+      opc-request-id:
+      - /5EFCCA3A6FC2E7D8FB3CC8A86E329CFD/D492B1DEAC226EE01FEF485DC8025CC2
+      opc-total-items:
+      - '2'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:21:47 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com/records/orig.nameonly.test.lexicon-test.com?limit=100&rtype=TXT
+  response:
+    body:
+      string: '{"items":[{"domain":"orig.nameonly.test.lexicon-test.com","recordHash":"896d848b26f834d9c8fe08f83aaa580b","isProtected":false,"rdata":"\"updated\"","rrsetVersion":"321","rtype":"TXT","ttl":3600},{"domain":"orig.nameonly.test.lexicon-test.com","recordHash":"d96871ac7da8df9d246600731475f74a","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"321","rtype":"TXT","ttl":3600}]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:21:52 GMT
+      ETag:
+      - '"321ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168d#application/json--gzip"'
+      Vary:
+      - Accept-Encoding
+      content-length:
+      - '389'
+      opc-request-id:
+      - /37CD2429E68DC95A647A313D501ACE51/607F21C01A4A7AFE3F6E6A667944DACD
+      opc-total-items:
+      - '2'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"items": [{"operation": "REMOVE", "recordHash": "896d848b26f834d9c8fe08f83aaa580b"},
+      {"operation": "ADD", "rtype": "TXT", "rdata": "updated", "ttl": 3600}]}'
+    headers:
+      Content-Length:
+      - '157'
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:21:52 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: PATCH
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com/records/orig.nameonly.test.lexicon-test.com
+  response:
+    body:
+      string: '{"items":[{"domain":"orig.nameonly.test.lexicon-test.com","recordHash":"896d848b26f834d9c8fe08f83aaa580b","isProtected":false,"rdata":"\"updated\"","rrsetVersion":"321","rtype":"TXT","ttl":3600},{"domain":"orig.nameonly.test.lexicon-test.com","recordHash":"d96871ac7da8df9d246600731475f74a","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"321","rtype":"TXT","ttl":3600}]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '389'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:21:54 GMT
+      ETag:
+      - '"321ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168d#application/json"'
+      opc-request-id:
+      - /4126FECB2DC642BED6E258F2B152F696/3C371FB43C15A4A57A36F190DA1A5BC1
+      opc-total-items:
+      - '2'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/oci/IntegrationTests/test_provider_when_calling_update_record_with_fqdn_name_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/oci/IntegrationTests/test_provider_when_calling_update_record_with_fqdn_name_should_modify_record.yaml
@@ -1,0 +1,222 @@
+interactions:
+- request:
+    body: null
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:21:54 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com
+  response:
+    body:
+      string: '{"zoneType":"PRIMARY","name":"lexicon-test.com","externalMasters":[],"self":"https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com","timeCreated":"2021-06-23T10:07:46Z","version":"448","serial":448,"nameservers":[{"hostname":"ns1.p68.dns.oraclecloud.net"},{"hostname":"ns2.p68.dns.oraclecloud.net"},{"hostname":"ns3.p68.dns.oraclecloud.net"},{"hostname":"ns4.p68.dns.oraclecloud.net"}],"compartmentId":"OCI-COMPARTMENT-ID","id":"DNS-ZONE-ID","lifecycleState":"ACTIVE","scope":"GLOBAL","viewId":null,"isProtected":false}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:21:56 GMT
+      ETag:
+      - '"448ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168docid1.compartment.oc1..aaaaaaaakklh3onuoqfzgpe4tlflbmabkytrmmukcllef5vfc65quvqhtfsq164374825086dc65cd5dc548c248f61328b5d668#application/json--gzip"'
+      Vary:
+      - Accept-Encoding
+      content-length:
+      - '645'
+      opc-request-id:
+      - /49C80BED8FC39894B41A22D4B76B47DD/D864CD5813787285A668FAD9E3B33036
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"items": [{"operation": "ADD", "rtype": "TXT", "rdata": "challengetoken",
+      "ttl": 3600}]}'
+    headers:
+      Content-Length:
+      - '89'
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:21:56 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: PATCH
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com/records/orig.testfqdn.lexicon-test.com
+  response:
+    body:
+      string: '{"items":[{"domain":"orig.testfqdn.lexicon-test.com","recordHash":"b157b0f18514bf637d2da9a60c2d5db7","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"306","rtype":"TXT","ttl":3600}]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '199'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:21:59 GMT
+      ETag:
+      - '"306ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168d#application/json"'
+      opc-request-id:
+      - /6D30341F71551E43710598C3E49E4A9B/888A0C3696923FA3F0E4E346166F5F01
+      opc-total-items:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:21:59 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com/records/orig.testfqdn.lexicon-test.com?limit=100&rtype=TXT
+  response:
+    body:
+      string: '{"items":[{"domain":"orig.testfqdn.lexicon-test.com","recordHash":"b157b0f18514bf637d2da9a60c2d5db7","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"306","rtype":"TXT","ttl":3600}]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '199'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:22:01 GMT
+      ETag:
+      - '"306ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168d#application/json"'
+      Vary:
+      - Accept-Encoding
+      opc-request-id:
+      - /DB5982A1064CA4218599C123A864212D/7B70B1FD8D3BC99E5DA52523FFD2C974
+      opc-total-items:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:22:01 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com/records?limit=100&rtype=TXT
+  response:
+    body:
+      string: '{"items":[{"domain":"orig.nameonly.test.lexicon-test.com","recordHash":"896d848b26f834d9c8fe08f83aaa580b","isProtected":false,"rdata":"\"updated\"","rrsetVersion":"321","rtype":"TXT","ttl":3600},{"domain":"orig.nameonly.test.lexicon-test.com","recordHash":"d96871ac7da8df9d246600731475f74a","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"321","rtype":"TXT","ttl":3600},{"domain":"orig.test.lexicon-test.com","recordHash":"c7825b2895d6a22416fe1e807f86d27d","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"304","rtype":"TXT","ttl":3600},{"domain":"orig.testfqdn.lexicon-test.com","recordHash":"b157b0f18514bf637d2da9a60c2d5db7","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"306","rtype":"TXT","ttl":3600},{"domain":"orig.testfull.lexicon-test.com","recordHash":"5812b10f4c43f8ac590a8bd07f5dce3c","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"307","rtype":"TXT","ttl":3600},{"domain":"random.fqdntest.lexicon-test.com","recordHash":"5d5b4b9a09be257562199ec4184d0a93","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"301","rtype":"TXT","ttl":3600},{"domain":"random.fulltest.lexicon-test.com","recordHash":"da642cca98776d00b0f61fad4051e489","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"302","rtype":"TXT","ttl":3600},{"domain":"random.test.lexicon-test.com","recordHash":"5939d233a3249cb1034c6267ee7d1013","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"303","rtype":"TXT","ttl":3600},{"domain":"ttl.fqdn.lexicon-test.com","recordHash":"b1a860728a050a1e193737002a8c392e","isProtected":false,"rdata":"\"ttlshouldbe3600\"","rrsetVersion":"298","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.createrecordset.lexicon-test.com","recordHash":"b6ebc41fde88500b72e3c74ed37f555e","isProtected":false,"rdata":"\"challengetoken2\"","rrsetVersion":"283","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.createrecordset.lexicon-test.com","recordHash":"eaca746d30c89bd96cf39ad069a282ce","isProtected":false,"rdata":"\"challengetoken1\"","rrsetVersion":"283","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.deleterecordinset.lexicon-test.com","recordHash":"05a878f361773a0bcaa7ac0b74900b7f","isProtected":false,"rdata":"\"challengetoken2\"","rrsetVersion":"445","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.fqdn.lexicon-test.com","recordHash":"2e1d5026438c46441999c0ed61cb6450","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"279","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.full.lexicon-test.com","recordHash":"92f11feb1c17981adef50d1c93ec3c5e","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"280","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.listrecordset.lexicon-test.com","recordHash":"06c966e4438fe15715878d4105682b58","isProtected":false,"rdata":"\"challengetoken1\"","rrsetVersion":"300","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.listrecordset.lexicon-test.com","recordHash":"cc91cf484d8cd148c3e9ddd3fd4018c0","isProtected":false,"rdata":"\"challengetoken2\"","rrsetVersion":"300","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.noop.lexicon-test.com","recordHash":"575c16c67d0a8ec908f50cca7bc8c0cb","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"284","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.test.lexicon-test.com","recordHash":"768ea81c2972b69ac41fd65fe5bb53be","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"281","rtype":"TXT","ttl":3600}]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:22:04 GMT
+      ETag:
+      - '"448ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168d#application/json--gzip"'
+      Vary:
+      - Accept-Encoding
+      content-length:
+      - '3496'
+      opc-request-id:
+      - /AA2E0A7C489BBE2B3F2FFA2CE9981DBC/7253ADAB89C7E434A1D23C63CF80167B
+      opc-total-items:
+      - '18'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"items": [{"operation": "REMOVE", "recordHash": "b157b0f18514bf637d2da9a60c2d5db7"},
+      {"operation": "ADD", "rtype": "TXT", "rdata": "challengetoken", "ttl": 3600}]}'
+    headers:
+      Content-Length:
+      - '164'
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:22:04 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: PATCH
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com/records/orig.testfqdn.lexicon-test.com
+  response:
+    body:
+      string: '{"items":[{"domain":"orig.testfqdn.lexicon-test.com","recordHash":"b157b0f18514bf637d2da9a60c2d5db7","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"306","rtype":"TXT","ttl":3600}]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '199'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:22:06 GMT
+      ETag:
+      - '"306ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168d#application/json"'
+      opc-request-id:
+      - /0AA457597FED7A3A92A3C815E38212F9/12683CF54E108521F649267942799166
+      opc-total-items:
+      - '1'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/oci/IntegrationTests/test_provider_when_calling_update_record_with_full_name_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/oci/IntegrationTests/test_provider_when_calling_update_record_with_full_name_should_modify_record.yaml
@@ -1,0 +1,222 @@
+interactions:
+- request:
+    body: null
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:22:06 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com
+  response:
+    body:
+      string: '{"zoneType":"PRIMARY","name":"lexicon-test.com","externalMasters":[],"self":"https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com","timeCreated":"2021-06-23T10:07:46Z","version":"448","serial":448,"nameservers":[{"hostname":"ns1.p68.dns.oraclecloud.net"},{"hostname":"ns2.p68.dns.oraclecloud.net"},{"hostname":"ns3.p68.dns.oraclecloud.net"},{"hostname":"ns4.p68.dns.oraclecloud.net"}],"compartmentId":"OCI-COMPARTMENT-ID","id":"DNS-ZONE-ID","lifecycleState":"ACTIVE","scope":"GLOBAL","viewId":null,"isProtected":false}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:22:09 GMT
+      ETag:
+      - '"448ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168docid1.compartment.oc1..aaaaaaaakklh3onuoqfzgpe4tlflbmabkytrmmukcllef5vfc65quvqhtfsq164374825086dc65cd5dc548c248f61328b5d668#application/json--gzip"'
+      Vary:
+      - Accept-Encoding
+      content-length:
+      - '645'
+      opc-request-id:
+      - /6F4A2808BC35929BD3C9BA87A9EEFD96/9371DD325B9BD6539712FF6A3E1FCE99
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"items": [{"operation": "ADD", "rtype": "TXT", "rdata": "challengetoken",
+      "ttl": 3600}]}'
+    headers:
+      Content-Length:
+      - '89'
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:22:09 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: PATCH
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com/records/orig.testfull.lexicon-test.com
+  response:
+    body:
+      string: '{"items":[{"domain":"orig.testfull.lexicon-test.com","recordHash":"5812b10f4c43f8ac590a8bd07f5dce3c","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"307","rtype":"TXT","ttl":3600}]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '199'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:22:11 GMT
+      ETag:
+      - '"307ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168d#application/json"'
+      opc-request-id:
+      - /1D33F59554B25C506A7910B6B8A739A3/2B95FE8EDE7AEEB2F5A4DA8ACBF3B052
+      opc-total-items:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:22:11 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com/records/orig.testfull.lexicon-test.com?limit=100&rtype=TXT
+  response:
+    body:
+      string: '{"items":[{"domain":"orig.testfull.lexicon-test.com","recordHash":"5812b10f4c43f8ac590a8bd07f5dce3c","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"307","rtype":"TXT","ttl":3600}]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '199'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:22:13 GMT
+      ETag:
+      - '"307ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168d#application/json"'
+      Vary:
+      - Accept-Encoding
+      opc-request-id:
+      - /026CA3DB015EDC94D1834B14480D1E38/D53FD4057BEF5700D1466A03C05D7825
+      opc-total-items:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:22:13 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com/records?limit=100&rtype=TXT
+  response:
+    body:
+      string: '{"items":[{"domain":"orig.nameonly.test.lexicon-test.com","recordHash":"896d848b26f834d9c8fe08f83aaa580b","isProtected":false,"rdata":"\"updated\"","rrsetVersion":"321","rtype":"TXT","ttl":3600},{"domain":"orig.nameonly.test.lexicon-test.com","recordHash":"d96871ac7da8df9d246600731475f74a","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"321","rtype":"TXT","ttl":3600},{"domain":"orig.test.lexicon-test.com","recordHash":"c7825b2895d6a22416fe1e807f86d27d","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"304","rtype":"TXT","ttl":3600},{"domain":"orig.testfqdn.lexicon-test.com","recordHash":"b157b0f18514bf637d2da9a60c2d5db7","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"306","rtype":"TXT","ttl":3600},{"domain":"orig.testfull.lexicon-test.com","recordHash":"5812b10f4c43f8ac590a8bd07f5dce3c","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"307","rtype":"TXT","ttl":3600},{"domain":"random.fqdntest.lexicon-test.com","recordHash":"5d5b4b9a09be257562199ec4184d0a93","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"301","rtype":"TXT","ttl":3600},{"domain":"random.fulltest.lexicon-test.com","recordHash":"da642cca98776d00b0f61fad4051e489","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"302","rtype":"TXT","ttl":3600},{"domain":"random.test.lexicon-test.com","recordHash":"5939d233a3249cb1034c6267ee7d1013","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"303","rtype":"TXT","ttl":3600},{"domain":"ttl.fqdn.lexicon-test.com","recordHash":"b1a860728a050a1e193737002a8c392e","isProtected":false,"rdata":"\"ttlshouldbe3600\"","rrsetVersion":"298","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.createrecordset.lexicon-test.com","recordHash":"b6ebc41fde88500b72e3c74ed37f555e","isProtected":false,"rdata":"\"challengetoken2\"","rrsetVersion":"283","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.createrecordset.lexicon-test.com","recordHash":"eaca746d30c89bd96cf39ad069a282ce","isProtected":false,"rdata":"\"challengetoken1\"","rrsetVersion":"283","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.deleterecordinset.lexicon-test.com","recordHash":"05a878f361773a0bcaa7ac0b74900b7f","isProtected":false,"rdata":"\"challengetoken2\"","rrsetVersion":"445","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.fqdn.lexicon-test.com","recordHash":"2e1d5026438c46441999c0ed61cb6450","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"279","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.full.lexicon-test.com","recordHash":"92f11feb1c17981adef50d1c93ec3c5e","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"280","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.listrecordset.lexicon-test.com","recordHash":"06c966e4438fe15715878d4105682b58","isProtected":false,"rdata":"\"challengetoken1\"","rrsetVersion":"300","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.listrecordset.lexicon-test.com","recordHash":"cc91cf484d8cd148c3e9ddd3fd4018c0","isProtected":false,"rdata":"\"challengetoken2\"","rrsetVersion":"300","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.noop.lexicon-test.com","recordHash":"575c16c67d0a8ec908f50cca7bc8c0cb","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"284","rtype":"TXT","ttl":3600},{"domain":"_acme-challenge.test.lexicon-test.com","recordHash":"768ea81c2972b69ac41fd65fe5bb53be","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"281","rtype":"TXT","ttl":3600}]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:22:15 GMT
+      ETag:
+      - '"448ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168d#application/json--gzip"'
+      Vary:
+      - Accept-Encoding
+      content-length:
+      - '3496'
+      opc-request-id:
+      - /B5D30B8841357451D8E8C84B74669537/FB26F4437439CD3FE5014BF988ED7365
+      opc-total-items:
+      - '18'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"items": [{"operation": "REMOVE", "recordHash": "5812b10f4c43f8ac590a8bd07f5dce3c"},
+      {"operation": "ADD", "rtype": "TXT", "rdata": "challengetoken", "ttl": 3600}]}'
+    headers:
+      Content-Length:
+      - '164'
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      date:
+      - Mon, 28 Jun 2021 22:22:15 GMT
+      host:
+      - dns.us-ashburn-1.oraclecloud.com
+      user-agent:
+      - python-requests/2.25.1
+    method: PATCH
+    uri: https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/lexicon-test.com/records/orig.testfull.lexicon-test.com
+  response:
+    body:
+      string: '{"items":[{"domain":"orig.testfull.lexicon-test.com","recordHash":"5812b10f4c43f8ac590a8bd07f5dce3c","isProtected":false,"rdata":"\"challengetoken\"","rrsetVersion":"307","rtype":"TXT","ttl":3600}]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '199'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jun 2021 22:22:19 GMT
+      ETag:
+      - '"307ocid1.dns-zone.oc1..847c27f48092401b867140660ee2168d#application/json"'
+      opc-request-id:
+      - /AE07B6C5A7F35635F7D420DB7588C49F/4D1CE4F55F28FBB17F38EE978AA72F9C
+      opc-total-items:
+      - '1'
+    status:
+      code: 200
+      message: OK
+version: 1


### PR DESCRIPTION
The Oracle Cloud Infrastructure (OCI) provider can create, list, update and
delete records in any public DNS zone hosted in a tenancy located in any
region within the OCI commercial (OC1) realm.

No authentication details are required if the OCI CLI installed and the DEFAULT
profile configured in the `~/.oci/config` file has the appropriate permission for
the target DNS zone.

Use the `--auth-*` command-line parameters or the
`LEXICON_OCI_AUTH_*` environment variables to
override the default file location and profile name.

Set the `--auth-type` parameter to `instance_principal` to use instance principal
authentication when running Lexicon on an Oracle Cloud Infrastructure compute
instance. This method requires permission to be granted via IAM policy to a
dynamic group that includes the compute instance.

See <https://docs.oracle.com/en-us/iaas/Content/DNS/Concepts/dnszonemanagement.htm>
for in-depth documentation on managing DNS via the OCI console, SDK or API.

Signed-off-by: Avi Miller <avi.miller@oracle.com>