### PR TITLE
Configuration reference: general configuration file example typo.

### DIFF
--- a/docs/configuration_reference.rst
+++ b/docs/configuration_reference.rst
@@ -45,7 +45,7 @@ provider option is named ``auth_token``):
         .. code-block:: yaml
 
             # /path/to/config/lexicon.yml
-            clouflare:
+            cloudflare:
               auth_token: YOUR_TOKEN
 
         For a provider-specific configuration file, provider options need to be set at the root:


### PR DESCRIPTION
Correcting configuration example typo, which cost me way more time than I'd like to admit :grimacing: 