### PR TITLE
Update dreamhost to use `dns-list_records` instead of `domain-list_domains`

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -29,7 +29,7 @@ lexicon/providers/dnsimple.py       @analogj
 lexicon/providers/dnsmadeeasy.py    @analogj @nydr
 lexicon/providers/dnspark.py        @analogj
 lexicon/providers/dnspod.py         @analogj
-lexicon/providers/dreamhost.py      @chhsiao1981
+lexicon/providers/dreamhost.py      @chhsiao1981 @ryan953
 lexicon/providers/dynu.py           @HerrFolgreich
 lexicon/providers/easydns.py        @analogj
 lexicon/providers/easyname.py       @astzweig @rqelibari

--- a/lexicon/providers/dreamhost.py
+++ b/lexicon/providers/dreamhost.py
@@ -100,14 +100,15 @@ class Provider(BaseProvider):
 
     def _authenticate(self):
         self.domain_id = None
-        payload = self._get("domain-list_domains")
+        payload = self._get("dns-list_records")
         data = payload.get("data", None)
         if data is None:
             raise AuthenticationError("Domain not found")
 
-        for domain in data:
-            if domain.get("domain", "") == self.domain:
+        for record in data:
+            if record.get("record", "") == self.domain and record.get("type", "") in ["A", "AAAA"]:
                 self.domain_id = self.domain
+                break
         if self.domain_id is None:
             raise AuthenticationError("Domain not found")
 

--- a/tests/fixtures/cassettes/dreamhost/IntegrationTests/test_provider_authenticate.yaml
+++ b/tests/fixtures/cassettes/dreamhost/IntegrationTests/test_provider_authenticate.yaml
@@ -9,9 +9,9 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.18.4]
     method: GET
-    uri: https://api.dreamhost.com/?cmd=domain-list_domains&format=json
+    uri: https://api.dreamhost.com/?cmd=dns-list_records&format=json
   response:
-    body: {string: !!python/unicode '{"result":"success","data":[{"domain":"lexicon-example.com"}]}'}
+    body: {string: !!python/unicode '{"result":"success","data":[{"type":"A","record":"lexicon-example.com"}]}'}
     headers:
       access-control-allow-origin: ['*']
       connection: [keep-alive]

--- a/tests/fixtures/cassettes/dreamhost/IntegrationTests/test_provider_authenticate_with_unmanaged_domain_should_fail.yaml
+++ b/tests/fixtures/cassettes/dreamhost/IntegrationTests/test_provider_authenticate_with_unmanaged_domain_should_fail.yaml
@@ -9,9 +9,9 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.18.4]
     method: GET
-    uri: https://api.dreamhost.com/?cmd=domain-list_domains&format=json
+    uri: https://api.dreamhost.com/?cmd=dns-list_records&format=json
   response:
-    body: {string: !!python/unicode '{"result":"success","data":[{"domain":"lexicon-example.com"}]}'}
+    body: {string: !!python/unicode '{"result":"success","data":[{"type":"A","record":"lexicon-example.com"}]}'}
     headers:
       access-control-allow-origin: ['*']
       connection: [keep-alive]

--- a/tests/fixtures/cassettes/dreamhost/IntegrationTests/test_provider_when_calling_create_record_for_A_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/dreamhost/IntegrationTests/test_provider_when_calling_create_record_for_A_with_valid_name_and_content.yaml
@@ -9,9 +9,9 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.18.4]
     method: GET
-    uri: https://api.dreamhost.com/?cmd=domain-list_domains&format=json
+    uri: https://api.dreamhost.com/?cmd=dns-list_records&format=json
   response:
-    body: {string: !!python/unicode '{"result":"success","data":[{"domain":"lexicon-example.com","AXFR_IPS":"none","TTL_SEC":0,"DOMAINID":1047330,"SOA_EMAIL":"trinopoty@hotmail.com","EXPIRE_SEC":0,"RETRY_SEC":0,"STATUS":1,"DESCRIPTION":"","LPM_DISPLAYGROUP":"","REFRESH_SEC":0,"MASTER_IPS":"","TYPE":"master"}],"ERRORARRAY":[]}'}
+    body: {string: !!python/unicode '{"result":"success","data":[{"type":"A","record":"lexicon-example.com"}]}'}
     headers:
       access-control-allow-origin: ['*']
       connection: [keep-alive]

