### PR TITLE
Updated valid record types for DreamHost integration

### DIFF
--- a/lexicon/providers/dreamhost.py
+++ b/lexicon/providers/dreamhost.py
@@ -107,9 +107,7 @@ class Provider(BaseProvider):
 
         for record in data:
             if record.get("record", "") == self.domain and record.get("type", "") in [
-                "A",
-                "AAAA",
-                "CNAME"
+                "A", "AAAA", "CNAME", "MX", "NS", "SOA", "TXT", "SRV"
             ]:
                 self.domain_id = self.domain
                 break

--- a/lexicon/providers/dreamhost.py
+++ b/lexicon/providers/dreamhost.py
@@ -109,6 +109,7 @@ class Provider(BaseProvider):
             if record.get("record", "") == self.domain and record.get("type", "") in [
                 "A",
                 "AAAA",
+                "CNAME"
             ]:
                 self.domain_id = self.domain
                 break


### PR DESCRIPTION
Currently, the DreamHost integration only recognizes `A` and `AAAA` records as valid for determining the validity of a domain. To be consistent with the other integrations in the repository, I updated the integration to check for the following record types: `A`, `AAAA`, `CNAME`, `MX`, `NS`, `SOA`, `TXT`,  and `SRV`