### PR TITLE
fix provider:easyname entity__name parsing

### DIFF
--- a/lexicon/providers/easyname.py
+++ b/lexicon/providers/easyname.py
@@ -257,7 +257,7 @@ class Provider(BaseProvider):
                 try:
                     rec = {}
                     columns = row.find_all("td")
-                    rec["name"] = (columns[0].string or "").strip()
+                    rec["name"] = (columns[0].contents[0].string or "").strip()
                     rec["type"] = (columns[1].contents[1].text or "").strip()
                     rec["content"] = (columns[2].contents[1].string or "").strip()
                     rec["priority"] = (columns[3].contents[1].string or "").strip()


### PR DESCRIPTION
current web interface presents entity__name as follows:

```html
<td class="entity__name" style="">
subdomain<span style="color: var(--color-grey-500);">.maindomain.toplevel</span>
</td>
```
this breaks parsing as string. this patch fixes the parsing.