--- a/tests/fixtures/cassettes/dreamhost/IntegrationTests/test_provider_when_calling_create_record_for_CNAME_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/dreamhost/IntegrationTests/test_provider_when_calling_create_record_for_CNAME_with_valid_name_and_content.yaml
@@ -9,9 +9,9 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.18.4]
     method: GET
-    uri: https://api.dreamhost.com/?cmd=domain-list_domains&format=json
+    uri: https://api.dreamhost.com/?cmd=dns-list_records&format=json
   response:
-    body: {string: !!python/unicode '{"result":"success","data":[{"domain":"lexicon-example.com","AXFR_IPS":"none","TTL_SEC":0,"DOMAINID":1047330,"SOA_EMAIL":"trinopoty@hotmail.com","EXPIRE_SEC":0,"RETRY_SEC":0,"STATUS":1,"DESCRIPTION":"","LPM_DISPLAYGROUP":"","REFRESH_SEC":0,"MASTER_IPS":"","TYPE":"master"}],"ERRORARRAY":[]}'}
+    body: {string: !!python/unicode '{"result":"success","data":[{"type":"A","record":"lexicon-example.com"}]}'}
     headers:
       access-control-allow-origin: ['*']
       connection: [keep-alive]

--- a/tests/fixtures/cassettes/dreamhost/IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_fqdn_name_and_content.yaml
+++ b/tests/fixtures/cassettes/dreamhost/IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_fqdn_name_and_content.yaml
@@ -9,9 +9,9 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.18.4]
     method: GET
-    uri: https://api.dreamhost.com/?cmd=domain-list_domains&format=json
+    uri: https://api.dreamhost.com/?cmd=dns-list_records&format=json
   response:
-    body: {string: !!python/unicode '{"result":"success","data":[{"domain":"lexicon-example.com","AXFR_IPS":"none","TTL_SEC":0,"DOMAINID":1047330,"SOA_EMAIL":"trinopoty@hotmail.com","EXPIRE_SEC":0,"RETRY_SEC":0,"STATUS":1,"DESCRIPTION":"","LPM_DISPLAYGROUP":"","REFRESH_SEC":0,"MASTER_IPS":"","TYPE":"master"}],"ERRORARRAY":[]}'}
+    body: {string: !!python/unicode '{"result":"success","data":[{"type":"A","record":"lexicon-example.com"}]}'}
     headers:
       access-control-allow-origin: ['*']
       connection: [keep-alive]

--- a/tests/fixtures/cassettes/dreamhost/IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_full_name_and_content.yaml
+++ b/tests/fixtures/cassettes/dreamhost/IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_full_name_and_content.yaml
@@ -9,9 +9,9 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.18.4]
     method: GET
-    uri: https://api.dreamhost.com/?cmd=domain-list_domains&format=json
+    uri: https://api.dreamhost.com/?cmd=dns-list_records&format=json
   response:
-    body: {string: !!python/unicode '{"result":"success","data":[{"domain":"lexicon-example.com","AXFR_IPS":"none","TTL_SEC":0,"DOMAINID":1047330,"SOA_EMAIL":"trinopoty@hotmail.com","EXPIRE_SEC":0,"RETRY_SEC":0,"STATUS":1,"DESCRIPTION":"","LPM_DISPLAYGROUP":"","REFRESH_SEC":0,"MASTER_IPS":"","TYPE":"master"}],"ERRORARRAY":[]}'}
+    body: {string: !!python/unicode '{"result":"success","data":[{"type":"A","record":"lexicon-example.com"}]}'}
     headers:
       access-control-allow-origin: ['*']
       connection: [keep-alive]

--- a/tests/fixtures/cassettes/dreamhost/IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/dreamhost/IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_valid_name_and_content.yaml
@@ -9,9 +9,9 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.18.4]
     method: GET
-    uri: https://api.dreamhost.com/?cmd=domain-list_domains&format=json
+    uri: https://api.dreamhost.com/?cmd=dns-list_records&format=json
   response:
-    body: {string: !!python/unicode '{"result":"success","data":[{"domain":"lexicon-example.com","AXFR_IPS":"none","TTL_SEC":0,"DOMAINID":1047330,"SOA_EMAIL":"trinopoty@hotmail.com","EXPIRE_SEC":0,"RETRY_SEC":0,"STATUS":1,"DESCRIPTION":"","LPM_DISPLAYGROUP":"","REFRESH_SEC":0,"MASTER_IPS":"","TYPE":"master"}],"ERRORARRAY":[]}'}
+    body: {string: !!python/unicode '{"result":"success","data":[{"type":"A","record":"lexicon-example.com"}]}'}
     headers:
       access-control-allow-origin: ['*']
       connection: [keep-alive]

