### PR TITLE
fix azure provider for adding TXT records if there is already an existing record

### DIFF
--- a/lexicon/providers/azure.py
+++ b/lexicon/providers/azure.py
@@ -349,7 +349,7 @@ def _build_recordset_from_values(rtype, values):
     if rtype == "SOA":
         recordset = {"SOARecord": {"email": values[0]} if values else {}}
     if rtype == "TXT":
-        recordset = {"TXTRecords": [{"value": values}]}
+        recordset = {"TXTRecords": [{"value": [value]} for value in values]}
     if rtype == "SRV":
         recordset = {"SRVRecords": [{"target": value} for value in values]}
 


### PR DESCRIPTION
This pull-request fixes the azure provider for adding TXT records if there is already an existing record. Its a rather small change, but it took quite some effort to find the issue. The problem was also discussed in #433.

Without this fix the azure provider will not work for certificates containing a normal hostname and a wild-card, as the resulting TXT record will be mangled. The azure API will accept the wrong request, but creates one TXT record with both values instead of two TXT records as necessary for the letsencrypt protocol to finish. The reason for this behaviour is that the azure provider requires to read the first entry and add it again as part of the second record, and the transfered header is not correct.

Wrong example:

```
$ dig -t TXT _acme-challenge.sbc1.domain.com @NS1-06.AZURE-DNS.COM                              
; <<>> DiG 9.16.1-Ubuntu <<>> -t TXT _acme-challenge.sbc1.domain.com @NS1-06.AZURE-DNS.COM
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 62528
;; flags: qr aa rd; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 1
;; WARNING: recursion requested but not available

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 1232
;; QUESTION SECTION:
;_acme-challenge.sbc1.domain.com. IN    TXT

;; ANSWER SECTION:
_acme-challenge.sbc1.domain.com. 60 IN  TXT     "G6fsh6Y5IeHRvdydEzSjCw35pj5QLGMRcqulk4TP6H8" "id0QOAEuXJCMe4T1yPApg3R9eLlT5k7wWKdG0U7lIL8"

```
Correct example:

```
$ dig -t TXT _acme-challenge.sbc2.domain.com @NS1-06.AZURE-DNS.COM
; <<>> DiG 9.16.1-Ubuntu <<>> -t TXT _acme-challenge.sbc2.domain.com @NS1-06.AZURE-DNS.COM
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 32487
;; flags: qr aa rd; QUERY: 1, ANSWER: 2, AUTHORITY: 0, ADDITIONAL: 1
;; WARNING: recursion requested but not available

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 1232
;; QUESTION SECTION:
;_acme-challenge.sbc2.domain.com. IN    TXT

;; ANSWER SECTION:
_acme-challenge.sbc2.domain.com. 10 IN  TXT     "KS9MBScJLZ8E2PPP1S8FgFHq5ROhxgO2e8JtiDnqTDA"
_acme-challenge.sbc2.domain.com. 10 IN  TXT     "0yBpWUI8MJpAMwVYTsQiSKRU90moJMmyOsAQAU40cEY"

;; Query time: 16 msec
;; SERVER: 40.90.4.6#53(40.90.4.6)
;; WHEN: Fri Aug 05 14:43:27 UTC 2022
;; MSG SIZE  rcvd: 172
```

With the fix the certificate creation work. I tested it extensively against the live azure API for list, create and create operation for individual and combined TXT records. Other parts of the provider are not affected.

Additional some debugging information:

1. working header content for one TXT record:
`{'properties': {'TXTRecords': [{'value': ['id0QOAEuXJCMe4T1yPApg3R9eLlT5k7wWKdG0U7lIL8']}], 'TTL': 60}}`

2. non working header content for two TXT records:
`{'properties': {'TXTRecords': [{'value': 'G6fsh6Y5IeHRvdydEzSjCw35pj5QLGMRcqulk4TP6H8'}, {'value': 'id0QOAEuXJCMe4T1yPApg3R9eLlT5k7wWKdG0U7lIL8'}], 'TTL': 60}}`

3.  working header content for two TXT records:
`{'properties': {'TXTRecords': [{"value": ["Cgh3OzpIUCeQtNWqdfhsCxXep25R9e90TMKW4-ubkpg"]}, {"value": ["sBbObZwsqPE_aT8wPweN9sz2fW4YswB8HAEQLRBA-20"]}], 'TTL': 60}}`

Note the missing brackets around the value entries.