### PR TITLE
Add support for Timeweb provider

### DIFF
--- a/docs/developer_guide.rst
+++ b/docs/developer_guide.rst
@@ -247,7 +247,7 @@ variable ``LEXICON_LIVE_TESTS`` set to ``true`` like below:
 
 .. code-block:: bash
 
-	LEXICON_LIVE_TESTS=true pytest lexicon/tests/providers/test_foo.py
+	LEXICON_LIVE_TESTS=true pytest tests/providers/test_foo.py
 
 .. note::
 

--- a/src/lexicon/_private/providers/cloudflare.py
+++ b/src/lexicon/_private/providers/cloudflare.py
@@ -31,7 +31,7 @@ class Provider(BaseProvider):
             3 - A scoped API token (permissions Zone:Zone(read) + Zone:DNS(edit) for one zone), with --auth-token and --zone-id flags.
 
             Finding zone_id value is explained in CloudFlare `Doc <https://developers.cloudflare.com/fundamentals/setup/find-account-and-zone-ids/>`_
-        """
+        """  # noqa: W293
         parser.add_argument(
             "--auth-username",
             help="specify email address for authentication (for Global API key only)",

--- a/src/lexicon/_private/providers/timeweb.py
+++ b/src/lexicon/_private/providers/timeweb.py
@@ -1,0 +1,192 @@
+"""Module provider for Timeweb"""
+import json
+import logging
+from argparse import ArgumentParser
+from typing import List
+import requests
+from lexicon.exceptions import AuthenticationError
+from lexicon.interfaces import Provider as BaseProvider
+
+
+LOGGER = logging.getLogger(__name__)
+
+# Timeweb API does not support TTL. All records get 600 by default.
+DEFAULT_TTL = 600
+DEFAULT_PAGE_SIZE = 100
+
+
+class Provider(BaseProvider):
+    """
+    Implements Timeweb DNS provider: https://timeweb.cloud.
+    See also API documentation: https://timeweb.cloud/api-docs#tag/Domeny
+    """
+
+    @staticmethod
+    def get_nameservers() -> List[str]:
+        return ["timeweb.cloud"]
+
+    @staticmethod
+    def configure_parser(parser: ArgumentParser) -> None:
+        parser.add_argument(
+            "--auth-token",
+            help="specify API token for authentication",
+        )
+
+    @staticmethod
+    def _check_ok(result) -> bool:
+        error_code = result.get("error_code")
+        if error_code:
+            status_code = result["status_code"]
+            message = result["message"]
+            LOGGER.error(f"Status code: {status_code}. {message}")
+            return False
+        else:
+            return True
+
+    def __init__(self, config):
+        super(Provider, self).__init__(config)
+        self.domain_id = None
+        self.api_endpoint = "https://api.timeweb.cloud/api/v1"
+        self.api_dns = f"/domains/{self.domain}"
+        self.api_dns_records = f"{self.api_dns}/dns-records"
+
+    def _request(self, action="GET", url="/", data=None, query_params=None):
+        if data is None:
+            data = {}
+        else:
+            LOGGER.debug(f"Preparing data: {data}")
+        if query_params is None:
+            query_params = {}
+        else:
+            LOGGER.debug(f"Preparing query params: {query_params}")
+        full_url = self.api_endpoint + url
+        LOGGER.debug(f"Sending {action} {full_url}")
+        response = requests.request(
+            action,
+            full_url,
+            params=query_params,
+            data=json.dumps(data),
+            headers={
+                "Authorization": f'Bearer {self._get_provider_option("auth_token")}',
+                "Content-Type": "application/json",
+            },
+        )
+        # if the request fails for any reason, throw an error.
+        response.raise_for_status()
+        r_json = response.json() if response.content else {}
+        LOGGER.debug(f"Result: {r_json}")
+        return r_json
+
+    def _get_subdomain(self, record_name):
+        if record_name.rstrip(".").endswith(self.domain):
+            record_name = self._relative_name(record_name)
+        return record_name
+
+    def authenticate(self):
+        result = self._get(self.api_dns)
+        if self._check_ok(result):
+            self.domain_id = result["domain"]["id"]
+        else:
+            raise AuthenticationError(f"Domain {self.domain} not found.")
+
+    def create_record(self, rtype, name, content):
+        data = {
+            "subdomain": self._get_subdomain(name),
+            "type": rtype,
+            "value": content,
+        }
+        try:
+            result = self._post(self.api_dns_records, data)
+            return self._check_ok(result)
+        except requests.exceptions.HTTPError as e:
+            status_code = e.response.status_code
+            if status_code == 409:
+                LOGGER.warning(f"Record {rtype} {name} returns {status_code} (already exists?)")
+                return True
+            raise e
+
+    def list_records(self, rtype=None, name=None, content=None):
+        records = []
+        processed_records = 0
+        while True:
+            query_params = {
+                "limit": DEFAULT_PAGE_SIZE,
+                "offset": processed_records
+            }
+            result = self._get(self.api_dns_records, query_params=query_params)
+            if not self._check_ok(result):
+                break
+            for record in result["dns_records"]:
+                r_rtype = record["type"]
+                r_name = record["data"].get("subdomain", self.domain)
+                r_content = record["data"]["value"]
+                processed_record = {
+                    "type": r_rtype,
+                    "name": self._full_name(name) if name else r_name,
+                    "ttl": DEFAULT_TTL,
+                    "content": r_content,
+                    "id": record["id"],
+                }
+                if (rtype is None or r_rtype == rtype) \
+                        and (name is None or r_name == self._get_subdomain(name)) \
+                        and (content is None or r_content == content):
+                    records.append(processed_record)
+                processed_records += 1
+
+            total_records = result["meta"]["total"]
+            if processed_records >= total_records:
+                break
+
+        LOGGER.debug(f"list_records: {records}")
+        LOGGER.debug(f"Number of records retrieved: {len(records)}")
+        return records
+
+    def update_record(self, identifier, rtype=None, name=None, content=None):
+        if identifier is None:
+            records = self.list_records(rtype, name)
+            if len(records) == 1:
+                record = records[0]
+                identifier = str(record["id"])
+            elif len(records) < 1:
+                raise Exception(
+                    "No records found matching type and name - won't update"
+                )
+            else:
+                raise Exception(
+                    "Multiple records found matching type and name - won't update"
+                )
+        else:
+            records = self.list_records()
+            record = next((r for r in records if str(r["id"]) == identifier), None)
+
+        data = {
+            "subdomain": self._get_subdomain(name) if name else record["name"],
+            "type": rtype if rtype else record["type"],
+            "value": content if content else record["content"]
+        }
+        result = self._patch(f"{self.api_dns_records}/{identifier}", data)
+
+        LOGGER.debug(f"update_record: {result}")
+        return self._check_ok(result)
+
+    def delete_record(self, identifier=None, rtype=None, name=None, content=None):
+        if name:
+            name = self._get_subdomain(name)
+        if not identifier:
+            records = self.list_records(rtype, name, content)
+            ids_to_delete = [r["id"] for r in records]
+        else:
+            ids_to_delete = [identifier]
+
+        if ids_to_delete:
+            overall_ok = True
+            for id_to_delete in ids_to_delete:
+                result = self._delete(f"{self.api_dns_records}/{id_to_delete}")
+                if self._check_ok(result):
+                    LOGGER.debug(f"Successfully deleted record {id_to_delete}")
+                else:
+                    overall_ok = False
+            return overall_ok
+        else:
+            LOGGER.warning("delete_record: no record found")
+            return False

--- a/tests/fixtures/cassettes/timeweb/IntegrationTests/test_provider_authenticate.yaml
+++ b/tests/fixtures/cassettes/timeweb/IntegrationTests/test_provider_authenticate.yaml
@@ -1,0 +1,50 @@
+interactions:
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com
+  response:
+    body:
+      string: '{"domain":{"domain_status":"paid","expiration":"2024-07-01","fqdn":"example.com","id":13140253,"is_premium":false,"is_technical":false,"days_left":0,"linked_ip":null,"paid_till":null,"person_id":852321,"premium_prolong_cost":null,"provider":"PDR","request_status":null,"subdomains":[{"fqdn":"subdomain.example.com","id":13170019,"linked_ip":null}],"tld_id":24,"is_whois_privacy_enabled":null},"response_id":"86932730-8179-45a2-a44e-742f905e25aa"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1117'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:32 GMT
+      Etag:
+      - W/"45d-7COldYnWtmT4iDOUwFsitWVJR7I"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/timeweb/IntegrationTests/test_provider_authenticate_with_unmanaged_domain_should_fail.yaml
+++ b/tests/fixtures/cassettes/timeweb/IntegrationTests/test_provider_authenticate_with_unmanaged_domain_should_fail.yaml
@@ -1,0 +1,50 @@
+interactions:
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://api.timeweb.cloud/api/v1/domains/thisisadomainidonotown.com
+  response:
+    body:
+      string: '{"status_code":404,"error_code":"not_found","message":"Not found","response_id":"07b9450d-f806-4023-828e-9fd9f314543d"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '119'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:33 GMT
+      Etag:
+      - W/"77-pbzDs7QM1PWBWl/fBmBdpxS7aXA"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 404
+      message: Not Found
+version: 1

--- a/tests/fixtures/cassettes/timeweb/IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_fqdn_name_and_content.yaml
+++ b/tests/fixtures/cassettes/timeweb/IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_fqdn_name_and_content.yaml
@@ -1,0 +1,98 @@
+interactions:
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com
+  response:
+    body:
+      string: '{"domain":{"domain_status":"paid","expiration":"2024-07-01","fqdn":"example.com","id":13140253,"is_premium":false,"is_technical":false,"days_left":0,"linked_ip":null,"paid_till":null,"person_id":852321,"premium_prolong_cost":null,"provider":"PDR","request_status":null,"subdomains":[{"fqdn":"subdomain.example.com","id":13170019,"linked_ip":null}],"tld_id":24,"is_whois_privacy_enabled":null},"response_id":"86932730-8179-45a2-a44e-742f905e25aa"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1117'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:33 GMT
+      Etag:
+      - W/"45d-z0iu8DRThTTQy423bii2zvfOOqg"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"subdomain": "_acme-challenge.fqdn", "type": "TXT", "value": "challengetoken"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '79'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com/dns-records
+  response:
+    body:
+      string: '{"dns_record":{"data":{"subdomain":"_acme-challenge.fqdn","value":"challengetoken"},"id":55806353,"type":"TXT"},"response_id":"8087997c-43c7-470a-99b6-79fd117e0d8c"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '165'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:33 GMT
+      Etag:
+      - W/"a5-PXp9rOp3bp6RRP1dgYx9pbR2mgA"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 201
+      message: Created
+version: 1

--- a/tests/fixtures/cassettes/timeweb/IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_full_name_and_content.yaml
+++ b/tests/fixtures/cassettes/timeweb/IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_full_name_and_content.yaml
@@ -1,0 +1,98 @@
+interactions:
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com
+  response:
+    body:
+      string: '{"domain":{"domain_status":"paid","expiration":"2024-07-01","fqdn":"example.com","id":13140253,"is_premium":false,"is_technical":false,"days_left":0,"linked_ip":null,"paid_till":null,"person_id":852321,"premium_prolong_cost":null,"provider":"PDR","request_status":null,"subdomains":[{"fqdn":"subdomain.example.com","id":13170019,"linked_ip":null}],"tld_id":24,"is_whois_privacy_enabled":null},"response_id":"86932730-8179-45a2-a44e-742f905e25aa"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1117'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:33 GMT
+      Etag:
+      - W/"45d-GOVvNXNrw39pmwuRIGTOJvkZDec"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"subdomain": "_acme-challenge.full", "type": "TXT", "value": "challengetoken"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '79'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com/dns-records
+  response:
+    body:
+      string: '{"dns_record":{"data":{"subdomain":"_acme-challenge.full","value":"challengetoken"},"id":55806355,"type":"TXT"},"response_id":"c5b6c898-09d3-496f-aa37-949b69b8ed4b"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '165'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:33 GMT
+      Etag:
+      - W/"a5-vLP0dOtPix1ltSTFcq8lC9BxfNo"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 201
+      message: Created
+version: 1

--- a/tests/fixtures/cassettes/timeweb/IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/timeweb/IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_valid_name_and_content.yaml
@@ -1,0 +1,98 @@
+interactions:
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com
+  response:
+    body:
+      string: '{"domain":{"domain_status":"paid","expiration":"2024-07-01","fqdn":"example.com","id":13140253,"is_premium":false,"is_technical":false,"days_left":0,"linked_ip":null,"paid_till":null,"person_id":852321,"premium_prolong_cost":null,"provider":"PDR","request_status":null,"subdomains":[{"fqdn":"subdomain.example.com","id":13170019,"linked_ip":null}],"tld_id":24,"is_whois_privacy_enabled":null},"response_id":"86932730-8179-45a2-a44e-742f905e25aa"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1117'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:34 GMT
+      Etag:
+      - W/"45d-jW7nVtreETCvyfQH5leBOwVdCS8"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"subdomain": "_acme-challenge.test", "type": "TXT", "value": "challengetoken"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '79'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com/dns-records
+  response:
+    body:
+      string: '{"dns_record":{"data":{"subdomain":"_acme-challenge.test","value":"challengetoken"},"id":55806357,"type":"TXT"},"response_id":"187e17fe-0c70-4eaf-8378-3fcbf7a2ca8c"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '165'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:34 GMT
+      Etag:
+      - W/"a5-Dc2QOy9i1azyZdNTo/Jn4P/wLD0"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 201
+      message: Created
+version: 1

--- a/tests/fixtures/cassettes/timeweb/IntegrationTests/test_provider_when_calling_create_record_multiple_times_should_create_record_set.yaml
+++ b/tests/fixtures/cassettes/timeweb/IntegrationTests/test_provider_when_calling_create_record_multiple_times_should_create_record_set.yaml
@@ -1,0 +1,148 @@
+interactions:
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com
+  response:
+    body:
+      string: '{"domain":{"domain_status":"paid","expiration":"2024-07-01","fqdn":"example.com","id":13140253,"is_premium":false,"is_technical":false,"days_left":0,"linked_ip":null,"paid_till":null,"person_id":852321,"premium_prolong_cost":null,"provider":"PDR","request_status":null,"subdomains":[{"fqdn":"subdomain.example.com","id":13170019,"linked_ip":null}],"tld_id":24,"is_whois_privacy_enabled":null},"response_id":"86932730-8179-45a2-a44e-742f905e25aa"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1117'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:34 GMT
+      Etag:
+      - W/"45d-wj07exR/V1Qb5p/PXqlFmSxlkSg"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"subdomain": "_acme-challenge.createrecordset", "type": "TXT", "value":
+      "challengetoken1"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '91'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com/dns-records
+  response:
+    body:
+      string: '{"dns_record":{"data":{"subdomain":"_acme-challenge.createrecordset","value":"challengetoken1"},"id":55806359,"type":"TXT"},"response_id":"7ffadf8c-d8f5-485e-9540-10e98b25b656"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '177'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:34 GMT
+      Etag:
+      - W/"b1-zQoGE30mVOUuyrGiW0mqg+ypkEU"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"subdomain": "_acme-challenge.createrecordset", "type": "TXT", "value":
+      "challengetoken2"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '91'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com/dns-records
+  response:
+    body:
+      string: '{"dns_record":{"data":{"subdomain":"_acme-challenge.createrecordset","value":"challengetoken2"},"id":55806361,"type":"TXT"},"response_id":"2b3ac2ce-6ead-4502-abfa-8d680ad57534"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '177'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:34 GMT
+      Etag:
+      - W/"b1-Le1OOCf2Gfo2tQKrvtn9Dsm/IA4"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 201
+      message: Created
+version: 1

--- a/tests/fixtures/cassettes/timeweb/IntegrationTests/test_provider_when_calling_create_record_with_duplicate_records_should_be_noop.yaml
+++ b/tests/fixtures/cassettes/timeweb/IntegrationTests/test_provider_when_calling_create_record_with_duplicate_records_should_be_noop.yaml
@@ -1,0 +1,195 @@
+interactions:
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com
+  response:
+    body:
+      string: '{"domain":{"domain_status":"paid","expiration":"2024-07-01","fqdn":"example.com","id":13140253,"is_premium":false,"is_technical":false,"days_left":0,"linked_ip":null,"paid_till":null,"person_id":852321,"premium_prolong_cost":null,"provider":"PDR","request_status":null,"subdomains":[{"fqdn":"subdomain.example.com","id":13170019,"linked_ip":null}],"tld_id":24,"is_whois_privacy_enabled":null},"response_id":"86932730-8179-45a2-a44e-742f905e25aa"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1117'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:35 GMT
+      Etag:
+      - W/"45d-aVX8TM433XY+gUuq2mZr/YrMhP4"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"subdomain": "_acme-challenge.noop", "type": "TXT", "value": "challengetoken"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '79'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com/dns-records
+  response:
+    body:
+      string: '{"dns_record":{"data":{"subdomain":"_acme-challenge.noop","value":"challengetoken"},"id":55806363,"type":"TXT"},"response_id":"af4d6f46-63aa-4f72-8f1c-a85d63091efb"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '165'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:35 GMT
+      Etag:
+      - W/"a5-aWItT+YQRDQqD4j2f60wMNOpcOk"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"subdomain": "_acme-challenge.noop", "type": "TXT", "value": "challengetoken"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '79'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com/dns-records
+  response:
+    body:
+      string: '{"status_code":409,"error_code":"dns_record_exists","message":"DNS
+        record already exists","response_id":"7a14c3f2-99b7-4957-9e51-40ad37657bfb"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '143'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:35 GMT
+      Etag:
+      - W/"8f-kB11IepXUKl9bqo7WMA2lUBN2/Q"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 409
+      message: Conflict
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com/dns-records?limit=100&offset=0
+  response:
+    body:
+      string: '{"meta":{"total":6},"dns_records":[{"data":{"subdomain":"_acme-challenge.noop","value":"challengetoken"},"id":55806363,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.createrecordset","value":"challengetoken2"},"id":55806361,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.createrecordset","value":"challengetoken1"},"id":55806359,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.test","value":"challengetoken"},"id":55806357,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.full","value":"challengetoken"},"id":55806355,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.fqdn","value":"challengetoken"},"id":55806353,"type":"TXT"}],"response_id":"7b695aab-e9f8-4349-845e-a088773d50af"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1772'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:35 GMT
+      Etag:
+      - W/"6ec-Zgh6tQD3xrZippUhD8/h9KqEDjc"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/timeweb/IntegrationTests/test_provider_when_calling_delete_record_by_filter_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/timeweb/IntegrationTests/test_provider_when_calling_delete_record_by_filter_should_remove_record.yaml
@@ -1,0 +1,236 @@
+interactions:
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com
+  response:
+    body:
+      string: '{"domain":{"domain_status":"paid","expiration":"2024-07-01","fqdn":"example.com","id":13140253,"is_premium":false,"is_technical":false,"days_left":0,"linked_ip":null,"paid_till":null,"person_id":852321,"premium_prolong_cost":null,"provider":"PDR","request_status":null,"subdomains":[{"fqdn":"subdomain.example.com","id":13170019,"linked_ip":null}],"tld_id":24,"is_whois_privacy_enabled":null},"response_id":"86932730-8179-45a2-a44e-742f905e25aa"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1117'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:35 GMT
+      Etag:
+      - W/"45d-7VHD0sd/JJSotZ4DjLGdN2OHZp8"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"subdomain": "delete.testfilt", "type": "TXT", "value": "challengetoken"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '74'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com/dns-records
+  response:
+    body:
+      string: '{"dns_record":{"data":{"subdomain":"delete.testfilt","value":"challengetoken"},"id":55806365,"type":"TXT"},"response_id":"781d5e18-e09d-4268-a863-65dc2988a814"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '160'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:35 GMT
+      Etag:
+      - W/"a0-9WRcWY2Gs5oMIasIwnJHYWW0Slc"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com/dns-records?limit=100&offset=0
+  response:
+    body:
+      string: '{"meta":{"total":7},"dns_records":[{"data":{"subdomain":"delete.testfilt","value":"challengetoken"},"id":55806365,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.noop","value":"challengetoken"},"id":55806363,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.createrecordset","value":"challengetoken2"},"id":55806361,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.createrecordset","value":"challengetoken1"},"id":55806359,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.test","value":"challengetoken"},"id":55806357,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.full","value":"challengetoken"},"id":55806355,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.fqdn","value":"challengetoken"},"id":55806353,"type":"TXT"}],"response_id":"cd12c435-8b15-406a-b91f-3d88202f1df2"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1865'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:35 GMT
+      Etag:
+      - W/"749-erZXxCQjg2VA1ms1kiGjTf8VJWo"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: DELETE
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com/dns-records/55806365
+  response:
+    body:
+      string: ''
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 03 Jan 2024 16:05:36 GMT
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com/dns-records?limit=100&offset=0
+  response:
+    body:
+      string: '{"meta":{"total":6},"dns_records":[{"data":{"subdomain":"_acme-challenge.noop","value":"challengetoken"},"id":55806363,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.createrecordset","value":"challengetoken2"},"id":55806361,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.createrecordset","value":"challengetoken1"},"id":55806359,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.test","value":"challengetoken"},"id":55806357,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.full","value":"challengetoken"},"id":55806355,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.fqdn","value":"challengetoken"},"id":55806353,"type":"TXT"}],"response_id":"7ecfc995-5cc6-4c42-8c83-77f680151999"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1772'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:36 GMT
+      Etag:
+      - W/"6ec-naxvgkcfSK8GciuZuN/0Pcn2MQE"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/timeweb/IntegrationTests/test_provider_when_calling_delete_record_by_filter_with_fqdn_name_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/timeweb/IntegrationTests/test_provider_when_calling_delete_record_by_filter_with_fqdn_name_should_remove_record.yaml
@@ -1,0 +1,236 @@
+interactions:
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com
+  response:
+    body:
+      string: '{"domain":{"domain_status":"paid","expiration":"2024-07-01","fqdn":"example.com","id":13140253,"is_premium":false,"is_technical":false,"days_left":0,"linked_ip":null,"paid_till":null,"person_id":852321,"premium_prolong_cost":null,"provider":"PDR","request_status":null,"subdomains":[{"fqdn":"subdomain.example.com","id":13170019,"linked_ip":null}],"tld_id":24,"is_whois_privacy_enabled":null},"response_id":"86932730-8179-45a2-a44e-742f905e25aa"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1117'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:36 GMT
+      Etag:
+      - W/"45d-fuOsDXviYETMltPaZrptuIFmMM8"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"subdomain": "delete.testfqdn", "type": "TXT", "value": "challengetoken"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '74'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com/dns-records
+  response:
+    body:
+      string: '{"dns_record":{"data":{"subdomain":"delete.testfqdn","value":"challengetoken"},"id":55806367,"type":"TXT"},"response_id":"262d05f2-233b-47e1-8143-f04b0b395ba1"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '160'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:41 GMT
+      Etag:
+      - W/"a0-aOm3lW0nnHIoIhLPGdx0yN8A5/0"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com/dns-records?limit=100&offset=0
+  response:
+    body:
+      string: '{"meta":{"total":7},"dns_records":[{"data":{"subdomain":"delete.testfqdn","value":"challengetoken"},"id":55806367,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.noop","value":"challengetoken"},"id":55806363,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.createrecordset","value":"challengetoken2"},"id":55806361,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.createrecordset","value":"challengetoken1"},"id":55806359,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.test","value":"challengetoken"},"id":55806357,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.full","value":"challengetoken"},"id":55806355,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.fqdn","value":"challengetoken"},"id":55806353,"type":"TXT"}],"response_id":"aa7f0448-4261-4d55-ad04-2c1710ecf4e5"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1865'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:41 GMT
+      Etag:
+      - W/"749-Y8xo55pkFQd6o49iXbLW6rJaeU8"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: DELETE
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com/dns-records/55806367
+  response:
+    body:
+      string: ''
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 03 Jan 2024 16:05:42 GMT
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com/dns-records?limit=100&offset=0
+  response:
+    body:
+      string: '{"meta":{"total":6},"dns_records":[{"data":{"subdomain":"_acme-challenge.noop","value":"challengetoken"},"id":55806363,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.createrecordset","value":"challengetoken2"},"id":55806361,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.createrecordset","value":"challengetoken1"},"id":55806359,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.test","value":"challengetoken"},"id":55806357,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.full","value":"challengetoken"},"id":55806355,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.fqdn","value":"challengetoken"},"id":55806353,"type":"TXT"}],"response_id":"eb88cdce-9f70-4b9e-ad77-1ba61e377d74"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1772'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:42 GMT
+      Etag:
+      - W/"6ec-VJOriJodoCCILmVbkiScZW1BwKQ"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/timeweb/IntegrationTests/test_provider_when_calling_delete_record_by_filter_with_full_name_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/timeweb/IntegrationTests/test_provider_when_calling_delete_record_by_filter_with_full_name_should_remove_record.yaml
@@ -1,0 +1,236 @@
+interactions:
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com
+  response:
+    body:
+      string: '{"domain":{"domain_status":"paid","expiration":"2024-07-01","fqdn":"example.com","id":13140253,"is_premium":false,"is_technical":false,"days_left":0,"linked_ip":null,"paid_till":null,"person_id":852321,"premium_prolong_cost":null,"provider":"PDR","request_status":null,"subdomains":[{"fqdn":"subdomain.example.com","id":13170019,"linked_ip":null}],"tld_id":24,"is_whois_privacy_enabled":null},"response_id":"86932730-8179-45a2-a44e-742f905e25aa"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1117'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:42 GMT
+      Etag:
+      - W/"45d-8zO52gGftPZgIgR6W2tO/ArHDVs"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"subdomain": "delete.testfull", "type": "TXT", "value": "challengetoken"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '74'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com/dns-records
+  response:
+    body:
+      string: '{"dns_record":{"data":{"subdomain":"delete.testfull","value":"challengetoken"},"id":55806369,"type":"TXT"},"response_id":"c18f107f-82e1-49a1-88bc-9b8e2cf00d5a"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '160'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:42 GMT
+      Etag:
+      - W/"a0-E93zjINI5FpH45Nmb+uU38k/byU"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com/dns-records?limit=100&offset=0
+  response:
+    body:
+      string: '{"meta":{"total":7},"dns_records":[{"data":{"subdomain":"delete.testfull","value":"challengetoken"},"id":55806369,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.noop","value":"challengetoken"},"id":55806363,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.createrecordset","value":"challengetoken2"},"id":55806361,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.createrecordset","value":"challengetoken1"},"id":55806359,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.test","value":"challengetoken"},"id":55806357,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.full","value":"challengetoken"},"id":55806355,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.fqdn","value":"challengetoken"},"id":55806353,"type":"TXT"}],"response_id":"f3a9a853-7fa3-4124-a962-09c37a337e99"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1865'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:42 GMT
+      Etag:
+      - W/"749-+cMeGxH0SXu0maG8yII+dnHh7EQ"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: DELETE
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com/dns-records/55806369
+  response:
+    body:
+      string: ''
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 03 Jan 2024 16:05:42 GMT
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com/dns-records?limit=100&offset=0
+  response:
+    body:
+      string: '{"meta":{"total":6},"dns_records":[{"data":{"subdomain":"_acme-challenge.noop","value":"challengetoken"},"id":55806363,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.createrecordset","value":"challengetoken2"},"id":55806361,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.createrecordset","value":"challengetoken1"},"id":55806359,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.test","value":"challengetoken"},"id":55806357,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.full","value":"challengetoken"},"id":55806355,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.fqdn","value":"challengetoken"},"id":55806353,"type":"TXT"}],"response_id":"59916b5e-affb-4ac8-9aab-2ad5ae5a5523"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1772'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:43 GMT
+      Etag:
+      - W/"6ec-WgJxEw8bitKgGrxnrt/ha26GfwE"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/timeweb/IntegrationTests/test_provider_when_calling_delete_record_by_identifier_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/timeweb/IntegrationTests/test_provider_when_calling_delete_record_by_identifier_should_remove_record.yaml
@@ -1,0 +1,236 @@
+interactions:
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com
+  response:
+    body:
+      string: '{"domain":{"domain_status":"paid","expiration":"2024-07-01","fqdn":"example.com","id":13140253,"is_premium":false,"is_technical":false,"days_left":0,"linked_ip":null,"paid_till":null,"person_id":852321,"premium_prolong_cost":null,"provider":"PDR","request_status":null,"subdomains":[{"fqdn":"subdomain.example.com","id":13170019,"linked_ip":null}],"tld_id":24,"is_whois_privacy_enabled":null},"response_id":"86932730-8179-45a2-a44e-742f905e25aa"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1117'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:43 GMT
+      Etag:
+      - W/"45d-zvejgWgnyRUOAsuMaLTNRBR2XpA"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"subdomain": "delete.testid", "type": "TXT", "value": "challengetoken"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '72'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com/dns-records
+  response:
+    body:
+      string: '{"dns_record":{"data":{"subdomain":"delete.testid","value":"challengetoken"},"id":55806371,"type":"TXT"},"response_id":"ec157006-eba6-412e-b692-21240d921a51"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '158'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:43 GMT
+      Etag:
+      - W/"9e-y4cBOkK79fH4ajqv4BhrS5M22cQ"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com/dns-records?limit=100&offset=0
+  response:
+    body:
+      string: '{"meta":{"total":7},"dns_records":[{"data":{"subdomain":"delete.testid","value":"challengetoken"},"id":55806371,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.noop","value":"challengetoken"},"id":55806363,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.createrecordset","value":"challengetoken2"},"id":55806361,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.createrecordset","value":"challengetoken1"},"id":55806359,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.test","value":"challengetoken"},"id":55806357,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.full","value":"challengetoken"},"id":55806355,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.fqdn","value":"challengetoken"},"id":55806353,"type":"TXT"}],"response_id":"f5cb5420-6909-492d-a0ea-eb2c4f20db18"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1863'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:43 GMT
+      Etag:
+      - W/"747-pdU3VKTutEhXMo3KmQZqy0TAJcE"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: DELETE
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com/dns-records/55806371
+  response:
+    body:
+      string: ''
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 03 Jan 2024 16:05:43 GMT
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com/dns-records?limit=100&offset=0
+  response:
+    body:
+      string: '{"meta":{"total":6},"dns_records":[{"data":{"subdomain":"_acme-challenge.noop","value":"challengetoken"},"id":55806363,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.createrecordset","value":"challengetoken2"},"id":55806361,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.createrecordset","value":"challengetoken1"},"id":55806359,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.test","value":"challengetoken"},"id":55806357,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.full","value":"challengetoken"},"id":55806355,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.fqdn","value":"challengetoken"},"id":55806353,"type":"TXT"}],"response_id":"9663c65e-2370-447e-8a59-428a3c6757a2"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1772'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:43 GMT
+      Etag:
+      - W/"6ec-OtTwNKrkJogViTlfNGZM/ZHBfys"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/timeweb/IntegrationTests/test_provider_when_calling_delete_record_with_record_set_by_content_should_leave_others_untouched.yaml
+++ b/tests/fixtures/cassettes/timeweb/IntegrationTests/test_provider_when_calling_delete_record_with_record_set_by_content_should_leave_others_untouched.yaml
@@ -1,0 +1,286 @@
+interactions:
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com
+  response:
+    body:
+      string: '{"domain":{"domain_status":"paid","expiration":"2024-07-01","fqdn":"example.com","id":13140253,"is_premium":false,"is_technical":false,"days_left":0,"linked_ip":null,"paid_till":null,"person_id":852321,"premium_prolong_cost":null,"provider":"PDR","request_status":null,"subdomains":[{"fqdn":"subdomain.example.com","id":13170019,"linked_ip":null}],"tld_id":24,"is_whois_privacy_enabled":null},"response_id":"86932730-8179-45a2-a44e-742f905e25aa"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1117'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:44 GMT
+      Etag:
+      - W/"45d-OP6WoeVltp6C2LmksAk+/+RpJX0"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"subdomain": "_acme-challenge.deleterecordinset", "type": "TXT", "value":
+      "challengetoken1"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '93'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com/dns-records
+  response:
+    body:
+      string: '{"dns_record":{"data":{"subdomain":"_acme-challenge.deleterecordinset","value":"challengetoken1"},"id":55806373,"type":"TXT"},"response_id":"ea6111ea-fc76-4036-b576-b38884ace795"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '179'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:44 GMT
+      Etag:
+      - W/"b3-cLvFRMCrlc6s9xTUnpNj6XJFvUM"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"subdomain": "_acme-challenge.deleterecordinset", "type": "TXT", "value":
+      "challengetoken2"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '93'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com/dns-records
+  response:
+    body:
+      string: '{"dns_record":{"data":{"subdomain":"_acme-challenge.deleterecordinset","value":"challengetoken2"},"id":55806375,"type":"TXT"},"response_id":"a299119f-1947-42a7-9ac3-02b8bf087a2c"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '179'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:44 GMT
+      Etag:
+      - W/"b3-tqzmjYACURcY3DaF6g+DgC7JRj4"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com/dns-records?limit=100&offset=0
+  response:
+    body:
+      string: '{"meta":{"total":8},"dns_records":[{"data":{"subdomain":"_acme-challenge.deleterecordinset","value":"challengetoken2"},"id":55806375,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.deleterecordinset","value":"challengetoken1"},"id":55806373,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.noop","value":"challengetoken"},"id":55806363,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.createrecordset","value":"challengetoken2"},"id":55806361,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.createrecordset","value":"challengetoken1"},"id":55806359,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.test","value":"challengetoken"},"id":55806357,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.full","value":"challengetoken"},"id":55806355,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.fqdn","value":"challengetoken"},"id":55806353,"type":"TXT"}],"response_id":"524cc6cf-a46a-4480-96a2-5e937a433f4a"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1996'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:44 GMT
+      Etag:
+      - W/"7cc-4nGIR0Jb1YyJF9MkbeDTaEEufmQ"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: DELETE
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com/dns-records/55806373
+  response:
+    body:
+      string: ''
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 03 Jan 2024 16:05:44 GMT
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com/dns-records?limit=100&offset=0
+  response:
+    body:
+      string: '{"meta":{"total":7},"dns_records":[{"data":{"subdomain":"_acme-challenge.deleterecordinset","value":"challengetoken2"},"id":55806375,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.noop","value":"challengetoken"},"id":55806363,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.createrecordset","value":"challengetoken2"},"id":55806361,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.createrecordset","value":"challengetoken1"},"id":55806359,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.test","value":"challengetoken"},"id":55806357,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.full","value":"challengetoken"},"id":55806355,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.fqdn","value":"challengetoken"},"id":55806353,"type":"TXT"}],"response_id":"0fce52ba-2474-40c9-b6be-7d62290cc187"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1884'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:45 GMT
+      Etag:
+      - W/"75c-LQV9Nh5QpxN2lhaDP/Ytr/4jfjg"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/timeweb/IntegrationTests/test_provider_when_calling_delete_record_with_record_set_name_remove_all.yaml
+++ b/tests/fixtures/cassettes/timeweb/IntegrationTests/test_provider_when_calling_delete_record_with_record_set_name_remove_all.yaml
@@ -1,0 +1,328 @@
+interactions:
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com
+  response:
+    body:
+      string: '{"domain":{"domain_status":"paid","expiration":"2024-07-01","fqdn":"example.com","id":13140253,"is_premium":false,"is_technical":false,"days_left":0,"linked_ip":null,"paid_till":null,"person_id":852321,"premium_prolong_cost":null,"provider":"PDR","request_status":null,"subdomains":[{"fqdn":"subdomain.example.com","id":13170019,"linked_ip":null}],"tld_id":24,"is_whois_privacy_enabled":null},"response_id":"86932730-8179-45a2-a44e-742f905e25aa"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1117'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:45 GMT
+      Etag:
+      - W/"45d-TIUkruA/qj7+cDobp6SXyPG1Je0"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"subdomain": "_acme-challenge.deleterecordset", "type": "TXT", "value":
+      "challengetoken1"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '91'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com/dns-records
+  response:
+    body:
+      string: '{"dns_record":{"data":{"subdomain":"_acme-challenge.deleterecordset","value":"challengetoken1"},"id":55806393,"type":"TXT"},"response_id":"485be6b2-3012-4f41-b8e3-32c8ccd6dcdc"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '177'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:45 GMT
+      Etag:
+      - W/"b1-Ct7fEFb3ipA5Tj80I5U5xMvCyWs"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"subdomain": "_acme-challenge.deleterecordset", "type": "TXT", "value":
+      "challengetoken2"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '91'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com/dns-records
+  response:
+    body:
+      string: '{"dns_record":{"data":{"subdomain":"_acme-challenge.deleterecordset","value":"challengetoken2"},"id":55806395,"type":"TXT"},"response_id":"fc8adaf0-3fa0-44e5-9fa8-50ba36451234"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '177'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:45 GMT
+      Etag:
+      - W/"b1-xRA/atS3oV7lh/62LDEjaqd46CI"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com/dns-records?limit=100&offset=0
+  response:
+    body:
+      string: '{"meta":{"total":9},"dns_records":[{"data":{"subdomain":"_acme-challenge.deleterecordset","value":"challengetoken2"},"id":55806395,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.deleterecordset","value":"challengetoken1"},"id":55806393,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.deleterecordinset","value":"challengetoken2"},"id":55806375,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.noop","value":"challengetoken"},"id":55806363,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.createrecordset","value":"challengetoken2"},"id":55806361,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.createrecordset","value":"challengetoken1"},"id":55806359,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.test","value":"challengetoken"},"id":55806357,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.full","value":"challengetoken"},"id":55806355,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.fqdn","value":"challengetoken"},"id":55806353,"type":"TXT"}],"response_id":"446b8e67-f83d-4266-b193-182dc5e73d89"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2104'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:45 GMT
+      Etag:
+      - W/"838-lRuEEky19azKvUBGExLgRbZ236Q"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: DELETE
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com/dns-records/55806395
+  response:
+    body:
+      string: ''
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 03 Jan 2024 16:05:45 GMT
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: DELETE
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com/dns-records/55806393
+  response:
+    body:
+      string: ''
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 03 Jan 2024 16:05:46 GMT
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com/dns-records?limit=100&offset=0
+  response:
+    body:
+      string: '{"meta":{"total":7},"dns_records":[{"data":{"subdomain":"_acme-challenge.deleterecordinset","value":"challengetoken2"},"id":55806375,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.noop","value":"challengetoken"},"id":55806363,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.createrecordset","value":"challengetoken2"},"id":55806361,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.createrecordset","value":"challengetoken1"},"id":55806359,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.test","value":"challengetoken"},"id":55806357,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.full","value":"challengetoken"},"id":55806355,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.fqdn","value":"challengetoken"},"id":55806353,"type":"TXT"}],"response_id":"e32e6e84-dae2-4833-98b1-6c42e2110a63"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1884'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:46 GMT
+      Etag:
+      - W/"75c-r0sOXcrKjeZpIBnPfqOhK8LqHtU"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/timeweb/IntegrationTests/test_provider_when_calling_list_records_should_handle_record_sets.yaml
+++ b/tests/fixtures/cassettes/timeweb/IntegrationTests/test_provider_when_calling_list_records_should_handle_record_sets.yaml
@@ -1,0 +1,196 @@
+interactions:
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com
+  response:
+    body:
+      string: '{"domain":{"domain_status":"paid","expiration":"2024-07-01","fqdn":"example.com","id":13140253,"is_premium":false,"is_technical":false,"days_left":0,"linked_ip":null,"paid_till":null,"person_id":852321,"premium_prolong_cost":null,"provider":"PDR","request_status":null,"subdomains":[{"fqdn":"subdomain.example.com","id":13170019,"linked_ip":null}],"tld_id":24,"is_whois_privacy_enabled":null},"response_id":"86932730-8179-45a2-a44e-742f905e25aa"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1117'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:46 GMT
+      Etag:
+      - W/"45d-r+CsDei30OHHpTg+aSc1jwHow+I"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"subdomain": "_acme-challenge.listrecordset", "type": "TXT", "value":
+      "challengetoken1"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '89'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com/dns-records
+  response:
+    body:
+      string: '{"dns_record":{"data":{"subdomain":"_acme-challenge.listrecordset","value":"challengetoken1"},"id":55806397,"type":"TXT"},"response_id":"c4f9ee2d-0465-4c46-bb72-0c0856280b14"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '175'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:46 GMT
+      Etag:
+      - W/"af-QMy2PFElh/hDaXjEUJ78zI35LHA"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"subdomain": "_acme-challenge.listrecordset", "type": "TXT", "value":
+      "challengetoken2"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '89'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com/dns-records
+  response:
+    body:
+      string: '{"dns_record":{"data":{"subdomain":"_acme-challenge.listrecordset","value":"challengetoken2"},"id":55806399,"type":"TXT"},"response_id":"7f065c28-8efb-4ba3-be8b-1da9a42c73fe"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '175'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:46 GMT
+      Etag:
+      - W/"af-gwhERaI6BoRfuyeScAfYJHpvKqE"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com/dns-records?limit=100&offset=0
+  response:
+    body:
+      string: '{"meta":{"total":9},"dns_records":[{"data":{"subdomain":"_acme-challenge.listrecordset","value":"challengetoken2"},"id":55806399,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.listrecordset","value":"challengetoken1"},"id":55806397,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.deleterecordinset","value":"challengetoken2"},"id":55806375,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.noop","value":"challengetoken"},"id":55806363,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.createrecordset","value":"challengetoken2"},"id":55806361,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.createrecordset","value":"challengetoken1"},"id":55806359,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.test","value":"challengetoken"},"id":55806357,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.full","value":"challengetoken"},"id":55806355,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.fqdn","value":"challengetoken"},"id":55806353,"type":"TXT"}],"response_id":"505a5f9d-a955-423c-93dd-aef8524406b3"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2100'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:46 GMT
+      Etag:
+      - W/"834-jn6mqDdQ+buZPyxbsNMLbF3IiPk"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/timeweb/IntegrationTests/test_provider_when_calling_list_records_with_fqdn_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/timeweb/IntegrationTests/test_provider_when_calling_list_records_with_fqdn_name_filter_should_return_record.yaml
@@ -1,0 +1,146 @@
+interactions:
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com
+  response:
+    body:
+      string: '{"domain":{"domain_status":"paid","expiration":"2024-07-01","fqdn":"example.com","id":13140253,"is_premium":false,"is_technical":false,"days_left":0,"linked_ip":null,"paid_till":null,"person_id":852321,"premium_prolong_cost":null,"provider":"PDR","request_status":null,"subdomains":[{"fqdn":"subdomain.example.com","id":13170019,"linked_ip":null}],"tld_id":24,"is_whois_privacy_enabled":null},"response_id":"86932730-8179-45a2-a44e-742f905e25aa"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1117'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:47 GMT
+      Etag:
+      - W/"45d-MrJC9WYbX+McZZII+cZEOf3t+AM"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"subdomain": "random.fqdntest", "type": "TXT", "value": "challengetoken"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '74'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com/dns-records
+  response:
+    body:
+      string: '{"dns_record":{"data":{"subdomain":"random.fqdntest","value":"challengetoken"},"id":55806401,"type":"TXT"},"response_id":"86e76efc-c2f1-4713-8cd2-8a26eb172ac0"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '160'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:47 GMT
+      Etag:
+      - W/"a0-oUykyOo2diCF8l2Gk40Ilgh8SpE"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com/dns-records?limit=100&offset=0
+  response:
+    body:
+      string: '{"meta":{"total":10},"dns_records":[{"data":{"subdomain":"random.fqdntest","value":"challengetoken"},"id":55806401,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.listrecordset","value":"challengetoken2"},"id":55806399,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.listrecordset","value":"challengetoken1"},"id":55806397,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.deleterecordinset","value":"challengetoken2"},"id":55806375,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.noop","value":"challengetoken"},"id":55806363,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.createrecordset","value":"challengetoken2"},"id":55806361,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.createrecordset","value":"challengetoken1"},"id":55806359,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.test","value":"challengetoken"},"id":55806357,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.full","value":"challengetoken"},"id":55806355,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.fqdn","value":"challengetoken"},"id":55806353,"type":"TXT"}],"response_id":"712241b2-11d7-4f9f-ad96-70a82d84c3da"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2193'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:47 GMT
+      Etag:
+      - W/"891-Eu2mZ9PE58ycZawaQ7S75yfCzbE"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/timeweb/IntegrationTests/test_provider_when_calling_list_records_with_full_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/timeweb/IntegrationTests/test_provider_when_calling_list_records_with_full_name_filter_should_return_record.yaml
@@ -1,0 +1,146 @@
+interactions:
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com
+  response:
+    body:
+      string: '{"domain":{"domain_status":"paid","expiration":"2024-07-01","fqdn":"example.com","id":13140253,"is_premium":false,"is_technical":false,"days_left":0,"linked_ip":null,"paid_till":null,"person_id":852321,"premium_prolong_cost":null,"provider":"PDR","request_status":null,"subdomains":[{"fqdn":"subdomain.example.com","id":13170019,"linked_ip":null}],"tld_id":24,"is_whois_privacy_enabled":null},"response_id":"86932730-8179-45a2-a44e-742f905e25aa"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1117'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:47 GMT
+      Etag:
+      - W/"45d-KI9th2J43sUMSoDtPIjw2fWCZi0"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"subdomain": "random.fulltest", "type": "TXT", "value": "challengetoken"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '74'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com/dns-records
+  response:
+    body:
+      string: '{"dns_record":{"data":{"subdomain":"random.fulltest","value":"challengetoken"},"id":55806403,"type":"TXT"},"response_id":"1320e0d2-10ed-4401-b518-7c2a29781bdb"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '160'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:47 GMT
+      Etag:
+      - W/"a0-mrW5wcoycpKEJe8/z2CImxw/9tQ"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com/dns-records?limit=100&offset=0
+  response:
+    body:
+      string: '{"meta":{"total":11},"dns_records":[{"data":{"subdomain":"random.fulltest","value":"challengetoken"},"id":55806403,"type":"TXT"},{"data":{"subdomain":"random.fqdntest","value":"challengetoken"},"id":55806401,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.listrecordset","value":"challengetoken2"},"id":55806399,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.listrecordset","value":"challengetoken1"},"id":55806397,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.deleterecordinset","value":"challengetoken2"},"id":55806375,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.noop","value":"challengetoken"},"id":55806363,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.createrecordset","value":"challengetoken2"},"id":55806361,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.createrecordset","value":"challengetoken1"},"id":55806359,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.test","value":"challengetoken"},"id":55806357,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.full","value":"challengetoken"},"id":55806355,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.fqdn","value":"challengetoken"},"id":55806353,"type":"TXT"}],"response_id":"4a5b6504-a628-4eb1-be31-26067f423298"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2286'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:48 GMT
+      Etag:
+      - W/"8ee-6jv2rvoFBuGuP4Gyp5VfWNUbvK8"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/timeweb/IntegrationTests/test_provider_when_calling_list_records_with_invalid_filter_should_be_empty_list.yaml
+++ b/tests/fixtures/cassettes/timeweb/IntegrationTests/test_provider_when_calling_list_records_with_invalid_filter_should_be_empty_list.yaml
@@ -1,0 +1,98 @@
+interactions:
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com
+  response:
+    body:
+      string: '{"domain":{"domain_status":"paid","expiration":"2024-07-01","fqdn":"example.com","id":13140253,"is_premium":false,"is_technical":false,"days_left":0,"linked_ip":null,"paid_till":null,"person_id":852321,"premium_prolong_cost":null,"provider":"PDR","request_status":null,"subdomains":[{"fqdn":"subdomain.example.com","id":13170019,"linked_ip":null}],"tld_id":24,"is_whois_privacy_enabled":null},"response_id":"86932730-8179-45a2-a44e-742f905e25aa"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1117'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:48 GMT
+      Etag:
+      - W/"45d-iEQqlJ8EB+6YCAyYiDvgrW5tyYk"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com/dns-records?limit=100&offset=0
+  response:
+    body:
+      string: '{"meta":{"total":11},"dns_records":[{"data":{"subdomain":"random.fulltest","value":"challengetoken"},"id":55806403,"type":"TXT"},{"data":{"subdomain":"random.fqdntest","value":"challengetoken"},"id":55806401,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.listrecordset","value":"challengetoken2"},"id":55806399,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.listrecordset","value":"challengetoken1"},"id":55806397,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.deleterecordinset","value":"challengetoken2"},"id":55806375,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.noop","value":"challengetoken"},"id":55806363,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.createrecordset","value":"challengetoken2"},"id":55806361,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.createrecordset","value":"challengetoken1"},"id":55806359,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.test","value":"challengetoken"},"id":55806357,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.full","value":"challengetoken"},"id":55806355,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.fqdn","value":"challengetoken"},"id":55806353,"type":"TXT"}],"response_id":"48e68d64-e056-43c8-9c7d-1d57d713fd55"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2286'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:48 GMT
+      Etag:
+      - W/"8ee-DGVSzcNjNi8rKCtvTdgExGmHslA"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/timeweb/IntegrationTests/test_provider_when_calling_list_records_with_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/timeweb/IntegrationTests/test_provider_when_calling_list_records_with_name_filter_should_return_record.yaml
@@ -1,0 +1,146 @@
+interactions:
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com
+  response:
+    body:
+      string: '{"domain":{"domain_status":"paid","expiration":"2024-07-01","fqdn":"example.com","id":13140253,"is_premium":false,"is_technical":false,"days_left":0,"linked_ip":null,"paid_till":null,"person_id":852321,"premium_prolong_cost":null,"provider":"PDR","request_status":null,"subdomains":[{"fqdn":"subdomain.example.com","id":13170019,"linked_ip":null}],"tld_id":24,"is_whois_privacy_enabled":null},"response_id":"86932730-8179-45a2-a44e-742f905e25aa"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1117'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:48 GMT
+      Etag:
+      - W/"45d-rb09UIatkW0a5bAkwMd0vrwH//k"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"subdomain": "random.test", "type": "TXT", "value": "challengetoken"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '70'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com/dns-records
+  response:
+    body:
+      string: '{"dns_record":{"data":{"subdomain":"random.test","value":"challengetoken"},"id":55806405,"type":"TXT"},"response_id":"c856f586-de1c-4cd5-8e47-fc3e8e831567"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '156'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:48 GMT
+      Etag:
+      - W/"9c-Jp/5ljhsk9WHytfg1pIRQBZkbog"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com/dns-records?limit=100&offset=0
+  response:
+    body:
+      string: '{"meta":{"total":12},"dns_records":[{"data":{"subdomain":"random.test","value":"challengetoken"},"id":55806405,"type":"TXT"},{"data":{"subdomain":"random.fulltest","value":"challengetoken"},"id":55806403,"type":"TXT"},{"data":{"subdomain":"random.fqdntest","value":"challengetoken"},"id":55806401,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.listrecordset","value":"challengetoken2"},"id":55806399,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.listrecordset","value":"challengetoken1"},"id":55806397,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.deleterecordinset","value":"challengetoken2"},"id":55806375,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.noop","value":"challengetoken"},"id":55806363,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.createrecordset","value":"challengetoken2"},"id":55806361,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.createrecordset","value":"challengetoken1"},"id":55806359,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.test","value":"challengetoken"},"id":55806357,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.full","value":"challengetoken"},"id":55806355,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.fqdn","value":"challengetoken"},"id":55806353,"type":"TXT"}],"response_id":"c4c4e985-7ce3-429b-82f2-c6fd3519875a"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2375'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:49 GMT
+      Etag:
+      - W/"947-HYayd0fM2I1r8AEwZ5O7mR/Aq3Q"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/timeweb/IntegrationTests/test_provider_when_calling_list_records_with_no_arguments_should_list_all.yaml
+++ b/tests/fixtures/cassettes/timeweb/IntegrationTests/test_provider_when_calling_list_records_with_no_arguments_should_list_all.yaml
@@ -1,0 +1,98 @@
+interactions:
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com
+  response:
+    body:
+      string: '{"domain":{"domain_status":"paid","expiration":"2024-07-01","fqdn":"example.com","id":13140253,"is_premium":false,"is_technical":false,"days_left":0,"linked_ip":null,"paid_till":null,"person_id":852321,"premium_prolong_cost":null,"provider":"PDR","request_status":null,"subdomains":[{"fqdn":"subdomain.example.com","id":13170019,"linked_ip":null}],"tld_id":24,"is_whois_privacy_enabled":null},"response_id":"86932730-8179-45a2-a44e-742f905e25aa"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1117'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:49 GMT
+      Etag:
+      - W/"45d-KmN6IZP355A5XAUjH+pCRFHUnxM"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com/dns-records?limit=100&offset=0
+  response:
+    body:
+      string: '{"meta":{"total":12},"dns_records":[{"data":{"subdomain":"random.test","value":"challengetoken"},"id":55806405,"type":"TXT"},{"data":{"subdomain":"random.fulltest","value":"challengetoken"},"id":55806403,"type":"TXT"},{"data":{"subdomain":"random.fqdntest","value":"challengetoken"},"id":55806401,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.listrecordset","value":"challengetoken2"},"id":55806399,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.listrecordset","value":"challengetoken1"},"id":55806397,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.deleterecordinset","value":"challengetoken2"},"id":55806375,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.noop","value":"challengetoken"},"id":55806363,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.createrecordset","value":"challengetoken2"},"id":55806361,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.createrecordset","value":"challengetoken1"},"id":55806359,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.test","value":"challengetoken"},"id":55806357,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.full","value":"challengetoken"},"id":55806355,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.fqdn","value":"challengetoken"},"id":55806353,"type":"TXT"}],"response_id":"521777cc-4ac6-4e26-b949-927e6f09e259"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2375'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:49 GMT
+      Etag:
+      - W/"947-7OxbuUMdsXY78aytiN9WGASu2hs"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/timeweb/IntegrationTests/test_provider_when_calling_update_record_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/timeweb/IntegrationTests/test_provider_when_calling_update_record_should_modify_record.yaml
@@ -1,0 +1,242 @@
+interactions:
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com
+  response:
+    body:
+      string: '{"domain":{"domain_status":"paid","expiration":"2024-07-01","fqdn":"example.com","id":13140253,"is_premium":false,"is_technical":false,"days_left":0,"linked_ip":null,"paid_till":null,"person_id":852321,"premium_prolong_cost":null,"provider":"PDR","request_status":null,"subdomains":[{"fqdn":"subdomain.example.com","id":13170019,"linked_ip":null}],"tld_id":24,"is_whois_privacy_enabled":null},"response_id":"86932730-8179-45a2-a44e-742f905e25aa"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1117'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:49 GMT
+      Etag:
+      - W/"45d-gL2Nuhw4He7PgUmqr6zojHB279E"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"subdomain": "orig.test", "type": "TXT", "value": "challengetoken"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '68'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com/dns-records
+  response:
+    body:
+      string: '{"dns_record":{"data":{"subdomain":"orig.test","value":"challengetoken"},"id":55806407,"type":"TXT"},"response_id":"10218abd-066b-4501-ab03-9803506d2b1b"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '154'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:49 GMT
+      Etag:
+      - W/"9a-sSnAhW5BWWdQraMrAYaVA7JYAPA"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com/dns-records?limit=100&offset=0
+  response:
+    body:
+      string: '{"meta":{"total":13},"dns_records":[{"data":{"subdomain":"orig.test","value":"challengetoken"},"id":55806407,"type":"TXT"},{"data":{"subdomain":"random.test","value":"challengetoken"},"id":55806405,"type":"TXT"},{"data":{"subdomain":"random.fulltest","value":"challengetoken"},"id":55806403,"type":"TXT"},{"data":{"subdomain":"random.fqdntest","value":"challengetoken"},"id":55806401,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.listrecordset","value":"challengetoken2"},"id":55806399,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.listrecordset","value":"challengetoken1"},"id":55806397,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.deleterecordinset","value":"challengetoken2"},"id":55806375,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.noop","value":"challengetoken"},"id":55806363,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.createrecordset","value":"challengetoken2"},"id":55806361,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.createrecordset","value":"challengetoken1"},"id":55806359,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.test","value":"challengetoken"},"id":55806357,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.full","value":"challengetoken"},"id":55806355,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.fqdn","value":"challengetoken"},"id":55806353,"type":"TXT"}],"response_id":"accf4805-e097-4276-99ec-5a62aabec065"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2462'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:50 GMT
+      Etag:
+      - W/"99e-Qs8CbAz3eTEDhSMMHkLFIMF5hpE"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com/dns-records?limit=100&offset=0
+  response:
+    body:
+      string: '{"meta":{"total":13},"dns_records":[{"data":{"subdomain":"orig.test","value":"challengetoken"},"id":55806407,"type":"TXT"},{"data":{"subdomain":"random.test","value":"challengetoken"},"id":55806405,"type":"TXT"},{"data":{"subdomain":"random.fulltest","value":"challengetoken"},"id":55806403,"type":"TXT"},{"data":{"subdomain":"random.fqdntest","value":"challengetoken"},"id":55806401,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.listrecordset","value":"challengetoken2"},"id":55806399,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.listrecordset","value":"challengetoken1"},"id":55806397,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.deleterecordinset","value":"challengetoken2"},"id":55806375,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.noop","value":"challengetoken"},"id":55806363,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.createrecordset","value":"challengetoken2"},"id":55806361,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.createrecordset","value":"challengetoken1"},"id":55806359,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.test","value":"challengetoken"},"id":55806357,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.full","value":"challengetoken"},"id":55806355,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.fqdn","value":"challengetoken"},"id":55806353,"type":"TXT"}],"response_id":"34bb49a0-acff-4a58-9ef5-7870e12bcb7b"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2462'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:50 GMT
+      Etag:
+      - W/"99e-9qjDaHygzPntuINDWn/BVucUAGs"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"subdomain": "updated.test", "type": "TXT", "value": "challengetoken"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: PATCH
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com/dns-records/55806407
+  response:
+    body:
+      string: '{"dns_record":{"data":{"subdomain":"updated.test","value":"challengetoken"},"id":55806407,"type":"TXT"},"response_id":"b3ccde60-4227-4f6e-a68f-fdf049c31c49"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '157'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:50 GMT
+      Etag:
+      - W/"9d-k0wRqREHAKWfAwtrTqwnFjGAK8s"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/timeweb/IntegrationTests/test_provider_when_calling_update_record_should_modify_record_name_specified.yaml
+++ b/tests/fixtures/cassettes/timeweb/IntegrationTests/test_provider_when_calling_update_record_should_modify_record_name_specified.yaml
@@ -1,0 +1,194 @@
+interactions:
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com
+  response:
+    body:
+      string: '{"domain":{"domain_status":"paid","expiration":"2024-07-01","fqdn":"example.com","id":13140253,"is_premium":false,"is_technical":false,"days_left":0,"linked_ip":null,"paid_till":null,"person_id":852321,"premium_prolong_cost":null,"provider":"PDR","request_status":null,"subdomains":[{"fqdn":"subdomain.example.com","id":13170019,"linked_ip":null}],"tld_id":24,"is_whois_privacy_enabled":null},"response_id":"86932730-8179-45a2-a44e-742f905e25aa"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1117'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:50 GMT
+      Etag:
+      - W/"45d-P6KU5XKKfPTQ4or7M6kvEDeBCKY"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"subdomain": "orig.nameonly.test", "type": "TXT", "value": "challengetoken"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '77'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com/dns-records
+  response:
+    body:
+      string: '{"dns_record":{"data":{"subdomain":"orig.nameonly.test","value":"challengetoken"},"id":55806409,"type":"TXT"},"response_id":"35f0c105-702f-4d6d-ac20-2658b838958f"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '163'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:50 GMT
+      Etag:
+      - W/"a3-RBpyj//njaF5XwZQ0jmuTOq7fTc"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com/dns-records?limit=100&offset=0
+  response:
+    body:
+      string: '{"meta":{"total":14},"dns_records":[{"data":{"subdomain":"orig.nameonly.test","value":"challengetoken"},"id":55806409,"type":"TXT"},{"data":{"subdomain":"updated.test","value":"challengetoken"},"id":55806407,"type":"TXT"},{"data":{"subdomain":"random.test","value":"challengetoken"},"id":55806405,"type":"TXT"},{"data":{"subdomain":"random.fulltest","value":"challengetoken"},"id":55806403,"type":"TXT"},{"data":{"subdomain":"random.fqdntest","value":"challengetoken"},"id":55806401,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.listrecordset","value":"challengetoken2"},"id":55806399,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.listrecordset","value":"challengetoken1"},"id":55806397,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.deleterecordinset","value":"challengetoken2"},"id":55806375,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.noop","value":"challengetoken"},"id":55806363,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.createrecordset","value":"challengetoken2"},"id":55806361,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.createrecordset","value":"challengetoken1"},"id":55806359,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.test","value":"challengetoken"},"id":55806357,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.full","value":"challengetoken"},"id":55806355,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.fqdn","value":"challengetoken"},"id":55806353,"type":"TXT"}],"response_id":"c003dd66-9f2f-4a20-9142-a22ee83c66d9"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2561'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:51 GMT
+      Etag:
+      - W/"a01-HHf/YPggOuk/A1jNhhl1wbQUrWQ"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"subdomain": "orig.nameonly.test", "type": "TXT", "value": "updated"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '70'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: PATCH
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com/dns-records/55806409
+  response:
+    body:
+      string: '{"dns_record":{"data":{"subdomain":"orig.nameonly.test","value":"updated"},"id":55806409,"type":"TXT"},"response_id":"ebe1e975-100d-4897-8f24-7e9a415b2f9e"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '156'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:51 GMT
+      Etag:
+      - W/"9c-fZsXchQ3bh3D5/pblXKPzMn3re0"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/timeweb/IntegrationTests/test_provider_when_calling_update_record_with_fqdn_name_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/timeweb/IntegrationTests/test_provider_when_calling_update_record_with_fqdn_name_should_modify_record.yaml
@@ -1,0 +1,242 @@
+interactions:
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com
+  response:
+    body:
+      string: '{"domain":{"domain_status":"paid","expiration":"2024-07-01","fqdn":"example.com","id":13140253,"is_premium":false,"is_technical":false,"days_left":0,"linked_ip":null,"paid_till":null,"person_id":852321,"premium_prolong_cost":null,"provider":"PDR","request_status":null,"subdomains":[{"fqdn":"subdomain.example.com","id":13170019,"linked_ip":null}],"tld_id":24,"is_whois_privacy_enabled":null},"response_id":"86932730-8179-45a2-a44e-742f905e25aa"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1117'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:51 GMT
+      Etag:
+      - W/"45d-COKS31VFkzCCrOflrB2nKCGEbbo"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"subdomain": "orig.testfqdn", "type": "TXT", "value": "challengetoken"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '72'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com/dns-records
+  response:
+    body:
+      string: '{"dns_record":{"data":{"subdomain":"orig.testfqdn","value":"challengetoken"},"id":55806411,"type":"TXT"},"response_id":"3a700262-fc35-46b1-95c3-6b0ec07ef5e9"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '158'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:51 GMT
+      Etag:
+      - W/"9e-9Ct8SLIDk8lI7T9H3o1UKJdvBTk"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com/dns-records?limit=100&offset=0
+  response:
+    body:
+      string: '{"meta":{"total":15},"dns_records":[{"data":{"subdomain":"orig.testfqdn","value":"challengetoken"},"id":55806411,"type":"TXT"},{"data":{"subdomain":"orig.nameonly.test","value":"updated"},"id":55806409,"type":"TXT"},{"data":{"subdomain":"updated.test","value":"challengetoken"},"id":55806407,"type":"TXT"},{"data":{"subdomain":"random.test","value":"challengetoken"},"id":55806405,"type":"TXT"},{"data":{"subdomain":"random.fulltest","value":"challengetoken"},"id":55806403,"type":"TXT"},{"data":{"subdomain":"random.fqdntest","value":"challengetoken"},"id":55806401,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.listrecordset","value":"challengetoken2"},"id":55806399,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.listrecordset","value":"challengetoken1"},"id":55806397,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.deleterecordinset","value":"challengetoken2"},"id":55806375,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.noop","value":"challengetoken"},"id":55806363,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.createrecordset","value":"challengetoken2"},"id":55806361,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.createrecordset","value":"challengetoken1"},"id":55806359,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.test","value":"challengetoken"},"id":55806357,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.full","value":"challengetoken"},"id":55806355,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.fqdn","value":"challengetoken"},"id":55806353,"type":"TXT"}],"response_id":"8bba35a0-3b54-48bb-bc27-5e2774923073"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2645'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:51 GMT
+      Etag:
+      - W/"a55-ZvDdNaByswyAurtiqLeNCewYxws"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com/dns-records?limit=100&offset=0
+  response:
+    body:
+      string: '{"meta":{"total":15},"dns_records":[{"data":{"subdomain":"orig.testfqdn","value":"challengetoken"},"id":55806411,"type":"TXT"},{"data":{"subdomain":"orig.nameonly.test","value":"updated"},"id":55806409,"type":"TXT"},{"data":{"subdomain":"updated.test","value":"challengetoken"},"id":55806407,"type":"TXT"},{"data":{"subdomain":"random.test","value":"challengetoken"},"id":55806405,"type":"TXT"},{"data":{"subdomain":"random.fulltest","value":"challengetoken"},"id":55806403,"type":"TXT"},{"data":{"subdomain":"random.fqdntest","value":"challengetoken"},"id":55806401,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.listrecordset","value":"challengetoken2"},"id":55806399,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.listrecordset","value":"challengetoken1"},"id":55806397,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.deleterecordinset","value":"challengetoken2"},"id":55806375,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.noop","value":"challengetoken"},"id":55806363,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.createrecordset","value":"challengetoken2"},"id":55806361,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.createrecordset","value":"challengetoken1"},"id":55806359,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.test","value":"challengetoken"},"id":55806357,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.full","value":"challengetoken"},"id":55806355,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.fqdn","value":"challengetoken"},"id":55806353,"type":"TXT"}],"response_id":"e6faeccb-80da-4c25-a0b7-92790d9e19a8"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2645'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:51 GMT
+      Etag:
+      - W/"a55-gWiBJI+zS5Wl4rGVd5ZVhb9V6cs"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"subdomain": "updated.testfqdn", "type": "TXT", "value": "challengetoken"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '75'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: PATCH
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com/dns-records/55806411
+  response:
+    body:
+      string: '{"dns_record":{"data":{"subdomain":"updated.testfqdn","value":"challengetoken"},"id":55806411,"type":"TXT"},"response_id":"5085598d-b0a9-4eeb-b914-89f51e0e3746"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '161'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:52 GMT
+      Etag:
+      - W/"a1-Tbbq3PTMniARoRiCrVKaxGYxBxk"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/timeweb/IntegrationTests/test_provider_when_calling_update_record_with_full_name_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/timeweb/IntegrationTests/test_provider_when_calling_update_record_with_full_name_should_modify_record.yaml
@@ -1,0 +1,242 @@
+interactions:
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com
+  response:
+    body:
+      string: '{"domain":{"domain_status":"paid","expiration":"2024-07-01","fqdn":"example.com","id":13140253,"is_premium":false,"is_technical":false,"days_left":0,"linked_ip":null,"paid_till":null,"person_id":852321,"premium_prolong_cost":null,"provider":"PDR","request_status":null,"subdomains":[{"fqdn":"subdomain.example.com","id":13170019,"linked_ip":null}],"tld_id":24,"is_whois_privacy_enabled":null},"response_id":"86932730-8179-45a2-a44e-742f905e25aa"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1117'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:52 GMT
+      Etag:
+      - W/"45d-vcYggTU3vphu34bnP+2VRkvRmL4"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"subdomain": "orig.testfull", "type": "TXT", "value": "challengetoken"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '72'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com/dns-records
+  response:
+    body:
+      string: '{"dns_record":{"data":{"subdomain":"orig.testfull","value":"challengetoken"},"id":55806413,"type":"TXT"},"response_id":"9ee23bba-2468-4758-873e-5e3648deb087"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '158'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:52 GMT
+      Etag:
+      - W/"9e-N6gouIdN7BAuOUje7sdpejGOI5c"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com/dns-records?limit=100&offset=0
+  response:
+    body:
+      string: '{"meta":{"total":16},"dns_records":[{"data":{"subdomain":"orig.testfull","value":"challengetoken"},"id":55806413,"type":"TXT"},{"data":{"subdomain":"updated.testfqdn","value":"challengetoken"},"id":55806411,"type":"TXT"},{"data":{"subdomain":"orig.nameonly.test","value":"updated"},"id":55806409,"type":"TXT"},{"data":{"subdomain":"updated.test","value":"challengetoken"},"id":55806407,"type":"TXT"},{"data":{"subdomain":"random.test","value":"challengetoken"},"id":55806405,"type":"TXT"},{"data":{"subdomain":"random.fulltest","value":"challengetoken"},"id":55806403,"type":"TXT"},{"data":{"subdomain":"random.fqdntest","value":"challengetoken"},"id":55806401,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.listrecordset","value":"challengetoken2"},"id":55806399,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.listrecordset","value":"challengetoken1"},"id":55806397,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.deleterecordinset","value":"challengetoken2"},"id":55806375,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.noop","value":"challengetoken"},"id":55806363,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.createrecordset","value":"challengetoken2"},"id":55806361,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.createrecordset","value":"challengetoken1"},"id":55806359,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.test","value":"challengetoken"},"id":55806357,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.full","value":"challengetoken"},"id":55806355,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.fqdn","value":"challengetoken"},"id":55806353,"type":"TXT"}],"response_id":"a19cfd3e-ec55-4bca-a260-723070b9eef0"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2739'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:52 GMT
+      Etag:
+      - W/"ab3-GdPnCkV/ISSxoNNbeRFs9JQBolQ"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com/dns-records?limit=100&offset=0
+  response:
+    body:
+      string: '{"meta":{"total":16},"dns_records":[{"data":{"subdomain":"orig.testfull","value":"challengetoken"},"id":55806413,"type":"TXT"},{"data":{"subdomain":"updated.testfqdn","value":"challengetoken"},"id":55806411,"type":"TXT"},{"data":{"subdomain":"orig.nameonly.test","value":"updated"},"id":55806409,"type":"TXT"},{"data":{"subdomain":"updated.test","value":"challengetoken"},"id":55806407,"type":"TXT"},{"data":{"subdomain":"random.test","value":"challengetoken"},"id":55806405,"type":"TXT"},{"data":{"subdomain":"random.fulltest","value":"challengetoken"},"id":55806403,"type":"TXT"},{"data":{"subdomain":"random.fqdntest","value":"challengetoken"},"id":55806401,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.listrecordset","value":"challengetoken2"},"id":55806399,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.listrecordset","value":"challengetoken1"},"id":55806397,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.deleterecordinset","value":"challengetoken2"},"id":55806375,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.noop","value":"challengetoken"},"id":55806363,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.createrecordset","value":"challengetoken2"},"id":55806361,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.createrecordset","value":"challengetoken1"},"id":55806359,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.test","value":"challengetoken"},"id":55806357,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.full","value":"challengetoken"},"id":55806355,"type":"TXT"},{"data":{"subdomain":"_acme-challenge.fqdn","value":"challengetoken"},"id":55806353,"type":"TXT"}],"response_id":"12053671-11c8-4029-9398-6c246052db39"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2739'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:52 GMT
+      Etag:
+      - W/"ab3-9i1oaqtpK39xVhbke1r4XUyymjM"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"subdomain": "updated.testfull", "type": "TXT", "value": "challengetoken"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '75'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: PATCH
+    uri: https://api.timeweb.cloud/api/v1/domains/example.com/dns-records/55806413
+  response:
+    body:
+      string: '{"dns_record":{"data":{"subdomain":"updated.testfull","value":"challengetoken"},"id":55806413,"type":"TXT"},"response_id":"1198e126-2acb-42bd-9164-8f084b8b8499"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - '*'
+      Access-Control-Expose-Headers:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '161'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 03 Jan 2024 16:05:53 GMT
+      Etag:
+      - W/"a1-nucFOP6KZpW1ITcqA1mWqIaQZQg"
+      Keep-Alive:
+      - timeout=15
+      Server:
+      - QRATOR
+      Vary:
+      - Origin
+      X-Krakend:
+      - Version 2.4.3
+      X-Krakend-Completed:
+      - 'false'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/providers/test_timeweb.py
+++ b/tests/providers/test_timeweb.py
@@ -1,0 +1,42 @@
+"""Integration tests for Timeweb"""
+from unittest import TestCase
+
+from integration_tests import IntegrationTestsV2
+
+import pytest
+
+
+# Hook into testing framework by inheriting unittest.TestCase and reuse
+# the tests which *each and every* implementation of the interface must
+# pass, by inheritance from integration_tests.IntegrationTestsV2
+class TimewebProviderTests(TestCase, IntegrationTestsV2):
+    """Integration tests for Timeweb provider"""
+
+    provider_name = 'timeweb'
+    domain = 'example.com'
+
+    def _filter_post_data_parameters(self):
+        return ['login_token']
+
+    def _filter_headers(self):
+        return ['Authorization']
+
+    def _filter_query_parameters(self):
+        return ['secret_key']
+
+    def _filter_response(self, response):
+        """See `IntegrationTests._filter_response` for more information on how
+        to filter the provider response."""
+        return response
+
+    @pytest.mark.skip(reason="provider only supports TXT records without delegation")
+    def test_provider_when_calling_create_record_for_A_with_valid_name_and_content(self):
+        return
+
+    @pytest.mark.skip(reason="provider only supports TXT records without delegation")
+    def test_provider_when_calling_create_record_for_CNAME_with_valid_name_and_content(self):
+        return
+
+    @pytest.mark.skip(reason="provider does not support TTL")
+    def test_provider_when_calling_list_records_after_setting_ttl(self):
+        return


### PR DESCRIPTION
I'm using Lexicon as a part of Letsencrypt certbot, and I needed support for my hosting provider, Timeweb. Thanks for the contributing guidelines, they are pretty straightforward -- hopefully all the requirements have been met.

Had to skip a couple of tests since Timeweb's DNS functionality is quite crippled (more info in commit description). All other tests seem to pass.