--- a/tests/fixtures/cassettes/dreamhost/IntegrationTests/test_provider_when_calling_create_record_multiple_times_should_create_record_set.yaml
+++ b/tests/fixtures/cassettes/dreamhost/IntegrationTests/test_provider_when_calling_create_record_multiple_times_should_create_record_set.yaml
@@ -9,9 +9,9 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.18.4]
     method: GET
-    uri: https://api.dreamhost.com/?cmd=domain-list_domains&format=json
+    uri: https://api.dreamhost.com/?cmd=dns-list_records&format=json
   response:
-    body: {string: !!python/unicode '{"result":"success","data":[{"domain":"lexicon-example.com"}]}'}
+    body: {string: !!python/unicode '{"result":"success","data":[{"type":"A","record":"lexicon-example.com"}]}'}
     headers:
       access-control-allow-origin: ['*']
       connection: [keep-alive]

--- a/tests/fixtures/cassettes/dreamhost/IntegrationTests/test_provider_when_calling_create_record_with_duplicate_records_should_be_noop.yaml
+++ b/tests/fixtures/cassettes/dreamhost/IntegrationTests/test_provider_when_calling_create_record_with_duplicate_records_should_be_noop.yaml
@@ -9,9 +9,9 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.18.4]
     method: GET
-    uri: https://api.dreamhost.com/?cmd=domain-list_domains&format=json
+    uri: https://api.dreamhost.com/?cmd=dns-list_records&format=json
   response:
-    body: {string: !!python/unicode '{"result":"success","data":[{"domain":"lexicon-example.com"}]}'}
+    body: {string: !!python/unicode '{"result":"success","data":[{"type":"A","record":"lexicon-example.com"}]}'}
     headers:
       access-control-allow-origin: ['*']
       connection: [keep-alive]

--- a/tests/fixtures/cassettes/dreamhost/IntegrationTests/test_provider_when_calling_delete_record_by_filter_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/dreamhost/IntegrationTests/test_provider_when_calling_delete_record_by_filter_should_remove_record.yaml
@@ -9,9 +9,9 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.18.4]
     method: GET
-    uri: https://api.dreamhost.com/?cmd=domain-list_domains&format=json
+    uri: https://api.dreamhost.com/?cmd=dns-list_records&format=json
   response:
-    body: {string: !!python/unicode '{"result":"success","data":[{"domain":"lexicon-example.com"}]}'}
+    body: {string: !!python/unicode '{"result":"success","data":[{"type":"A","record":"lexicon-example.com"}]}'}
     headers:
       access-control-allow-origin: ['*']
       connection: [keep-alive]

--- a/tests/fixtures/cassettes/dreamhost/IntegrationTests/test_provider_when_calling_delete_record_by_filter_with_fqdn_name_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/dreamhost/IntegrationTests/test_provider_when_calling_delete_record_by_filter_with_fqdn_name_should_remove_record.yaml
@@ -9,9 +9,9 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.18.4]
     method: GET
-    uri: https://api.dreamhost.com/?cmd=domain-list_domains&format=json
+    uri: https://api.dreamhost.com/?cmd=dns-list_records&format=json
   response:
-    body: {string: !!python/unicode '{"result":"success","data":[{"domain":"lexicon-example.com"}]}'}
+    body: {string: !!python/unicode '{"result":"success","data":[{"type":"A","record":"lexicon-example.com"}]}'}
     headers:
       access-control-allow-origin: ['*']
       connection: [keep-alive]

--- a/tests/fixtures/cassettes/dreamhost/IntegrationTests/test_provider_when_calling_delete_record_by_filter_with_full_name_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/dreamhost/IntegrationTests/test_provider_when_calling_delete_record_by_filter_with_full_name_should_remove_record.yaml
@@ -9,9 +9,9 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.18.4]
     method: GET
-    uri: https://api.dreamhost.com/?cmd=domain-list_domains&format=json
+    uri: https://api.dreamhost.com/?cmd=dns-list_records&format=json
   response:
-    body: {string: !!python/unicode '{"result":"success","data":[{"domain":"lexicon-example.com"}]}'}
+    body: {string: !!python/unicode '{"result":"success","data":[{"type":"A","record":"lexicon-example.com"}]}'}
     headers:
       access-control-allow-origin: ['*']
       connection: [keep-alive]

