### PR TITLE
Exclude integration tests from source distributions + remove MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,0 @@
-include README.rst LICENSE

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ repository = "https://github.com/AnalogJ/lexicon"
 packages = [
     { include = "lexicon" },
 ]
+exclude = [ "lexicon/tests/providers/" ]
 
 [tool.poetry.dependencies]
 python = "^3.6"


### PR DESCRIPTION
Hi,
Since cassettes aren't included in sdists, these tests aren't very useful. I am also removing MANIFEST.in which is unused as far as I can tell.