### PR TITLE
Ensure TTL is provided as an integer

### DIFF
--- a/lexicon/providers/godaddy.py
+++ b/lexicon/providers/godaddy.py
@@ -105,7 +105,7 @@ class Provider(BaseProvider):
         # Append a new entry corresponding to given parameters.
         data = {"type": rtype, "name": relative_name, "data": content}
         if ttl:
-            data["ttl"] = ttl
+            data["ttl"] = int(ttl)
 
         records.append(data)
 


### PR DESCRIPTION
Providing the `ttl` as an environment variable (LEXICON_TTL) causes the GoDaddy API to throw a 422 error since it expects an integer but receives a string. This one-line change ensures that the `ttl` if provided is always an integer