--- a/tests/fixtures/cassettes/dreamhost/IntegrationTests/test_provider_when_calling_delete_record_by_identifier_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/dreamhost/IntegrationTests/test_provider_when_calling_delete_record_by_identifier_should_remove_record.yaml
@@ -9,9 +9,9 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.18.4]
     method: GET
-    uri: https://api.dreamhost.com/?cmd=domain-list_domains&format=json
+    uri: https://api.dreamhost.com/?cmd=dns-list_records&format=json
   response:
-    body: {string: !!python/unicode '{"result":"success","data":[{"domain":"lexicon-example.com"}]}'}
+    body: {string: !!python/unicode '{"result":"success","data":[{"type":"A","record":"lexicon-example.com"}]}'}
     headers:
       access-control-allow-origin: ['*']
       connection: [keep-alive]

--- a/tests/fixtures/cassettes/dreamhost/IntegrationTests/test_provider_when_calling_delete_record_with_record_set_by_content_should_leave_others_untouched.yaml
+++ b/tests/fixtures/cassettes/dreamhost/IntegrationTests/test_provider_when_calling_delete_record_with_record_set_by_content_should_leave_others_untouched.yaml
@@ -9,9 +9,9 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.18.4]
     method: GET
-    uri: https://api.dreamhost.com/?cmd=domain-list_domains&format=json
+    uri: https://api.dreamhost.com/?cmd=dns-list_records&format=json
   response:
-    body: {string: !!python/unicode '{"result":"success","data":[{"domain":"lexicon-example.com"}]}'}
+    body: {string: !!python/unicode '{"result":"success","data":[{"type":"A","record":"lexicon-example.com"}]}'}
     headers:
       access-control-allow-origin: ['*']
       connection: [keep-alive]

--- a/tests/fixtures/cassettes/dreamhost/IntegrationTests/test_provider_when_calling_delete_record_with_record_set_name_remove_all.yaml
+++ b/tests/fixtures/cassettes/dreamhost/IntegrationTests/test_provider_when_calling_delete_record_with_record_set_name_remove_all.yaml
@@ -9,9 +9,9 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.18.4]
     method: GET
-    uri: https://api.dreamhost.com/?cmd=domain-list_domains&format=json
+    uri: https://api.dreamhost.com/?cmd=dns-list_records&format=json
   response:
-    body: {string: !!python/unicode '{"result":"success","data":[{"domain":"lexicon-example.com"}]}'}
+    body: {string: !!python/unicode '{"result":"success","data":[{"type":"A","record":"lexicon-example.com"}]}'}
     headers:
       access-control-allow-origin: ['*']
       connection: [keep-alive]

--- a/tests/fixtures/cassettes/dreamhost/IntegrationTests/test_provider_when_calling_list_records_should_handle_record_sets.yaml
+++ b/tests/fixtures/cassettes/dreamhost/IntegrationTests/test_provider_when_calling_list_records_should_handle_record_sets.yaml
@@ -9,9 +9,9 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.18.4]
     method: GET
-    uri: https://api.dreamhost.com/?cmd=domain-list_domains&format=json
+    uri: https://api.dreamhost.com/?cmd=dns-list_records&format=json
   response:
-    body: {string: !!python/unicode '{"result":"success","data":[{"domain":"lexicon-example.com"}]}'}
+    body: {string: !!python/unicode '{"result":"success","data":[{"type":"A","record":"lexicon-example.com"}]}'}
     headers:
       access-control-allow-origin: ['*']
       connection: [keep-alive]

--- a/tests/fixtures/cassettes/dreamhost/IntegrationTests/test_provider_when_calling_list_records_with_fqdn_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/dreamhost/IntegrationTests/test_provider_when_calling_list_records_with_fqdn_name_filter_should_return_record.yaml
@@ -9,9 +9,9 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.18.4]
     method: GET
-    uri: https://api.dreamhost.com/?cmd=domain-list_domains&format=json
+    uri: https://api.dreamhost.com/?cmd=dns-list_records&format=json
   response:
-    body: {string: !!python/unicode '{"result":"success","data":[{"domain":"lexicon-example.com"}]}'}
+    body: {string: !!python/unicode '{"result":"success","data":[{"type":"A","record":"lexicon-example.com"}]}'}
     headers:
       access-control-allow-origin: ['*']
       connection: [keep-alive]

