### PR TITLE
Configuration reference: provider options environment example missing binary

### DIFF
--- a/docs/configuration_reference.rst
+++ b/docs/configuration_reference.rst
@@ -23,7 +23,7 @@ provider option is named ``auth_token``):
 
   .. code-block:: bash
 
-        $ LEXICON_CLOUDFLARE_AUTH_TOKEN=YOUR_TOKEN cloudflare create domain.net TXT --name foo --content bar
+        $ LEXICON_CLOUDFLARE_AUTH_TOKEN=YOUR_TOKEN lexicon cloudflare create domain.net TXT --name foo --content bar
 
 * by **configuration file**: construct a configuration file containing the provider options, for instance:
 


### PR DESCRIPTION
Lexicon binary is missing in the "Passing provider options to Lexicon" environment variable example.

While we're at it, I couldn't get `--config-dir` to work in the trailing position as given in "provider options" -> "configuration file" example. Usage message for lexicon suggests that optional parameters should go first followed by the actual DNS manipulation command. Otherwise argument processing seems to break in my experience. However I have not looked through the code to confirm this beyond doubt. Should we move it forward like so?
`lexicon --config-dir /path/to/config cloudflare create domain.net TXT --name foo --content bar`
It might appear as a minor thing, but it did cost me additional headbashing in conjuction with the typo from https://github.com/AnalogJ/lexicon/pull/1431 since I had BOTH parameter placement in lexicon invocation AND yml-configuration wrong! :confused:
Hopefully this suggested change can save some time for other users.