### PR TITLE
Clarify Yandex PDD mentions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -186,7 +186,7 @@ The current supported providers are:
 .. _vercel: https://vercel.com/docs/api#endpoints/dns
 .. _vultr: https://www.vultr.com/api/#tag/dns
 .. _webgo: https://www.webgo.de/
-.. _yandex: https://tech.yandex.com/domain/doc/reference/dns-add-docpage/
+.. _yandex: https://yandex.com/dev/domain/doc/reference/dns-add.html
 .. _zeit:
 .. _zilore: https://zilore.com/en/help/api
 .. _zonomi: http://zonomi.com/app/dns/dyndns.jsp

--- a/docs/providers/route53.rst
+++ b/docs/providers/route53.rst
@@ -5,6 +5,8 @@ route53
 
     * ``private_zone`` Indicates what kind of hosted zone to use. if true, use only private zones. if false, use only public zones
 
+    * ``zone_id`` The aws hostedzone id to use; e.g. 'a1b2zabcdefghi'
+
     * ``auth_username`` Alternative way to specify the access_key for authentication
 
     * ``auth_token`` Alternative way to specify the access_secret for authentication

--- a/docs/providers/yandex.rst
+++ b/docs/providers/yandex.rst
@@ -1,2 +1,2 @@
 yandex
-    * ``auth_token`` Specify pdd token (https://tech.yandex.com/domain/doc/concepts/access-docpage/)
+    * ``auth_token`` Specify pdd token (https://yandex.com/dev/domain/doc/concepts/access.html)

--- a/lexicon/providers/yandex.py
+++ b/lexicon/providers/yandex.py
@@ -1,4 +1,7 @@
-"""Module provider for Yandex"""
+"""Module provider for Yandex PDD
+
+API doc: https://yandex.com/dev/domain/doc/reference/dns-add.html
+"""
 import json
 import logging
 
@@ -17,15 +20,15 @@ NAMESERVER_DOMAINS = ["yandex.com"]
 
 
 def provider_parser(subparser):
-    """Generate parser provider for Yandex"""
+    """Generate parser provider for Yandex PDD"""
     subparser.add_argument(
         "--auth-token",
-        help="specify PDD token (https://tech.yandex.com/domain/doc/concepts/access-docpage/)",
+        help="specify PDD token (https://yandex.com/dev/domain/doc/concepts/access.html)",
     )
 
 
 class Provider(BaseProvider):
-    """Provider class for Yandex"""
+    """Provider class for Yandex PDD"""
 
     def __init__(self, config):
         super(Provider, self).__init__(config)

--- a/lexicon/tests/providers/test_yandex.py
+++ b/lexicon/tests/providers/test_yandex.py
@@ -1,4 +1,4 @@
-"""Integration tests for Yandes"""
+"""Integration tests for Yandex PDD"""
 from unittest import TestCase
 
 import pytest
@@ -10,7 +10,7 @@ from lexicon.tests.providers.integration_tests import IntegrationTestsV2
 # the tests which *each and every* implementation of the interface must
 # pass, by inheritance from define_tests.TheTests
 class YandexPDDProviderTests(TestCase, IntegrationTestsV2):
-    """TestCase for Yandex"""
+    """TestCase for Yandex PDD"""
 
     provider_name = "yandex"
     domain = "capsulecd.com"


### PR DESCRIPTION
Currently "yandex" provider is just "yandex" but in reality, it's Yandex PDD, and I want to introduce Yandex.Cloud DNS provider shortly. This PR adjusts mentions of yandex to clarify it is PDD flavour of it.