--- a/tests/fixtures/cassettes/dreamhost/IntegrationTests/test_provider_when_calling_list_records_with_full_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/dreamhost/IntegrationTests/test_provider_when_calling_list_records_with_full_name_filter_should_return_record.yaml
@@ -9,9 +9,9 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.18.4]
     method: GET
-    uri: https://api.dreamhost.com/?cmd=domain-list_domains&format=json
+    uri: https://api.dreamhost.com/?cmd=dns-list_records&format=json
   response:
-    body: {string: !!python/unicode '{"result":"success","data":[{"domain":"lexicon-example.com"}]}'}
+    body: {string: !!python/unicode '{"result":"success","data":[{"type":"A","record":"lexicon-example.com"}]}'}
     headers:
       access-control-allow-origin: ['*']
       connection: [keep-alive]

--- a/tests/fixtures/cassettes/dreamhost/IntegrationTests/test_provider_when_calling_list_records_with_invalid_filter_should_be_empty_list.yaml
+++ b/tests/fixtures/cassettes/dreamhost/IntegrationTests/test_provider_when_calling_list_records_with_invalid_filter_should_be_empty_list.yaml
@@ -9,9 +9,9 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.18.4]
     method: GET
-    uri: https://api.dreamhost.com/?cmd=domain-list_domains&format=json
+    uri: https://api.dreamhost.com/?cmd=dns-list_records&format=json
   response:
-    body: {string: !!python/unicode '{"result":"success","data":[{"domain":"lexicon-example.com"}]}'}
+    body: {string: !!python/unicode '{"result":"success","data":[{"type":"A","record":"lexicon-example.com"}]}'}
     headers:
       access-control-allow-origin: ['*']
       connection: [keep-alive]

--- a/tests/fixtures/cassettes/dreamhost/IntegrationTests/test_provider_when_calling_list_records_with_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/dreamhost/IntegrationTests/test_provider_when_calling_list_records_with_name_filter_should_return_record.yaml
@@ -9,9 +9,9 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.18.4]
     method: GET
-    uri: https://api.dreamhost.com/?cmd=domain-list_domains&format=json
+    uri: https://api.dreamhost.com/?cmd=dns-list_records&format=json
   response:
-    body: {string: !!python/unicode '{"result":"success","data":[{"domain":"lexicon-example.com"}]}'}
+    body: {string: !!python/unicode '{"result":"success","data":[{"type":"A","record":"lexicon-example.com"}]}'}
     headers:
       access-control-allow-origin: ['*']
       connection: [keep-alive]

--- a/tests/fixtures/cassettes/dreamhost/IntegrationTests/test_provider_when_calling_list_records_with_no_arguments_should_list_all.yaml
+++ b/tests/fixtures/cassettes/dreamhost/IntegrationTests/test_provider_when_calling_list_records_with_no_arguments_should_list_all.yaml
@@ -9,9 +9,9 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.18.4]
     method: GET
-    uri: https://api.dreamhost.com/?cmd=domain-list_domains&format=json
+    uri: https://api.dreamhost.com/?cmd=dns-list_records&format=json
   response:
-    body: {string: !!python/unicode '{"result":"success","data":[{"domain":"lexicon-example.com"}]}'}
+    body: {string: !!python/unicode '{"result":"success","data":[{"type":"A","record":"lexicon-example.com"}]}'}
     headers:
       access-control-allow-origin: ['*']
       connection: [keep-alive]

--- a/tests/fixtures/cassettes/dreamhost/IntegrationTests/test_provider_when_calling_update_record_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/dreamhost/IntegrationTests/test_provider_when_calling_update_record_should_modify_record.yaml
@@ -9,9 +9,9 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.18.4]
     method: GET
-    uri: https://api.dreamhost.com/?cmd=domain-list_domains&format=json
+    uri: https://api.dreamhost.com/?cmd=dns-list_records&format=json
   response:
-    body: {string: !!python/unicode '{"result":"success","data":[{"domain":"lexicon-example.com"}]}'}
+    body: {string: !!python/unicode '{"result":"success","data":[{"type":"A","record":"lexicon-example.com"}]}'}
     headers:
       access-control-allow-origin: ['*']
       connection: [keep-alive]

--- a/tests/fixtures/cassettes/dreamhost/IntegrationTests/test_provider_when_calling_update_record_should_modify_record_name_specified.yaml
+++ b/tests/fixtures/cassettes/dreamhost/IntegrationTests/test_provider_when_calling_update_record_should_modify_record_name_specified.yaml
@@ -9,9 +9,9 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.18.4]
     method: GET
