### PR TITLE
Update of the netcup nameserver

### DIFF
--- a/lexicon/providers/netcup.py
+++ b/lexicon/providers/netcup.py
@@ -9,7 +9,7 @@ from lexicon.providers.base import Provider as BaseProvider
 
 LOGGER = logging.getLogger(__name__)
 
-NAMESERVER_DOMAINS = ["netcup.de"]
+NAMESERVER_DOMAINS = ["netcup.net"]
 
 
 def provider_parser(subparser):


### PR DESCRIPTION
Source: DNS lookup

second-dns.netcup.net.
third-dns.netcup.net.
root-dns.netcup.net.
