### PR TITLE
Remove cryptography<4 constraint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ packages = [
 [tool.poetry.dependencies]
 python = "^3.6"
 tldextract = ">=2,<4"
-cryptography = ">=2,<4"
+cryptography = ">=2"
 pyyaml = ">=3,<6"
 requests = "^2"
 beautifulsoup4 = "^4"


### PR DESCRIPTION
Cryptography changed their versioning from a custom versioning scheme to one inspired by Firefox. As such they've jumped from 3.4.8 to 35.0.0. This causes issues for lexicon, as 35 is less than 4.

You can see this dependency causing trouble with MacPorts as seen in this (misguided unfortunately) ticket here: https://trac.macports.org/ticket/63567

I didn't know if this warrents a version bump of lexicon from 3.7.0 to 3.7.1. If it does let me know :slightly_smiling_face: 