-    uri: https://api.dreamhost.com/?cmd=domain-list_domains&format=json
+    uri: https://api.dreamhost.com/?cmd=dns-list_records&format=json
   response:
-    body: {string: !!python/unicode '{"result":"success","data":[{"domain":"lexicon-example.com"}]}'}
+    body: {string: !!python/unicode '{"result":"success","data":[{"type":"A","record":"lexicon-example.com"}]}'}
     headers:
       access-control-allow-origin: ['*']
       connection: [keep-alive]

--- a/tests/fixtures/cassettes/dreamhost/IntegrationTests/test_provider_when_calling_update_record_with_fqdn_name_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/dreamhost/IntegrationTests/test_provider_when_calling_update_record_with_fqdn_name_should_modify_record.yaml
@@ -9,9 +9,9 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.18.4]
     method: GET
-    uri: https://api.dreamhost.com/?cmd=domain-list_domains&format=json
+    uri: https://api.dreamhost.com/?cmd=dns-list_records&format=json
   response:
-    body: {string: !!python/unicode '{"result":"success","data":[{"domain":"lexicon-example.com"}]}'}
+    body: {string: !!python/unicode '{"result":"success","data":[{"type":"A","record":"lexicon-example.com"}]}'}
     headers:
       access-control-allow-origin: ['*']
       connection: [keep-alive]

--- a/tests/fixtures/cassettes/dreamhost/IntegrationTests/test_provider_when_calling_update_record_with_full_name_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/dreamhost/IntegrationTests/test_provider_when_calling_update_record_with_full_name_should_modify_record.yaml
@@ -9,9 +9,9 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.18.4]
     method: GET
-    uri: https://api.dreamhost.com/?cmd=domain-list_domains&format=json
+    uri: https://api.dreamhost.com/?cmd=dns-list_records&format=json
   response:
-    body: {string: !!python/unicode '{"result":"success","data":[{"domain":"lexicon-example.com"}]}'}
+    body: {string: !!python/unicode '{"result":"success","data":[{"type":"A","record":"lexicon-example.com"}]}'}
     headers:
       access-control-allow-origin: ['*']
       connection: [keep-alive]


### PR DESCRIPTION
The Dreamhost api command `domain-list_domains` will be retired on Nov 2nd 2021.

This diff converts the `_authenticate()` method to use [`dns-list_records`](https://help.dreamhost.com/hc/en-us/articles/217555707-DNS-API-commands) instead. 

Fixes #974

----

The obvious difference between  `domain-list_domains` and `dns-list_records` is that list_records will return any A, CNAME, MX, TXT (and so on) record in the Dreamhost account. Potentially a lot more information compared to the list of domains.

Using the test api token (scroll to ["Test Account"](https://help.dreamhost.com/hc/en-us/articles/217560167-Application-programming-interface-overview)) we can see the difference in response size:

Before:
```
$ curl -so /dev/null "https://api.dreamhost.com/?key=6SHU5P2HLDAYECUM&cmd=domain-list_domains&format=json"  -w '%{size_download}'
752
```
After:
```
$ curl -so /dev/null "https://api.dreamhost.com/?key=6SHU5P2HLDAYECUM&cmd=dns-list_records&format=json"  -w '%{size_download}'
15940
```
This is just an example account but illustrates the difference. Any account could have a large number of domain, and/or a large number of records per domain.

I added the condition that the found record should be of type "A" or "AAAA". It's trivial for someone to add any domain (like facebook.com) to their account and create that record though. Doing so puts `facebook.com` in both the responses for both `dns-list_records` and `domains-list_domains`. I can see that behavior today in my account.
This means that `_authenticate()` wasn't, and still doesn't, do a strong ownership check of the domain name. Instead is does verify that the api token works. We shouldn't need that ownership check though, because if nameservers point somewhere else nothing will read that dns record.

--- 

The notice about all the deprecated Dreamhost API's is [here](https://help.dreamhost.com/hc/en-us/articles/217560167-Application-programming-interface-overview), but it's likely to change after Nov 2nd. Copied here for reference:
> Upcoming EOL
>
> As of November 2, 2021, the following API commands will be removed and no longer function.
> 
> Account API commands
> Domain API commands
> Mail API commands
> MySQL API commands
> Rewards API commands
> User API commands
> The following three commands will continue to function normally.
> 
> Announcement List API commands
> API metacommands
> DNS API commands